### PR TITLE
Align CI checks with pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: test
-          args: --release
 
   lints:
     name: Lints
@@ -70,7 +69,7 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets --all-features -- -D warnings
 
   build:
     strategy:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve the coverage and accuracy of our automated checks. The main changes are focused on how tests and lints are run in CI.

**CI workflow improvements:**

* Removed the `--release` flag from the `cargo test` command to run tests in debug mode, which is faster and more common for CI environments.
* Updated the `cargo clippy` linting command to include `--all-targets` and `--all-features`, ensuring that lint checks are performed across all targets and feature combinations, not just the default set.