### PR TITLE
Add Function Definition and Invocation Support, Improve Documentation Comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,21 +2,20 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "develop"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose --release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Crates.io Version](https://img.shields.io/crates/v/abyss-lang)
+[![Crates.io Version](https://img.shields.io/crates/v/abyss-lang)](https://crates.io/crates/abyss-lang)
 [![Build](https://github.com/liebe-magi/abyss/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/liebe-magi/abyss/actions/workflows/build.yml)
 
 # **AbySS: Advanced-scripting by Symbolic Syntax**
@@ -26,7 +26,6 @@ AbySS (Advanced-scripting by Symbolic Syntax) is a programming language designed
   - [Loops](#loops)
   - [Functions](#functions)
   - [Input/Output](#inputoutput)
-- [Examples](#examples)
 - [VSCode Extension](#vscode-extension)
 - [Roadmap](#roadmap)
 - [License](#license)
@@ -286,9 +285,77 @@ These examples illustrate the flexibility of the `orbit` construct in AbySS, whi
 
 ### **Functions**
 
-Functions in AbySS are currently under development. While the core syntax and design are still being finalized, the general concept involves using the `engrave` keyword to define functions. The specifics, such as parameter passing, return types, and function calls, will be detailed as the feature progresses.
+In AbySS, functions are defined using the `engrave` keyword. Functions allow you to encapsulate reusable code blocks and return values. You can define functions with parameters, specify return types, and call these functions within your scripts.
 
-This feature is actively being developed, so stay tuned for updates as AbySS continues to evolve.
+#### **Function Definition**
+
+Functions are defined using the `engrave` keyword, followed by the function name, parameters, optional return type, and the function body enclosed in `{}`.
+
+```abyss
+engrave add(a: arcana, b: arcana) -> arcana {
+    reveal a + b;
+};
+```
+
+In this example, the `add` function takes two parameters `a` and `b` of type `arcana` (integer), and returns their sum as an `arcana`.
+
+#### **Function Calls**
+
+You can call a function by using its name followed by parentheses, and pass arguments matching the function's parameters.
+
+```abyss
+forge result: arcana = add(3, 5);
+unveil(result); // Outputs: 8
+```
+
+This example calls the `add` function with the arguments `3` and `5`, stores the result in the `result` variable, and prints it using `unveil`.
+
+#### **Nested Function Calls**
+
+AbySS allows you to call functions within other function calls, enabling complex operations to be broken down into simpler components.
+
+```abyss
+engrave add_three_numbers(x: arcana, y: arcana, z: arcana) -> arcana {
+    reveal add(add(x, y), z);
+};
+
+forge result: arcana = add_three_numbers(1, 2, 3);
+unveil(result); // Outputs: 6
+```
+
+In this example, the `add_three_numbers` function calls the `add` function twice to sum three numbers.
+
+#### **Return Values**
+
+Functions in AbySS use the `reveal` keyword to return values. If a function does not explicitly return a value, it implicitly returns `abyss`.
+
+```abyss
+engrave greet() -> rune {
+    reveal "Hello, AbySS!";
+};
+
+unveil(greet()); // Outputs: Hello, AbySS!
+```
+
+This function `greet` returns a `rune` (string) and prints it using `unveil`.
+
+#### **Recursive Functions**
+
+AbySS supports recursive function calls, allowing functions to call themselves.
+
+```abyss
+engrave factorial(n: arcana) -> arcana {
+    oracle (n <= 1) {
+        (boon) => reveal 1;
+    };
+    reveal n * factorial(n - 1);
+};
+
+forge result: arcana = factorial(5);
+unveil(result); // Outputs: 120
+```
+
+This recursive function calculates the factorial of a number.
 
 ### **Input/Output**
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AbySS (Advanced-scripting by Symbolic Syntax) is a programming language designed
 - [Language Syntax](#language-syntax)
   - [Basic Syntax](#basic-syntax)
   - [Types](#types)
+  - [Type Casting](#type-casting)
   - [Variable Declaration](#variable-declaration)
   - [Conditionals](#conditionals)
   - [Loops](#loops)
@@ -43,7 +44,7 @@ Alternatively, you can install AbySS by cloning the repository and building it l
 ```bash
 git clone https://github.com/your-repository/abyss.git
 cd abyss
-cargo build
+cargo install --path .
 ```
 
 For test coverage with `cargo-llvm-cov`, install the tool as follows:
@@ -114,9 +115,27 @@ forge message: rune = "Hello, AbySS";
 forge is_active: omen = boon;
 ```
 
+- `arcana`: Derived from the Latin word for "secret" or "mystery," and also referencing the structured numbering of tarot cards, arcana represents integer values, symbolizing the hidden foundations of calculations in programming.
+- `aether`: Inspired by the classical element of ether, believed to fill the universe beyond the terrestrial sphere, aether represents floating-point numbers, capturing the idea of fluid, continuous quantities.
+- `rune`: Borrowed from ancient writing systems used in magic, rune represents strings, suggesting the idea that words and symbols hold power in programming as they do in mystical inscriptions.
+- `omen`: Drawing from the concept of a prophetic sign, omen represents boolean values. The keywords `boon` and `hex` are used for `true` and `false`, respectively — `boon` originates from Old English, meaning a blessing or benefit, while `hex` comes from Germanic folklore, signifying a curse or spell, reinforcing the mystical theme of the language.
+- `abyss`: Symbolizing infinite nothingness, abyss represents the void type, indicating no value is returned, and is also the name of the language, reflecting its philosophy of exploring the depths of symbolic scripting.
+
+### **Type Casting**
+
+In AbySS, type casting is achieved using the `trans` keyword.
+This allows the conversion of values from one type to another.
+
+`trans`: Short for "transformation," `trans` enables the conversion of one type into another, reflecting the idea of magical transformations in programming.
+
+```abyss
+forge x: arcana = trans(3.14 as arcana);
+```
+
 ### **Variable Declaration**
 
-Variables are declared using the `forge` keyword. You must explicitly specify the variable type.
+Variables are declared using the `forge` keyword.
+You must explicitly specify the variable type.
 
 ```abyss
 forge x: arcana = 42;
@@ -130,9 +149,15 @@ forge morph counter: arcana = 10;
 counter += 5;
 ```
 
+- `forge`: Derived from the concept of a blacksmith forging items, this keyword represents the creation and declaration of new variables, symbolizing the act of crafting something new.
+- `morph`: Inspired by transformation, morph is used to indicate mutable variables that can change their form or value over time.
+
 ### **Conditionals**
 
-In AbySS, you can use the `oracle` construct to handle conditionals. One approach is to define conditions directly within each pattern, allowing for flexible and readable branching logic. This method lets you skip a separate conditional statement and write all conditions within the branches themselves.
+In AbySS, you can use the `oracle` construct to handle conditionals. One approach is to define conditions directly within each pattern, allowing for flexible and readable branching logic.
+This method lets you skip a separate conditional statement and write all conditions within the branches themselves.
+
+- `oracle`: Reflecting the role of an oracle in ancient mythology, this keyword is used for conditionals, where decisions and predictions are made based on input.
 
 #### **Pattern-based Oracle**
 
@@ -145,7 +170,9 @@ oracle {
 };
 ```
 
-In this example, the conditions are written directly within the patterns. The oracle evaluates each condition in sequence and executes the matching branch. If no specific conditions are met, the default pattern `_` is executed.
+In this example, the conditions are written directly within the patterns.
+The oracle evaluates each condition in sequence and executes the matching branch.
+If no specific conditions are met, the default pattern `_` is executed.
 
 #### **Boolean-based Oracle**
 
@@ -190,17 +217,25 @@ oracle (a, b) {
 };
 ```
 
-In this example, oracle evaluates multiple conditions (a and b) together and executes the corresponding branch based on their values. If no specific conditions are met, the default pattern _ is used.
+In this example, oracle evaluates multiple conditions (a and b) together and executes the corresponding branch based on their values.
+If no specific conditions are met, the default pattern _ is used.
 
 This flexibility makes `oracle` a powerful tool for creating readable and intuitive branching logic in AbySS.
 
 ### **Loops**
 
-In AbySS, loops are managed using the `orbit` keyword. This construct allows for both simple and complex loop structures, with additional control provided by the `resume` and `eject` keywords. Below, we explore a range of use cases for loops in AbySS, from basic to advanced scenarios.
+In AbySS, loops are managed using the `orbit` keyword.
+This construct allows for both simple and complex loop structures, with additional control provided by the `resume` and `eject` keywords.
+Below, we explore a range of use cases for loops in AbySS, from basic to advanced scenarios.
+
+- `orbit`: Inspired by the celestial motion of planets, orbit represents loops, where the code revolves around a central task repeatedly until a condition changes.
+- `resume`: Reflecting the continuation of interrupted tasks, resume allows the loop to skip the current iteration and move on to the next.
+- `eject`: Analogous to an emergency exit or escape mechanism, eject breaks out of loops, terminating the iteration prematurely.
 
 #### **Simple Loop**
 
-The most basic form of a loop in AbySS iterates over a range of values. In this example, the loop iterates from 0 to 5 (exclusive of 5).
+The most basic form of a loop in AbySS iterates over a range of values.
+In this example, the loop iterates from 0 to 5 (exclusive of 5).
 
 ```abyss
 orbit (i = 0..5) {
@@ -208,7 +243,8 @@ orbit (i = 0..5) {
 }
 ```
 
-This loop prints the numbers from 0 to 4 using the `unveil` function. The `..` operator defines a half-open range, which excludes the upper bound.
+This loop prints the numbers from 0 to 4 using the `unveil` function.
+The `..` operator defines a half-open range, which excludes the upper bound.
 
 #### **Closed Range Loop**
 
@@ -219,11 +255,13 @@ orbit (i = 0..=10) {
     unveil(i);
 }
 ```
+
 In this loop, the numbers from 0 to 10 (inclusive) are printed.
 
 #### **Infinite Loop**
 
-By omitting the loop parameters, you can create an infinite loop that runs until a certain condition is met. The loop can be terminated using the `eject` keyword, which breaks the loop when the condition is satisfied.
+By omitting the loop parameters, you can create an infinite loop that runs until a certain condition is met.
+The loop can be terminated using the `eject` keyword, which breaks the loop when the condition is satisfied.
 
 ```abyss
 forge morph i: arcana = 0;
@@ -239,7 +277,8 @@ This example increments `i` in each iteration until it reaches 100, at which poi
 
 #### **Loop with Multiple Parameters**
 
-AbySS allows you to define loops with more than one parameter, making it easier to iterate over multiple ranges simultaneously. Here's an example where two loop variables, `i` and `j`, are defined:
+AbySS allows you to define loops with more than one parameter, making it easier to iterate over multiple ranges simultaneously.
+Here's an example where two loop variables, `i` and `j`, are defined:
 
 ```abyss
 orbit (i = 0..3, j = 0..3) {
@@ -247,11 +286,13 @@ orbit (i = 0..3, j = 0..3) {
 }
 ```
 
-In this loop, `i` and `j` both iterate over the range from 0 to 2, and each pair of values is printed. This pattern is useful when you need to perform operations that depend on two or more varying values simultaneously.
+In this loop, `i` and `j` both iterate over the range from 0 to 2, and each pair of values is printed.
+This pattern is useful when you need to perform operations that depend on two or more varying values simultaneously.
 
 #### **Resume Keyword**
 
-The `resume` keyword allows you to skip the current iteration of a loop and move on to the next iteration. This can be used to control the flow of nested loops.
+The `resume` keyword allows you to skip the current iteration of a loop and move on to the next iteration.
+This can be used to control the flow of nested loops.
 
 ```abyss
 orbit (i = 0..3) {
@@ -263,11 +304,13 @@ orbit (i = 0..3) {
     }
 }
 ```
+
 In this example, the inner loop skips the iteration whenever `i` is equal to `j`.
 
 #### **Eject Keyword**
 
-The `eject` keyword breaks the loop entirely. In nested loops, you can specify which loop to break by passing the loop variable as an argument.
+The `eject` keyword breaks the loop entirely.
+In nested loops, you can specify which loop to break by passing the loop variable as an argument.
 
 ```abyss
 orbit (i = 0..3) {
@@ -279,13 +322,19 @@ orbit (i = 0..3) {
     }
 }
 ```
+
 Here, the outer loop breaks entirely when `i` equals 2, effectively terminating both the inner and outer loops.
 
-These examples illustrate the flexibility of the `orbit` construct in AbySS, which allows for sophisticated looping patterns with easy-to-read syntax. The ability to control flow with `resume` and `eject` further enhances the language's expressiveness in handling loops.
+These examples illustrate the flexibility of the `orbit` construct in AbySS, which allows for sophisticated looping patterns with easy-to-read syntax.
+The ability to control flow with `resume` and `eject` further enhances the language's expressiveness in handling loops.
 
 ### **Functions**
 
-In AbySS, functions are defined using the `engrave` keyword. Functions allow you to encapsulate reusable code blocks and return values. You can define functions with parameters, specify return types, and call these functions within your scripts.
+In AbySS, functions are defined using the `engrave` keyword.
+Functions allow you to encapsulate reusable code blocks and return values.
+You can define functions with parameters, specify return types, and call these functions within your scripts.
+
+- `engrave`: Symbolizing the act of carving a magical circle, engrave is used for function definitions, representing the meticulous process of inscribing reusable spells into the code.
 
 #### **Function Definition**
 
@@ -327,7 +376,8 @@ In this example, the `add_three_numbers` function calls the `add` function twice
 
 #### **Return Values**
 
-Functions in AbySS use the `reveal` keyword to return values. If a function does not explicitly return a value, it implicitly returns `abyss`.
+Functions in AbySS use the `reveal` keyword to return values.
+If a function does not explicitly return a value, it implicitly returns `abyss`.
 
 ```abyss
 engrave greet() -> rune {
@@ -359,7 +409,11 @@ This recursive function calculates the factorial of a number.
 
 ### **Input/Output**
 
-For output, AbySS uses the `unveil` function to print values to the console. You can pass multiple variables or expressions as arguments, separated by commas. This allows you to concatenate different elements in the output.
+For output, AbySS uses the `unveil` function to print values to the console.
+You can pass multiple variables or expressions as arguments, separated by commas.
+This allows you to concatenate different elements in the output.
+
+- `unveil`: Chosen for its metaphorical meaning of revealing something hidden, unveil is used for output operations, making the internal state of the program visible to the user.
 
 ```abyss
 unveil("Hello, AbySS");
@@ -379,7 +433,6 @@ To install the extension, search for "[AbySS Codex Familiar](https://marketplace
 
 ### **Roadmap**
 
-- **Function Definitions**: Ongoing development of function definition syntax and implementation (Work-in-progress).
 - **Module System**: Introduce the ability to import functions and variables from other files (TBD).
 - **Standard Input**: Implement standard input functionality to allow user input during script execution (TBD).
 - **Error Handling**: Implement robust error handling (TBD).

--- a/examples/engrave.aby
+++ b/examples/engrave.aby
@@ -1,0 +1,18 @@
+// Nested function calls
+engrave add(a: arcana, b: arcana) -> arcana {
+    reveal a + b;
+};
+
+engrave add_three_numbers(x: arcana, y: arcana, z: arcana) -> arcana {
+    reveal add(add(x, y), z);
+};
+
+forge result: arcana = add_three_numbers(1, 2, 3);
+unveil(result);
+
+// Function has no return type
+engrave unveil_add(a: arcana, b: arcana) -> abyss {
+    unveil(a + b);
+    reveal;
+};
+unveil_add(100, 28);

--- a/src/abyss.pest
+++ b/src/abyss.pest
@@ -5,13 +5,22 @@ line_comment  = _{ "//" ~ (!"\n" ~ ANY)* }
 block_comment = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
 statements = { SOI ~ statement* ~ EOI }
-statement  = { (forge_var | unveil | reveal | orbit | orbit_flow | assignment | expression) ~ ";" }
+statement  = { (forge_var | engrave | unveil | reveal | orbit | orbit_flow | assignment | expression) ~ ";" }
 block      = { "{" ~ statement* ~ "}" }
 
 forge_var  = { "forge" ~ morph? ~ identifier ~ ":" ~ type ~ "=" ~ expression }
 assignment = { identifier ~ assignment_op ~ expression }
-unveil     = { "unveil" ~ "(" ~ expression ~ ("," ~ expression)* ~ ")" }
-reveal     = { "reveal" ~ expression* }
+
+engrave        = { "engrave" ~ identifier ~ "(" ~ engrave_params? ~ ")" ~ ("->" ~ engrave_type)? ~ block }
+engrave_params = { engrave_param ~ ("," ~ engrave_param)* }
+engrave_param  = { identifier ~ ":" ~ type }
+engrave_type   = { type }
+
+func_call = { identifier ~ "(" ~ func_args? ~ ")" }
+func_args = { expression ~ ("," ~ expression)* }
+
+unveil = { "unveil" ~ "(" ~ expression ~ ("," ~ expression)* ~ ")" }
+reveal = { "reveal" ~ expression* }
 
 oracle_expr             = { "oracle" ~ oracle_conditional? ~ "{" ~ oracle_branch* ~ "}" }
 oracle_conditional      = { "(" ~ (conditional_assignments | expressions) ~ ")" }
@@ -36,12 +45,13 @@ eject_expr  = { "eject" ~ identifier? }
 
 trans_expr = { "trans" ~ "(" ~ expression ~ "as" ~ type ~ ")" }
 
-identifier = @{ ASCII_ALPHANUMERIC+ }
-type       =  { "omen" | "aether" | "arcana" | "rune" }
-omen       = @{ "boon" | "hex" }
-aether     = @{ sign? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
-arcana     = @{ sign? ~ ASCII_DIGIT+ }
-rune       = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+
+type   =  { "omen" | "aether" | "arcana" | "rune" | "abyss" }
+omen   = @{ "boon" | "hex" }
+aether = @{ sign? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
+arcana = @{ sign? ~ ASCII_DIGIT+ }
+rune   = @{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 
 sign  = { "+" | "-" }
 morph = { "morph" }
@@ -55,7 +65,7 @@ comp_expr   = { add_expr ~ (comp_op ~ add_expr)? }
 add_expr    = { mul_expr ~ (add_op ~ mul_expr)* }
 mul_expr    = { pow_expr ~ (mul_op ~ pow_expr)* }
 pow_expr    = { factor ~ (pow_op ~ factor)* }
-factor      = { trans_expr | omen | aether | arcana | rune | identifier | "(" ~ expression ~ ")" }
+factor      = { trans_expr | omen | aether | arcana | rune | func_call | identifier | "(" ~ expression ~ ")" }
 
 assignment_op = { "+=" | "-=" | "*=" | "/=" | "%=" | "^=" | "**=" | "=" }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,6 @@
 use pest::Span;
 
+/// Represents line and column information for debugging purposes.
 #[derive(Debug, Clone)]
 pub struct LineInfo {
     pub line: usize,
@@ -7,12 +8,14 @@ pub struct LineInfo {
 }
 
 impl LineInfo {
+    /// Creates a `LineInfo` from a given `Span`.
     pub fn from_span(span: &Span) -> Self {
         let (line, column) = span.start_pos().line_col();
         LineInfo { line, column }
     }
 }
 
+/// Represents the abstract syntax tree (AST) for the language.
 #[derive(Debug, Clone)]
 pub enum AST {
     Statement(Box<AST>, Option<LineInfo>),
@@ -20,6 +23,7 @@ pub enum AST {
     Arcana(i64, Option<LineInfo>),
     Aether(f64, Option<LineInfo>),
     Rune(String, Option<LineInfo>),
+    Abyss(Option<LineInfo>),
     Add(Box<AST>, Box<AST>, Option<LineInfo>),
     Sub(Box<AST>, Box<AST>, Option<LineInfo>),
     Mul(Box<AST>, Box<AST>, Option<LineInfo>),
@@ -45,7 +49,7 @@ pub enum AST {
     },
     Assignment {
         name: String,
-        value: Box<AST>, // 定義済み変数への代入用ノード
+        value: Box<AST>,
         op: AssignmentOp,
         line_info: Option<LineInfo>,
     },
@@ -81,31 +85,52 @@ pub enum AST {
     },
     Resume(Option<String>, Option<LineInfo>),
     Eject(Option<String>, Option<LineInfo>),
+    Engrave {
+        name: String,
+        params: Vec<AST>,
+        return_type: Type,
+        body: Box<AST>,
+        line_info: Option<LineInfo>,
+    },
+    EngraveParam {
+        name: String,
+        param_type: Type,
+        line_info: Option<LineInfo>,
+    },
+    FuncCall {
+        name: String,
+        args: Vec<AST>,
+        line_info: Option<LineInfo>,
+    },
 }
 
+/// Represents a conditional assignment within an oracle statement.
 #[derive(Debug, Clone)]
 pub struct ConditionalAssignment {
-    pub variable: String,     // 条件文で参照する変数
-    pub expression: Box<AST>, // 変数に代入される式
+    pub variable: String,
+    pub expression: Box<AST>,
     pub line_info: Option<LineInfo>,
 }
 
+/// Represents the type of a variable or expression.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
     Arcana,
     Aether,
     Rune,
     Omen,
+    Abyss,
 }
 
+/// Represents an assignment operation.
 #[derive(Debug, Clone)]
 pub enum AssignmentOp {
-    Assign, // 単純な代入
+    Assign,
     AddAssign,
     SubAssign,
     MulAssign,
     DivAssign,
-    ModAssign,       // 剰余代入を追加
-    PowArcanaAssign, // ^=
-    PowAetherAssign, // **=
+    ModAssign,
+    PowArcanaAssign,
+    PowAetherAssign,
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,35 +1,64 @@
-use crate::ast::{LineInfo, Type};
+use crate::ast::{LineInfo, Type, AST};
 use crate::eval::EvalError;
 use std::collections::HashMap;
 
-#[derive(Debug)]
+/// Stores information about a variable, including its value, type, and mutability.
+#[derive(Debug, Clone)]
 pub struct VarInfo {
     pub value: Value,
     pub var_type: Type,
     pub is_morph: bool,
+    pub line_info: Option<LineInfo>,
 }
 
-#[derive(Debug)]
+/// Represents a function in the environment, including its name, parameters, return type, body, and line information.
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub name: String,
+    pub params: Vec<AST>,
+    pub return_type: Type,
+    pub body: Box<AST>,
+    pub line_info: Option<LineInfo>,
+}
+
+/// Manages variable and function scopes in the execution environment.
+/// This includes handling both global and local scopes.
+#[derive(Debug, Clone)]
 pub struct Environment {
-    scopes: Vec<HashMap<String, VarInfo>>,
+    scopes: Vec<HashMap<String, VarInfo>>, // Variable scopes
+    function_scopes: Vec<HashMap<String, Function>>, // Function scopes
 }
 
 impl Environment {
+    /// Creates a new environment with an initial global scope.
     pub fn new() -> Self {
         Environment {
             scopes: vec![HashMap::new()],
+            function_scopes: vec![HashMap::new()],
         }
     }
 
+    /// Pushes a new scope onto the stack, creating a new local environment for variables and functions.
     pub fn push_scope(&mut self) {
         self.scopes.push(HashMap::new());
+        self.function_scopes.push(HashMap::new());
     }
 
+    /// Pops the most recent scope off the stack, discarding the current local environment.
     pub fn pop_scope(&mut self) {
         self.scopes.pop();
+        self.function_scopes.pop();
     }
 
-    pub fn set_var(&mut self, name: String, value: Value, var_type: Type, is_morph: bool) {
+    /// Sets a variable in the current scope, specifying its name, value, type, and whether it's mutable.
+    pub fn set_var(
+        &mut self,
+        name: String,
+        value: Value,
+        var_type: Type,
+        is_morph: bool,
+        line_info: Option<LineInfo>,
+    ) {
         if let Some(current_scope) = self.scopes.last_mut() {
             current_scope.insert(
                 name,
@@ -37,11 +66,13 @@ impl Environment {
                     value,
                     var_type,
                     is_morph,
+                    line_info,
                 },
             );
         }
     }
 
+    /// Retrieves a variable from the environment by searching the scopes from the most recent to the global scope.
     pub fn get_var(&self, name: &str) -> Option<&VarInfo> {
         for scope in self.scopes.iter().rev() {
             if let Some(var_info) = scope.get(name) {
@@ -51,16 +82,17 @@ impl Environment {
         None
     }
 
+    /// Updates an existing variable's value in the environment if it is mutable and the types match.
+    /// Returns an error if the variable is immutable, the types do not match, or the variable is not found.
     pub fn update_var(
         &mut self,
         name: &str,
         value: Value,
         var_type: Type,
-        line_info: Option<LineInfo>, // LineInfoを追加
+        line_info: Option<LineInfo>,
     ) -> Result<(), EvalError> {
         for scope in self.scopes.iter_mut().rev() {
             if let Some(var_info) = scope.get_mut(name) {
-                // 変数が可変でない場合、エラーを返す
                 if !var_info.is_morph {
                     return Err(EvalError::InvalidOperation(
                         format!("Cannot reassign to immutable variable {}", name),
@@ -68,7 +100,6 @@ impl Environment {
                     ));
                 }
 
-                // 変数の型が異なる場合、エラーを返す
                 if var_info.var_type != var_type {
                     return Err(EvalError::InvalidOperation(
                         format!(
@@ -79,16 +110,34 @@ impl Environment {
                     ));
                 }
 
-                // 書き換えが許可され、型も一致している場合、値を更新
                 var_info.value = value;
                 return Ok(());
             }
         }
         Err(EvalError::UndefinedVariable(name.to_string(), line_info))
     }
+
+    /// Registers a function in the current scope, associating it with its name.
+    pub fn set_function(&mut self, name: String, function: Function) {
+        if let Some(current_scope) = self.function_scopes.last_mut() {
+            current_scope.insert(name, function);
+        }
+    }
+
+    /// Retrieves a function by name from the environment, searching from the most recent scope to the global scope.
+    pub fn get_function(&self, name: &str) -> Option<&Function> {
+        for scope in self.function_scopes.iter().rev() {
+            if let Some(function) = scope.get(name) {
+                return Some(function);
+            }
+        }
+        None
+    }
 }
 
-#[derive(Debug)]
+/// Represents the value stored in a variable, which can be a boolean (Omen), integer (Arcana),
+/// floating-point number (Aether), or string (Rune).
+#[derive(Debug, Clone)]
 pub enum Value {
     Omen(bool),
     Arcana(i64),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,6 +3,7 @@ use crate::env::{Environment, Function, Value};
 use colored::*;
 use std::fmt;
 
+/// Represents the result of an evaluation in the interpreter.
 #[derive(Debug)]
 pub enum EvalResult {
     Omen(bool),
@@ -15,6 +16,7 @@ pub enum EvalResult {
     Eject(Option<String>),
 }
 
+/// Represents possible errors that can occur during evaluation.
 #[derive(Debug)]
 pub enum EvalError {
     UndefinedVariable(String, Option<LineInfo>),
@@ -37,11 +39,12 @@ impl fmt::Display for EvalError {
 }
 impl std::error::Error for EvalError {}
 
+/// Displays an error message along with the relevant source code and line information, if available.
 pub fn display_error_with_source(script: &str, line_info: Option<LineInfo>, error_message: &str) {
     if let Some(info) = line_info {
         let lines: Vec<&str> = script.lines().collect();
         if let Some(source_line) = lines.get(info.line - 1) {
-            // 行番号は1から始まるため -1
+            // Line numbers start from 1, so we subtract 1
             eprintln!(
                 "{}",
                 format!(
@@ -60,6 +63,16 @@ pub fn display_error_with_source(script: &str, line_info: Option<LineInfo>, erro
     }
 }
 
+/// Evaluates an abstract syntax tree (AST) node in the given environment.
+///
+/// # Arguments
+///
+/// * `ast` - The AST node to be evaluated.
+/// * `env` - The environment containing variable and function bindings.
+///
+/// # Returns
+///
+/// The result of the evaluation, or an `EvalError` if an error occurs.
 pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalError> {
     match ast {
         AST::Statement(node, _line_info) => evaluate(node, env),
@@ -449,9 +462,8 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
             branches,
             line_info,
         } => {
-            env.push_scope(); // 新しいスコープを作成
+            env.push_scope();
 
-            // 条件式を評価して環境に代入するヘルパー関数
             let mut evaluate_and_set_var =
                 |conditional: &ConditionalAssignment| -> Result<(), EvalError> {
                     let result = evaluate(&conditional.expression, env)?;
@@ -494,14 +506,11 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                     Ok(())
                 };
 
-            // 条件式が指定されている場合、すべての条件式を評価して環境に代入
             for conditional in conditionals {
                 evaluate_and_set_var(conditional)?;
             }
 
-            // 分岐の評価処理
             for branch in branches {
-                // コメントノードの場合はスキップ
                 if let AST::Comment(_, _) = branch {
                     continue;
                 }
@@ -513,13 +522,10 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                 } = branch
                 {
                     let matched = if pattern.is_empty() {
-                        // デフォルトブランチ
                         true
                     } else if *is_match {
-                        // パターンマッチング
                         let mut matched = true;
                         for (idx, pattern) in pattern.iter().enumerate() {
-                            // patternがOracleDontCareItemの場合は条件を満たす
                             if let AST::OracleDontCareItem(_) = pattern {
                                 continue;
                             }
@@ -562,13 +568,11 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                         }
                         matched
                     } else {
-                        // Omen型パターンマッチング
                         pattern.iter().all(|pattern| {
                             matches!(evaluate(pattern, env), Ok(EvalResult::Omen(true)))
                         })
                     };
 
-                    // パターンが一致したらブランチを評価して終了
                     if matched {
                         let result = match evaluate(&body, env) {
                             Ok(result) => match result {
@@ -577,13 +581,13 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                             },
                             Err(e) => return Err(e),
                         };
-                        env.pop_scope(); // スコープを終了
+                        env.pop_scope();
                         return Ok(result);
                     }
                 }
             }
 
-            env.pop_scope(); // スコープを終了
+            env.pop_scope();
             Ok(EvalResult::Abyss)
         }
         AST::Reveal(expr, _line_info) => {
@@ -605,20 +609,16 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
             }
             Ok(last_result)
         }
-        AST::OracleDontCareItem(_line_info) => {
-            Ok(EvalResult::Omen(true)) // ワイルドカードは常に真
-        }
+        AST::OracleDontCareItem(_line_info) => Ok(EvalResult::Omen(true)),
         AST::Orbit {
             params,
             body,
             line_info,
         } => {
             if params.is_empty() {
-                // パラメータがない場合、無限ループを実行
                 loop {
-                    env.push_scope(); // 新しいスコープを作成
+                    env.push_scope();
 
-                    // ループ本体の評価
                     let result = evaluate(body, env)?;
 
                     match result {
@@ -627,12 +627,11 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                         _ => {}
                     }
 
-                    env.pop_scope(); // スコープを終了
+                    env.pop_scope();
                 }
 
                 Ok(EvalResult::Abyss)
             } else {
-                // 最初のパラメータを取り出し、それに対するループ処理を行う
                 if let AST::OrbitParam {
                     name,
                     start,
@@ -644,16 +643,14 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                     let start_value = evaluate(start, env)?;
                     let end_value = evaluate(end, env)?;
 
-                    // Arcana型である必要がある（整数型のループパラメータ）
                     if let (EvalResult::Arcana(start_num), EvalResult::Arcana(end_num)) =
                         (start_value, end_value)
                     {
                         let range = start_num..end_num + if op == ".." { 0 } else { 1 };
 
                         for value in range {
-                            env.push_scope(); // 新しいスコープを作成
+                            env.push_scope();
 
-                            // パラメータを環境に追加
                             env.set_var(
                                 name.clone(),
                                 Value::Arcana(value),
@@ -662,7 +659,6 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 line_info.clone(),
                             );
 
-                            // 残りのパラメータで再帰的に処理を行う
                             let remaining_params = params[1..].to_vec();
                             let result = match remaining_params.len() == 0 {
                                 true => evaluate(body, env)?,
@@ -680,7 +676,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 EvalResult::Resume(identifier) => {
                                     if let Some(id) = identifier {
                                         if id == *name {
-                                            continue; // 現在のループを再開
+                                            continue;
                                         } else {
                                             env.pop_scope();
                                             return Ok(EvalResult::Resume(Some(id)));
@@ -691,7 +687,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 EvalResult::Eject(identifier) => {
                                     if let Some(id) = identifier {
                                         if id == *name {
-                                            break; // 現在のループを抜ける
+                                            break;
                                         } else {
                                             env.pop_scope();
                                             return Ok(EvalResult::Eject(Some(id)));
@@ -702,7 +698,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 _ => {}
                             }
 
-                            env.pop_scope(); // スコープを終了
+                            env.pop_scope();
                         }
                         Ok(EvalResult::Abyss)
                     } else {
@@ -728,7 +724,6 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
             body,
             line_info,
         } => {
-            // 関数を環境に登録
             let function = Function {
                 name: name.clone(),
                 params: params.clone(),
@@ -744,27 +739,22 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
             args,
             line_info,
         } => {
-            // 関数の取得
             let function = {
                 env.get_function(name)
                     .ok_or_else(|| EvalError::UndefinedVariable(name.clone(), line_info.clone()))?
             }
             .clone();
 
-            // パラメータを先にクローンしておく
             let params = function.params.clone();
 
-            // まず、引数を評価し、その結果を保存
             let mut evaluated_args = Vec::new();
             for arg in args {
                 let evaluated_arg = evaluate(arg, env)?;
                 evaluated_args.push(evaluated_arg);
             }
 
-            // 新しいスコープで関数実行
             env.push_scope();
 
-            // 引数の評価結果と関数パラメータへの対応付け
             for (evaluated_arg, param) in evaluated_args.into_iter().zip(params.iter()) {
                 let (name, param_type) = match param {
                     AST::EngraveParam {
@@ -798,12 +788,10 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                 );
             }
 
-            // 関数ボディの評価
             let result = evaluate(&function.body, env)?;
 
-            env.pop_scope(); // スコープを終了
+            env.pop_scope();
 
-            // resultがfunctionの戻り値の型と一致するか確認
             match (result, function.return_type) {
                 (EvalResult::Arcana(n), Type::Arcana) => Ok(EvalResult::Arcana(n)),
                 (EvalResult::Aether(n), Type::Aether) => Ok(EvalResult::Aether(n)),
@@ -816,9 +804,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                 )),
             }
         }
-        AST::Comment(_, _) => {
-            Ok(EvalResult::Abyss) // コメントは何もしない
-        }
+        AST::Comment(_, _) => Ok(EvalResult::Abyss),
         _ => Err(EvalError::InvalidOperation(
             format!("Unsupported operation: {:?}", ast),
             None,

--- a/src/format.rs
+++ b/src/format.rs
@@ -140,6 +140,7 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             true => "boon".to_string(),
             false => "hex".to_string(),
         },
+        AST::Abyss(_) => "abyss".to_string(),
         AST::Unveil(args, _) => format!(
             "unveil({})",
             args.iter()
@@ -157,7 +158,12 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             format!("trans({} as {})", format_ast(value, indent_level), type_str)
         }
         AST::Reveal(value, _) => {
-            format!("reveal {}", format_ast(value, indent_level))
+            let val = format_ast(value, indent_level);
+            let trimmed_val = val.trim();
+            match trimmed_val {
+                "abyss" => "reveal".to_string(),
+                _ => format!("reveal {}", trimmed_val),
+            }
         }
         AST::Block(statements, _) => {
             let mut result = format!("{}{{\n", indent);
@@ -254,6 +260,60 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             Some(idendifier) => format!("eject {}", idendifier),
             None => "eject".to_string(),
         },
+        AST::Engrave {
+            name,
+            params,
+            return_type,
+            body,
+            ..
+        } => {
+            let return_type_str = match return_type {
+                Type::Arcana => "arcana",
+                Type::Aether => "aether",
+                Type::Rune => "rune",
+                Type::Omen => "omen",
+                Type::Abyss => "",
+            };
+            let params_str = params
+                .iter()
+                .map(|param| format_ast(param, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            match return_type_str {
+                "" => format!(
+                    "engrave {}({}) {}",
+                    name,
+                    params_str,
+                    format_ast(body, indent_level)
+                ),
+                _ => format!(
+                    "engrave {}({}) -> {} {}",
+                    name,
+                    params_str,
+                    return_type_str,
+                    format_ast(body, indent_level)
+                ),
+            }
+        }
+        AST::EngraveParam {
+            name, param_type, ..
+        } => {
+            let type_str = match param_type {
+                Type::Arcana => "arcana",
+                Type::Aether => "aether",
+                Type::Rune => "rune",
+                _ => "",
+            };
+            format!("{}: {}", name, type_str)
+        }
+        AST::FuncCall { name, args, .. } => {
+            let args_str = args
+                .iter()
+                .map(|arg| format_ast(arg, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{}({})", name, args_str)
+        }
         AST::Comment(text, _) => text.clone(),
         _ => format!("Not implemented: {:?}", ast),
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,12 +1,22 @@
 use crate::ast::{AssignmentOp, Type, AST};
 
+/// Formats an AST node into a readable string with appropriate indentation.
+/// This function handles various types of AST nodes, applying formatting rules based on node type.
+/// It also manages operator precedence to ensure correct placement of parentheses.
+///
+/// # Arguments
+/// * `ast` - The AST node to format.
+/// * `indent_level` - The level of indentation for the formatted output.
+///
+/// # Returns
+/// A formatted string representation of the AST node.
 pub fn format_ast(ast: &AST, indent_level: usize) -> String {
-    let indent = "    ".repeat(indent_level); // インデントを生成
+    let indent = "    ".repeat(indent_level);
 
-    // 優先順位テーブル
+    // Determines the precedence level for an AST node to handle operator precedence.
     let precedence = |node: &AST| match node {
-        AST::LogicalOr(_, _, _) => 10,  // 最も低い優先順位
-        AST::LogicalAnd(_, _, _) => 20, // 次に低い
+        AST::LogicalOr(_, _, _) => 10,
+        AST::LogicalAnd(_, _, _) => 20,
         AST::Equal(_, _, _) | AST::NotEqual(_, _, _) => 30,
         AST::LessThan(_, _, _)
         | AST::LessThanOrEqual(_, _, _)
@@ -14,13 +24,14 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
         | AST::GreaterThanOrEqual(_, _, _) => 40,
         AST::Add(_, _, _) | AST::Sub(_, _, _) => 50,
         AST::Mul(_, _, _) | AST::Div(_, _, _) | AST::Mod(_, _, _) => 60,
-        AST::PowArcana(_, _, _) | AST::PowAether(_, _, _) => 70, // 累乗演算の優先順位が最も高い
-        AST::LogicalNot(_, _) => 80, // 単項演算子（論理否定）も高い優先順位
-        _ => 100,                    // その他のノード
+        AST::PowArcana(_, _, _) | AST::PowAether(_, _, _) => 70,
+        AST::LogicalNot(_, _) => 80,
+        _ => 100,
     };
 
     let current_precedence = precedence(ast);
 
+    // Formats a sub-expression, adding parentheses if necessary based on precedence.
     let format_with_parentheses = |expr: &AST, parent_precedence: u8| -> String {
         let sub_precedence = precedence(expr);
         let code = format_ast(expr, indent_level);
@@ -130,9 +141,9 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
         AST::Arcana(value, _) => format!("{}", value),
         AST::Aether(value, _) => {
             if value.fract() == 0.0 {
-                format!("{:.1}", value) // 小数点以下が0の場合は1桁で表示
+                format!("{:.1}", value)
             } else {
-                format!("{}", value) // それ以外の場合はそのまま表示
+                format!("{}", value)
             }
         }
         AST::Rune(value, _) => format!("\"{}\"", value),
@@ -200,7 +211,6 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             }
             result.push_str(" {\n");
             for branch in branches {
-                // コメントノードの場合はスキップ
                 if let AST::Comment(text, _) = branch {
                     result.push_str(&format!("{}{}\n", "    ".repeat(indent_level + 1), text));
                     continue;

--- a/tests/test_base.rs
+++ b/tests/test_base.rs
@@ -13,7 +13,7 @@ pub fn test_base(input: &str) -> Result<Vec<EvalResult>, Box<dyn std::error::Err
                 if inner_pair.as_rule() != Rule::EOI {
                     match build_ast(inner_pair) {
                         Ok(ast) => {
-                            // println!("{:#?}", ast);
+                            // println!("{:?}", ast);
                             match evaluate(&ast, &mut env) {
                                 Ok(result) => {
                                     results.push(result);

--- a/tests/test_engrave.rs
+++ b/tests/test_engrave.rs
@@ -1,0 +1,185 @@
+mod test_base;
+
+use abyss_lang::eval::EvalResult;
+use test_base::test_base;
+
+#[test]
+fn test_simple_function() {
+    let input = r#"
+    engrave add(a: arcana, b: arcana) -> arcana {
+        reveal a + b;
+    };
+    forge result: arcana = add(2, 3);
+    result;
+    "#;
+
+    let result_rust = 2 + 3;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Arcana(result_abyss) = results[2] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Arcana result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_function_with_strings() {
+    let input = r#"
+    engrave greet(name: rune) -> rune {
+        reveal "Hello, " + name;
+    };
+    forge message: rune = greet("Abyss");
+    message;
+    "#;
+
+    let message_rust = "Hello, Abyss".to_string();
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Rune(message_abyss) = &results[2] {
+                assert_eq!(message_rust, *message_abyss);
+            } else {
+                panic!("Expected Rune result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_function_with_floats() {
+    let input = r#"
+    engrave multiply(a: aether, b: aether) -> aether {
+        reveal a * b;
+    };
+    forge result: aether = multiply(2.5, 4.0);
+    result;
+    "#;
+
+    let result_rust = 2.5 * 4.0;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Aether(result_abyss) = results[2] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Aether result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_function_with_boon_hex() {
+    let input = r#"
+    engrave is_even(num: arcana) -> omen {
+        oracle(num % 2 == 0) {
+            (boon) => reveal boon;
+            (hex) => reveal hex;
+        };
+    };
+    forge result: omen = is_even(4);
+    result;
+    "#;
+
+    let result_rust = true;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Omen(result_abyss) = results[2] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Omen result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_nested_function_calls() {
+    let input = r#"
+    engrave add(a: arcana, b: arcana) -> arcana {
+        reveal a + b;
+    };
+
+    engrave add_three_numbers(x: arcana, y: arcana, z: arcana) -> arcana {
+        reveal add(add(x, y), z);
+    };
+
+    forge result: arcana = add_three_numbers(1, 2, 3);
+    result;
+    "#;
+
+    let result_rust = 1 + 2 + 3;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Arcana(result_abyss) = results[3] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Arcana result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_function_with_no_arguments() {
+    let input = r#"
+    engrave return_ten() -> arcana {
+        reveal 10;
+    };
+
+    forge result: arcana = return_ten();
+    result;
+    "#;
+
+    let result_rust = 10;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Arcana(result_abyss) = results[2] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Arcana result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_function_with_recursive_calls() {
+    let input = r#"
+    engrave factorial(n: arcana) -> arcana {
+        oracle(n <= 1) {
+            (boon) => reveal 1;
+            (hex) => reveal n * factorial(n - 1);
+        };
+    };
+
+    forge result: arcana = factorial(5);
+    result;
+    "#;
+
+    let result_rust = 1 * 2 * 3 * 4 * 5;
+
+    match test_base(input) {
+        Ok(results) => {
+            if let EvalResult::Arcana(result_abyss) = results[2] {
+                assert_eq!(result_rust, result_abyss);
+            } else {
+                panic!("Expected Arcana result");
+            }
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}


### PR DESCRIPTION
1. Function Definition and Invocation Support (resolved #8)

- Implemented the `engrave` keyword for function definitions. Functions can now be declared with parameters, return types, and a function body.
- Added support for function calls using the syntax `function_name(arguments)`. 
- Enabled the evaluation of function return values through the `reveal` keyword. Functions without a return value implicitly return `abyss`.

2. Documentation Comments

- Added detailed Rust documentation comments (`///`) throughout the codebase to improve code readability and maintainability.
- These comments provide concise descriptions of functions, structs, and enums, helping future developers understand the purpose and usage of each component.