### PR TITLE
chore: prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-lang"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariadne",
  "chumsky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abyss-lang"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 description = "AbySS: Advanced-scripting by Symbolic Syntax"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(name = "abyss")]
 #[command(about = "AbySS: Advanced-scripting by Symbolic Syntax", long_about = None)]
-#[command(version)]
+#[command(version = concat!("v", env!("CARGO_PKG_VERSION")))]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
This pull request updates the versioning for the AbySS project and improves how the CLI displays its version information. The main changes are as follows:

Versioning updates:

* Bumped the crate version from `0.1.0` to `0.2.0` in `Cargo.toml` to reflect new changes and progress.

CLI improvements:

* Modified the CLI version output in `src/main.rs` to explicitly show the package version prefixed with `v` (e.g., `v0.2.0`) by using `concat!` with the `CARGO_PKG_VERSION` environment variable.