### PR TITLE
Prepare v0.4.0 release: crate metadata and modern release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
         id: properties
         shell: bash
         run: |
-          VERSION=$(grep '^version = ' crates/abyss-cli/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          VERSION=$(grep '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,13 @@ jobs:
 
       - name: Create Release
         if: steps.check_version.outputs.bump == 'true'
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ steps.check_version.outputs.version }}
-          release_name: v${{ steps.check_version.outputs.version }}
+          name: v${{ steps.check_version.outputs.version }}
           draft: true
           prerelease: false
+          generate_release_notes: true
 
       - name: Publish to crates.io
         if: steps.check_version.outputs.bump == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
         id: check_version
         shell: bash
         run: |
-          # Get version from Cargo.toml
-          VERSION=$(grep '^version = ' crates/abyss-cli/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          # Get version from the root workspace Cargo.toml
+          VERSION=$(grep '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
           echo "Current version: $VERSION"
           
           # Get latest tag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,18 @@
 resolver = "2"
 members = ["crates/abyss-core", "crates/abyss-interpreter", "crates/abyss-cli"]
 
+[workspace.package]
+version = "0.4.0"
+edition = "2024"
+authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
+license = "MIT"
+repository = "https://github.com/liebe-magi/abyss-lang"
+homepage = "https://abyss-lang.dev"
+
+[workspace.dependencies]
+abyss-core = { path = "crates/abyss-core", version = "0.4.0" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.4.0" }
+
 [workspace.metadata.release]
 shared-version = true
 tag = false

--- a/crates/abyss-cli/Cargo.toml
+++ b/crates/abyss-cli/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "abyss-lang"
-version = "0.4.0"
-edition = "2024"
-authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
-description = "AbySS: Advanced-scripting by Symbolic Syntax"
+description = "AbySS: Advanced-scripting by Symbolic Syntax — a magic-themed scripting language. Installs the `abyss` binary with `cast` (REPL), `invoke` (script runner), and `align` (formatter) subcommands."
 readme = "README.md"
-repository = "https://github.com/liebe-magi/abyss-lang"
-license = "MIT"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["abyss", "interpreter", "scripting", "cli", "repl"]
+categories = ["command-line-utilities", "development-tools"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
-abyss-core = { path = "../abyss-core" }
-abyss-interpreter = { path = "../abyss-interpreter" }
+abyss-core.workspace = true
+abyss-interpreter.workspace = true
 clap = { version = "4.0", features = ["derive"] }
 colored = "3.0.0"
 dirs = "6.0.0"

--- a/crates/abyss-core/Cargo.toml
+++ b/crates/abyss-core/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "abyss-core"
-version = "0.4.0"
-edition = "2024"
+description = "Core language primitives for the AbySS scripting language: AST, chumsky-based parser, static analysis, and formatter. Shared between the CLI interpreter and editor tooling."
+readme = "README.md"
+keywords = ["abyss", "parser", "ast", "language", "interpreter"]
+categories = ["parsing", "development-tools"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 ariadne = "0.6"

--- a/crates/abyss-interpreter/Cargo.toml
+++ b/crates/abyss-interpreter/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "abyss-interpreter"
-version = "0.4.0"
-edition = "2024"
+description = "Runtime engine for the AbySS scripting language: evaluator, runtime environment, value representation, and the built-in standard library."
+readme = "README.md"
+keywords = ["abyss", "interpreter", "runtime", "language", "stdlib"]
+categories = ["development-tools"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
-abyss-core = { path = "../abyss-core" }
+abyss-core.workspace = true
 colored = "3.0.0"
 ordered-float = "5"

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -35,6 +35,41 @@ def get_cargo_version(cargo_path):
         print(f"Error reading Cargo.toml: {e}")
         sys.exit(1)
 
+def get_workspace_dep_versions(cargo_path):
+    """Return {name: version} for intra-workspace crates listed in
+    [workspace.dependencies] (those pointing at a local `crates/…` path).
+    These versions must match [workspace.package].version; otherwise a
+    release-time `cargo publish` will produce stale dependency requirements
+    and may fail or publish incorrect metadata.
+    """
+    try:
+        with open(cargo_path, 'r') as f:
+            content = f.read()
+        section_match = re.search(
+            r'^\[workspace\.dependencies\]\s*\n(.*?)(?=^\[|\Z)',
+            content,
+            re.MULTILINE | re.DOTALL,
+        )
+        if not section_match:
+            return {}
+        section = section_match.group(1)
+        versions = {}
+        entry_re = re.compile(
+            r'^\s*([\w-]+)\s*=\s*\{([^}]+)\}\s*$',
+            re.MULTILINE,
+        )
+        for m in entry_re.finditer(section):
+            name = m.group(1)
+            body = m.group(2)
+            path_match = re.search(r'path\s*=\s*"(crates/[^"]+)"', body)
+            version_match = re.search(r'version\s*=\s*"([^"]+)"', body)
+            if path_match and version_match:
+                versions[name] = version_match.group(1)
+        return versions
+    except Exception as e:
+        print(f"Error reading Cargo.toml for workspace dependencies: {e}")
+        sys.exit(1)
+
 def get_package_json_version(package_path):
     try:
         with open(package_path, 'r') as f:
@@ -62,15 +97,33 @@ def main():
 
     cargo_version = get_cargo_version(cargo_path)
     package_version = get_package_json_version(package_path)
+    dep_versions = get_workspace_dep_versions(cargo_path)
 
     print(f"Cargo version: {cargo_version}")
     print(f"Package version: {package_version}")
+    if dep_versions:
+        print(f"Workspace deps: {dep_versions}")
 
     if cargo_version != package_version:
         print(f"Error: Versions do not match! Cargo.toml has '{cargo_version}' but package.json has '{package_version}'")
         print("Please update the version in one of these files to match the other.")
         sys.exit(1)
-    
+
+    mismatched = [
+        (name, ver) for name, ver in dep_versions.items() if ver != cargo_version
+    ]
+    if mismatched:
+        print(
+            f"Error: [workspace.dependencies] entries disagree with [workspace.package].version ('{cargo_version}'):"
+        )
+        for name, ver in mismatched:
+            print(f"  - {name}: '{ver}'")
+        print(
+            "Bump [workspace.dependencies].*.version in lockstep with [workspace.package].version, "
+            "otherwise `cargo publish` will emit stale dependency requirements."
+        )
+        sys.exit(1)
+
     print("Versions match.")
     sys.exit(0)
 

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -8,14 +8,28 @@ def get_cargo_version(cargo_path):
     try:
         with open(cargo_path, 'r') as f:
             content = f.read()
-            # Look for version = "x.y.z" in the [package] section
-            # This is a simple regex and might need adjustment if Cargo.toml is complex
-            # but usually version is at the top under [package]
-            match = re.search(r'^version\s*=\s*"(\d+\.\d+\.\d+(?:-[\w.]+)?)"', content, re.MULTILINE)
+            # The canonical version lives under [workspace.package] in the root
+            # Cargo.toml; individual crates inherit it via `version.workspace = true`.
+            # Scope the search to the [workspace.package] section so unrelated
+            # version specifiers (e.g. entries in [workspace.dependencies]) do not
+            # shadow it.
+            section_match = re.search(
+                r'^\[workspace\.package\]\s*\n(.*?)(?=^\[|\Z)',
+                content,
+                re.MULTILINE | re.DOTALL,
+            )
+            if not section_match:
+                print("Could not find [workspace.package] section in Cargo.toml")
+                sys.exit(1)
+            match = re.search(
+                r'^version\s*=\s*"(\d+\.\d+\.\d+(?:-[\w.]+)?)"',
+                section_match.group(1),
+                re.MULTILINE,
+            )
             if match:
                 return match.group(1)
             else:
-                print("Could not find version in Cargo.toml")
+                print("Could not find version in [workspace.package]")
                 sys.exit(1)
     except Exception as e:
         print(f"Error reading Cargo.toml: {e}")
@@ -35,7 +49,7 @@ def get_package_json_version(package_path):
 
 def main():
     root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    cargo_path = os.path.join(root_dir, 'crates/abyss-cli/Cargo.toml')
+    cargo_path = os.path.join(root_dir, 'Cargo.toml')
     package_path = os.path.join(root_dir, 'editors/code/package.json')
 
     if not os.path.exists(cargo_path):


### PR DESCRIPTION
## Summary

The Rust side has been split into three crates (`abyss-core`, `abyss-interpreter`, `abyss-lang`) since the last published version (`0.3.1`), but the two newly introduced crates ship with only `name` / `version` / `edition`. Without this PR, merging `develop` → `main` would trigger `release.yml`, tag `v0.4.0`, draft a release, and then crash on `cargo publish -p abyss-core` because crates.io rejects manifests that lack `description` and `license` and `cargo publish` rejects path dependencies that omit a version requirement.

This PR makes the workspace genuinely releasable and modernizes the release workflow:

- Add `[workspace.package]` and `[workspace.dependencies]` to the root `Cargo.toml` so each crate inherits version, edition, authors, license, repository, and homepage from a single source of truth, and intra-workspace `path` dependencies carry version requirements at publish time.
- Add `description`, `readme`, `keywords`, and `categories` to all three crate manifests.
- Source the canonical version from the root `Cargo.toml` in `scripts/check_version_sync.py`, `.github/workflows/build.yml`, and `.github/workflows/release.yml` (the per-crate manifests no longer hold a literal version line).
- Replace the archived `actions/create-release@v1` with `softprops/action-gh-release@v3.0.0` (pinned by SHA) and turn on `generate_release_notes: true` so the draft release lands with auto-generated notes from PRs since the previous tag instead of an empty body.

## Commits

### `chore(release): centralize crate metadata for crates.io publication readiness`
- `Cargo.toml`: `[workspace.package]` + `[workspace.dependencies]`.
- `crates/abyss-core/Cargo.toml`, `crates/abyss-interpreter/Cargo.toml`: add `description` / `readme` / `keywords` / `categories`, inherit shared fields from the workspace.
- `crates/abyss-interpreter/Cargo.toml`, `crates/abyss-cli/Cargo.toml`: consume intra-workspace crates via `*.workspace = true`, eliminating the bare path deps that previously lacked a version requirement.
- `scripts/check_version_sync.py`: scope the regex to `[workspace.package]` and read the root `Cargo.toml`.
- `.github/workflows/{build,release}.yml`: read the version from the root `Cargo.toml`.

### `ci(release): replace deprecated create-release action with action-gh-release`
- Swap `actions/create-release` (archived) for `softprops/action-gh-release@v3.0.0`.
- Rename `release_name` → `name` to match the v3 input schema.
- Drop the explicit `GITHUB_TOKEN` env block (the action picks it up from the default token).
- Enable `generate_release_notes: true`.

## Verification

- [x] `cargo check --all` — clean.
- [x] `cargo fmt --all -- --check` — no diff.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings.
- [x] `cargo test --all` — all 270+ integration tests across `abyss-core` and `abyss-interpreter` pass.
- [x] `python3 scripts/check_version_sync.py` — `Cargo: 0.4.0` / `Package: 0.4.0` match.
- [x] `cargo publish --dry-run --allow-dirty -p abyss-core` — packages without the previous "manifest has no description, license …" warning. The packaged `Cargo.toml` correctly carries description, license, readme, keywords, categories, homepage, and repository (verified by inspecting `target/package/abyss-core-0.4.0/Cargo.toml`).
- [x] pre-commit ran the version-sync hook on commit 1 and passed.
- [ ] CI (`build.yml`) green on this PR.

## Notes

- A full `cargo publish --dry-run` for `abyss-interpreter` and `abyss-cli` cannot succeed before `abyss-core` is on crates.io for the first time, because cargo always tries to resolve the dep against the index. The release workflow's existing `cargo publish` sequence (`abyss-core` → `sleep 30` → `abyss-interpreter` → `sleep 30` → `abyss-lang`) is what unblocks them on the actual publish; that sequencing is unchanged.
- Releasing the binaries (the `build` matrix uploads `abyss` artifacts but `release.yml` does not yet attach them to the GitHub release) is left out of scope for this PR — it can be a follow-up after the v0.4.0 publish succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)