### PR TITLE
Refresh AGENTS.md accuracy and fill frozen-spec Purpose placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,15 +34,15 @@ AbySS is a magic-themed scripting language with its own interpreter, formatter, 
 - Coverage is uploaded to Codecov by `.github/workflows/build.yml`.
 
 ### Git workflow
-- Default branch is `develop`; `main` is release-only. Direct pushes to `develop` are blocked by branch protection — always branch off with a verb-led kebab-case topic branch (`add-…`, `fix-…`, `refactor-…`) and open a PR.
+- Default branch is `develop`; `main` is release-only. Direct pushes to either branch are blocked by branch protection — always branch off with a verb-led kebab-case topic branch (`add-…`, `fix-…`, `refactor-…`) and open a PR. `develop` → `main` promotion also goes through a PR.
 - PR titles and bodies are written in English, matching the established practice on the repository, even when the originating conversation is in another language.
 - CI (`build.yml`) runs `cargo check`, `cargo test` with coverage, `cargo fmt --check`, `cargo clippy -D warnings`, version-sync validation, and the VS Code extension type-check + package step. All must pass before merge.
-- Releases are driven by `release.yml` on push to `main`: if `crates/abyss-cli/Cargo.toml` has a new version, the workflow tags, creates a draft release, and publishes `abyss-core` → `abyss-interpreter` → `abyss-lang` to crates.io in that order.
+- Releases are driven by `release.yml` on push to `main`: when the root `Cargo.toml` `[workspace.package].version` differs from the latest tag, the workflow tags, drafts a GitHub release, and publishes `abyss-core` → `abyss-interpreter` → `abyss-lang` to crates.io in that order.
 
 ### Pre-commit hooks (`.pre-commit-config.yaml`)
 - `cargo fmt`, `cargo clippy -D warnings`, `cargo check`, `cargo test` on any `.rs` change.
 - `bun run compile` on any `editors/code/` change (requires `bun install --frozen-lockfile` to succeed).
-- `python3 scripts/check_version_sync.py` enforces that `crates/abyss-cli/Cargo.toml` and `editors/code/package.json` stay at the same version.
+- `python3 scripts/check_version_sync.py` enforces that the root `Cargo.toml` workspace version (`[workspace.package].version` plus intra-workspace dep versions in `[workspace.dependencies]`) stays aligned with `editors/code/package.json`.
 
 ## Domain Vocabulary
 

--- a/openspec/specs/coverage/spec.md
+++ b/openspec/specs/coverage/spec.md
@@ -1,7 +1,7 @@
 # coverage Specification
 
 ## Purpose
-TBD - created by archiving change expand-test-coverage. Update Purpose after archive.
+Pin the minimum regression coverage required around foundational interpreter components — `SymbolTable` scope and lookup operations, evaluator error reporting, and stdlib argument and receiver validation — so silent breakage of these primitives surfaces as a failing test rather than a downstream language bug.
 ## Requirements
 ### Requirement: SymbolTable Functionality
 The `SymbolTable` MUST support all defined operations including scope management and symbol definition/lookup.

--- a/openspec/specs/documentation-structure/spec.md
+++ b/openspec/specs/documentation-structure/spec.md
@@ -1,7 +1,7 @@
 # documentation-structure Specification
 
 ## Purpose
-TBD - created by archiving change migrate-docs-to-starlight. Update Purpose after archive.
+Describe how the AbySS documentation site under `docs/` is organised — onboarding and structured reference sections built on Starlight — and how its code highlighting stays in lockstep with the VS Code extension by treating `editors/code/syntaxes/abyss.tmLanguage.json` as the single source of truth that the docs build pipeline consumes directly.
 ## Requirements
 ### Requirement: Documentation Site Structure
 The project SHALL provide a documentation site under `docs/` powered by a static site generator that organizes content into clear onboarding and reference sections.

--- a/openspec/specs/editor-syntax/spec.md
+++ b/openspec/specs/editor-syntax/spec.md
@@ -1,7 +1,7 @@
 # editor-syntax Specification
 
 ## Purpose
-TBD - created by archiving change update-vscode-syntax-v030. Update Purpose after archive.
+Specify how the AbySS Codex Familiar VS Code extension's TextMate grammar (`editors/code/syntaxes/abyss.tmLanguage.json`) scopes every reserved keyword, primitive and collection type, boolean constant, builtin function, artifact construct, and structural operator emitted by the v0.3+ lexer, so editor highlighting stays aligned with the parser tokens defined in the interpreter.
 ## Requirements
 ### Requirement: Reserved keywords match the lexer
 The AbySS Codex Familiar TextMate grammar (`editors/code/syntaxes/abyss.tmLanguage.json`) SHALL tag every reserved keyword emitted by the v0.3.0 lexer (`forge`, `morph`, `core`, `oracle`, `orbit`, `resume`, `eject`, `engrave`, `reveal`, `artifact`) with the `keyword.control.abyss` scope, and SHALL keep builtin helpers such as `unveil`, `summon`, and the `.trans(...)` method inside the `support.function.abyss` scope so users can distinguish actual keywords from callable symbols.

--- a/openspec/specs/evaluator-infrastructure/spec.md
+++ b/openspec/specs/evaluator-infrastructure/spec.md
@@ -1,7 +1,7 @@
 # evaluator-infrastructure Specification
 
 ## Purpose
-TBD - created by archiving change refactor-evaluator-architecture. Update Purpose after archive.
+Define the runtime evaluator's module organisation and core semantics: concern-separated modules under `abyss-interpreter/src/eval/` (results, values, collections, expressions, statements), type names exposed as first-class glyph globals, the dot-call `trans` conversion entry point, the dual `oracle` evaluation modes (if-else vs. match), and the mutability rules that gate `morph core` artifact method invocations.
 ## Requirements
 ### Requirement: Evaluator modules enforce concern boundaries
 The interpreter SHALL organise the evaluator under `src/eval/` with separate Rust modules for result/diagnostic types, shared value helpers, collection indexing utilities, expression evaluation, and statement/control-flow execution, ensuring each file exposes a focused API and the public `eval` module simply re-exports the entry points (`evaluate`, `display_error_with_source`, `EvalResult`, `EvalError`).

--- a/openspec/specs/parser-infrastructure/spec.md
+++ b/openspec/specs/parser-infrastructure/spec.md
@@ -1,7 +1,7 @@
 # parser-infrastructure Specification
 
 ## Purpose
-TBD - created by archiving change migrate-parser-to-chumsky. Update Purpose after archive.
+Define the source-to-AST pipeline of the AbySS interpreter: a `chumsky`-based parser with `ariadne` themed diagnostics, span-preserving AST nodes, and the surface syntax of every language construct (collections, artifact definitions and methods, glyph types, oracle if-else / match modes, dot-call conversions). This capability replaces the legacy `pest` grammar and is the single source of truth for what `.aby` syntax the interpreter accepts.
 ## Requirements
 ### Requirement: Parser uses chumsky combinators
 The system SHALL construct the AbySS AST by applying `chumsky` parser combinators defined in Rust code, compiled against the latest supported `chumsky 0.11` API and its lifetime-aware parser traits, replacing the legacy `pest` grammar and `build_ast` transformer.

--- a/openspec/specs/parser-infrastructure/spec.md
+++ b/openspec/specs/parser-infrastructure/spec.md
@@ -4,7 +4,7 @@
 Define the source-to-AST pipeline of the AbySS interpreter: a `chumsky`-based parser with `ariadne` themed diagnostics, span-preserving AST nodes, and the surface syntax of every language construct (collections, artifact definitions and methods, glyph types, oracle if-else / match modes, dot-call conversions). This capability replaces the legacy `pest` grammar and is the single source of truth for what `.aby` syntax the interpreter accepts.
 ## Requirements
 ### Requirement: Parser uses chumsky combinators
-The system SHALL construct the AbySS AST by applying `chumsky` parser combinators defined in Rust code, compiled against the latest supported `chumsky 0.11` API and its lifetime-aware parser traits, replacing the legacy `pest` grammar and `build_ast` transformer.
+The system SHALL construct the AbySS AST by applying `chumsky` parser combinators defined in Rust code, compiled against the latest supported `chumsky 0.12` API and its lifetime-aware parser traits, replacing the legacy `pest` grammar and `build_ast` transformer.
 
 #### Scenario: Parse valid incantation
 - **GIVEN** a `.aby` script whose syntax is valid under the current language rules

--- a/openspec/specs/release-automation/spec.md
+++ b/openspec/specs/release-automation/spec.md
@@ -1,7 +1,7 @@
 # release-automation Specification
 
 ## Purpose
-TBD - created by archiving change implement-release-workflow. Update Purpose after archive.
+Specify how the project ships new versions: `cargo release` for local version bumps that touch `Cargo.toml` without producing tags, pushes, or publishes; CI detecting a workspace version bump on `main` and triggering the release job; and automated tagging, GitHub draft-release creation, and crates.io publishing in correct dependency order from a single workflow run.
 ## Requirements
 ### Requirement: Local Version Management
 The developer MUST be able to bump versions locally using `cargo release` without triggering git tags or publishing to crates.io immediately.

--- a/openspec/specs/runtime-builtins/spec.md
+++ b/openspec/specs/runtime-builtins/spec.md
@@ -1,7 +1,7 @@
 # runtime-builtins Specification
 
 ## Purpose
-Define the runtime data model and the stdlib surface that scripts can call: a unified `Callable` abstraction for engraved and builtin functions, the I/O builtins (`unveil`, `summon`) treated as ordinary function calls, shared heap-backed collection values (`scroll`, `lexicon`, `rune` via `Rc<RefCell<_>>`), artifact storage and validation (instantiation, field access, assignment, equality, type checking), the centralised builtin method dispatch table keyed by runtime type, and the `materia.trans` method as the canonical conversion entry point.
+Define the runtime data model and the stdlib surface that scripts can call: a unified `Callable` abstraction for engraved and builtin functions, the I/O builtins (`unveil`, `summon`) treated as ordinary function calls, shared heap-backed values (collections `scroll` and `lexicon` via `Rc<RefCell<_>>`, and `rune` via `Rc<String>`), artifact storage and validation (instantiation, field access, assignment, equality, type checking), the centralised builtin method dispatch table keyed by runtime type, and the `materia.trans` method as the canonical conversion entry point.
 ## Requirements
 ### Requirement: Runtime exposes callable abstraction
 The interpreter SHALL register both engraved functions and built-in functions as `Callable` entries so that the environment can resolve any symbol through a single lookup path.

--- a/openspec/specs/runtime-builtins/spec.md
+++ b/openspec/specs/runtime-builtins/spec.md
@@ -1,7 +1,7 @@
 # runtime-builtins Specification
 
 ## Purpose
-TBD - created by archiving change refactor-unveil-summon-builtins. Update Purpose after archive.
+Define the runtime data model and the stdlib surface that scripts can call: a unified `Callable` abstraction for engraved and builtin functions, the I/O builtins (`unveil`, `summon`) treated as ordinary function calls, shared heap-backed collection values (`scroll`, `lexicon`, `rune` via `Rc<RefCell<_>>`), artifact storage and validation (instantiation, field access, assignment, equality, type checking), the centralised builtin method dispatch table keyed by runtime type, and the `materia.trans` method as the canonical conversion entry point.
 ## Requirements
 ### Requirement: Runtime exposes callable abstraction
 The interpreter SHALL register both engraved functions and built-in functions as `Callable` entries so that the environment can resolve any symbol through a single lookup path.


### PR DESCRIPTION
## Summary

Two small documentation-only commits that close the open follow-up items left over from the v0.4.0 release:

- `AGENTS.md` — accuracy refresh in the Git workflow section: note that **both** `develop` and `main` are protected (the previous wording only mentioned `develop`), point at the new canonical version source under root `Cargo.toml` `[workspace.package]`, and reflect that `scripts/check_version_sync.py` now also guards `[workspace.dependencies].*.version` (added during PR #379).
- `openspec/specs/*/spec.md` — replace the seven `TBD - created by archiving change …` auto-generated `Purpose` stubs with one-paragraph statements derived from the requirements each spec owns and the originating change. Closes Copilot review comments #3 and #4 on PR #380.

No code paths or behaviour change.

## Commits

### `docs: align AGENTS.md with current branch protection and version source`
- `develop` and `main` both noted as protected.
- Release trigger description updated to read from root `Cargo.toml` `[workspace.package].version`.
- `check_version_sync.py` description updated to mention the workspace-dep drift guard.

### `docs: replace TBD placeholders in frozen openspec specs`
- Filled `Purpose` for: `coverage`, `parser-infrastructure`, `documentation-structure`, `evaluator-infrastructure`, `editor-syntax`, `runtime-builtins`, `release-automation`. Each one-sentence-or-two summary is grounded in the requirements already present in the spec and the originating archived change-id.

## Verification

- [x] `grep -rn TBD openspec/specs` — no remaining placeholders.
- [x] All edits are docs-only; no code, workflow, or schema changes.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)