### PR TITLE
chore: adopt Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-lang"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "ariadne",
  "chumsky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "abyss-lang"
-version = "0.0.2"
-edition = "2021"
-authors = ["liebe-magi <liebe.magi@gmail.com>"]
+version = "0.1.0"
+edition = "2024"
+authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 description = "AbySS: Advanced-scripting by Symbolic Syntax"
 readme = "README.md"
-repository = "https://github.com/liebe-magi/AbySS"
+repository = "https://github.com/liebe-magi/abyss-lang"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-use crate::ast::{LineInfo, Type, AST};
+use crate::ast::{AST, LineInfo, Type};
 use crate::eval::EvalError;
 use std::collections::HashMap;
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AssignmentOp, ConditionalAssignment, LineInfo, Type, AST};
+use crate::ast::{AST, AssignmentOp, ConditionalAssignment, LineInfo, Type};
 use crate::env::{Environment, Function, Value};
 use colored::*;
 use std::{fmt, io::Write};
@@ -259,7 +259,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                     return Err(EvalError::InvalidOperation(
                         "VarAssign operation requires a valid type!".to_string(),
                         line_info.clone(),
-                    ))
+                    ));
                 }
             };
             env.set_var(
@@ -306,7 +306,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 return Err(EvalError::InvalidOperation(
                                     format!("Unsupported operation for variable {}", name),
                                     line_info.clone(),
-                                ))
+                                ));
                             }
                         };
                         env.update_var(
@@ -329,7 +329,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 return Err(EvalError::InvalidOperation(
                                     format!("Unsupported operation for variable {}", name),
                                     line_info.clone(),
-                                ))
+                                ));
                             }
                         };
                         env.update_var(
@@ -347,7 +347,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                 return Err(EvalError::InvalidOperation(
                                     format!("Unsupported operation for variable {}", name),
                                     line_info.clone(),
-                                ))
+                                ));
                             }
                         };
                         env.update_var(name, Value::Rune(new_value), Type::Rune, line_info.clone())
@@ -500,7 +500,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                             return Err(EvalError::InvalidOperation(
                                 format!("Unsupported type in oracle conditional: {:?}", result),
                                 line_info.clone(),
-                            ))
+                            ));
                         }
                     }
                     Ok(())
@@ -562,7 +562,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                                         "Oracle branch pattern type must match conditional type"
                                             .to_string(),
                                         line_info.clone(),
-                                    ))
+                                    ));
                                 }
                             }
                         }
@@ -763,7 +763,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                         return Err(EvalError::InvalidOperation(
                             format!("Expected EngraveParam in function definition: {}", name),
                             line_info.clone(),
-                        ))
+                        ));
                     }
                 };
                 let value = match (evaluated_arg, param_type) {
@@ -775,7 +775,7 @@ pub fn evaluate(ast: &AST, env: &mut Environment) -> Result<EvalResult, EvalErro
                         return Err(EvalError::TypeError(
                             format!("Type mismatch for parameter {}", name),
                             line_info.clone(),
-                        ))
+                        ));
                     }
                 };
                 env.set_var(

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AssignmentOp, Type, AST};
+use crate::ast::{AST, AssignmentOp, Type};
 
 /// Formats an AST node into a readable string with appropriate indentation.
 /// This function handles various types of AST nodes, applying formatting rules based on node type.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 use abyss_lang::{
     env::Environment,
-    eval::{display_error_with_source, evaluate, EvalError, EvalResult},
+    eval::{EvalError, EvalResult, display_error_with_source, evaluate},
     format::format_ast,
-    parser::{emit_diagnostics, parse, ParserDiagnostic},
+    parser::{ParserDiagnostic, emit_diagnostics, parse},
 };
 use clap::{Parser, Subcommand};
 use colored::*;
+use rustyline::Editor;
 use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
-use rustyline::Editor;
 use std::fs;
 use std::path::PathBuf;
 

--- a/src/parser/diagnostics.rs
+++ b/src/parser/diagnostics.rs
@@ -6,8 +6,8 @@ use chumsky::{
     span::Span as ChumskySpan,
 };
 
-use super::helpers::LineMap;
 use super::SimpleSpan;
+use super::helpers::LineMap;
 
 #[derive(Debug, Clone)]
 pub struct ParserDiagnostic {

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -8,11 +8,11 @@ use chumsky::{
     recursive::{self, Direct},
 };
 
-use crate::ast::{AssignmentOp, ConditionalAssignment, LineInfo, Type, AST};
+use crate::ast::{AST, AssignmentOp, ConditionalAssignment, LineInfo, Type};
 
+use super::SimpleSpan;
 use super::helpers::LineMap;
 use super::tokens::{SpannedToken, Token};
-use super::SimpleSpan;
 
 type ParserInput<'src> = IterInput<std::vec::IntoIter<SpannedToken>, SimpleSpan<usize>>;
 type ParserError<'src> = Rich<'src, Token, SimpleSpan<usize>>;

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -59,47 +59,47 @@ pub fn scrub_comments_preserve_layout(source: &str) -> String {
     let mut chars = source.chars().peekable();
 
     while let Some(ch) = chars.next() {
-        if ch == '/' {
-            if let Some(&next) = chars.peek() {
-                if next == '/' {
-                    // Single-line comment: consume until newline, keep newline intact.
-                    result.push(' '); // replace first '/'
-                    chars.next(); // consume second '/'
-                    result.push(' ');
+        if ch == '/'
+            && let Some(&next) = chars.peek()
+        {
+            if next == '/' {
+                // Single-line comment: consume until newline, keep newline intact.
+                result.push(' '); // replace first '/'
+                chars.next(); // consume second '/'
+                result.push(' ');
 
-                    while let Some(&c) = chars.peek() {
-                        chars.next();
-                        if c == '\n' {
-                            result.push('\n');
-                            break;
-                        }
+                while let Some(&c) = chars.peek() {
+                    chars.next();
+                    if c == '\n' {
+                        result.push('\n');
+                        break;
+                    }
+                    result.push(' ');
+                }
+
+                continue;
+            } else if next == '*' {
+                // Block comment: consume until closing */ while preserving newlines.
+                result.push(' '); // first '/'
+                chars.next(); // consume '*'
+                result.push(' ');
+
+                let mut prev = '\0';
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        result.push('\n');
+                    } else {
                         result.push(' ');
                     }
 
-                    continue;
-                } else if next == '*' {
-                    // Block comment: consume until closing */ while preserving newlines.
-                    result.push(' '); // first '/'
-                    chars.next(); // consume '*'
-                    result.push(' ');
-
-                    let mut prev = '\0';
-                    for c in chars.by_ref() {
-                        if c == '\n' {
-                            result.push('\n');
-                        } else {
-                            result.push(' ');
-                        }
-
-                        if prev == '*' && c == '/' {
-                            break;
-                        }
-
-                        prev = c;
+                    if prev == '*' && c == '/' {
+                        break;
                     }
 
-                    continue;
+                    prev = c;
                 }
+
+                continue;
             }
         }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,17 +1,17 @@
-pub use helpers::{abyss_whitespace, attach_line_info, scrub_comments_preserve_layout, LineMap};
+pub use helpers::{LineMap, abyss_whitespace, attach_line_info, scrub_comments_preserve_layout};
 pub use span::SimpleSpan;
-pub use tokens::{lexer, SpannedToken, Token};
+pub use tokens::{SpannedToken, Token, lexer};
 mod diagnostics;
 mod grammar;
 mod helpers;
 mod span;
 mod tokens;
 
-pub use diagnostics::{emit_diagnostics, ParserDiagnostic};
+pub use diagnostics::{ParserDiagnostic, emit_diagnostics};
 
 use std::sync::Arc;
 
-use chumsky::{input::IterInput, Parser};
+use chumsky::{Parser, input::IterInput};
 use ordered_float::OrderedFloat;
 
 use crate::ast::AST;

--- a/tests/test_base.rs
+++ b/tests/test_base.rs
@@ -1,6 +1,6 @@
 use abyss_lang::{
     env::Environment,
-    eval::{display_error_with_source, evaluate, EvalError, EvalResult},
+    eval::{EvalError, EvalResult, display_error_with_source, evaluate},
     parser::{emit_diagnostics, parse},
 };
 


### PR DESCRIPTION
This pull request includes a version update and a series of code cleanups and reordering, primarily focused on import statements and minor formatting improvements. The changes help modernize the codebase, improve readability, and ensure consistency with Rust 2024 edition standards.

**Project Metadata Update:**

* Updated `Cargo.toml` to version 0.1.0, set edition to 2024, updated author email, and changed the repository URL to the new canonical address.

**Code Cleanups and Import Reordering:**

* Reordered and grouped import statements for clarity and consistency across multiple files, including `src/env.rs`, `src/eval.rs`, `src/format.rs`, `src/main.rs`, `src/parser/diagnostics.rs`, `src/parser/grammar.rs`, `src/parser/mod.rs`, and `tests/test_base.rs`. [[1]](diffhunk://#diff-4da8e8ee5c65a27bd048a2f2e55de0a9c75e87618fc02e17b235cc5413e625a0L1-R1) [[2]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L1-R1) [[3]](diffhunk://#diff-c875d3cb38acba1839738726b3d4aa920bec536459b52d5bc5069a91dd1620f5L1-R1) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL3-L12) [[5]](diffhunk://#diff-3ed4f4c674f17ae62b3357aa39ea43febdd23e12b6bdef84af27210c4dfafe93L9-R10) [[6]](diffhunk://#diff-4d916b6275e2cc73b8befc0e2b71d2bee30c3258c3a7f9b63811c02df92aa96bL11-L15) [[7]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L1-R14) [[8]](diffhunk://#diff-fb781392bbd85c5ec85fb9d7a8a4bfb3af1eadd5e0de4398b850c2d0cedb36baL3-R3)

**Formatting and Syntax Improvements:**

* Standardized error handling by fixing the placement of closing parentheses in error returns in `src/eval.rs` for better readability. [[1]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L262-R262) [[2]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L309-R309) [[3]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L332-R332) [[4]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L350-R350) [[5]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L503-R503) [[6]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L565-R565) [[7]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L766-R766) [[8]](diffhunk://#diff-84c46c1047bea02643d764007dc4ae2cb6e93767ba92faa9583659cb88b49bf4L778-R778)
* Improved the comment-scrubbing logic in `src/parser/helpers.rs` by using more idiomatic Rust syntax (`if ch == '/' && let Some(&next) = chars.peek()`) and removing an unnecessary closing brace. [[1]](diffhunk://#diff-7341269fc9b6ad97f3aa8c95a88428e8ae51b490eb38ee174ff1fa9e7b292cbfL62-R64) [[2]](diffhunk://#diff-7341269fc9b6ad97f3aa8c95a88428e8ae51b490eb38ee174ff1fa9e7b292cbfL104)