### PR TITLE
Make release.yml idempotent and recoverable from partial failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Skip the version-bump check and re-run the release steps. Use after a partial failure (each step is idempotent: tag creation, draft release, and crates.io publishes skip when already done)."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -25,44 +31,56 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Check for version bump
+      - name: Resolve target version
         id: check_version
         shell: bash
         run: |
-          # Get version from the root workspace Cargo.toml
+          # Always work from a complete tag view so re-runs see tags pushed
+          # by an earlier (possibly failed) attempt.
+          git fetch --tags --force
+
           VERSION=$(grep '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-          echo "Current version: $VERSION"
-          
-          # Get latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "Latest tag: $LATEST_TAG"
-          
-          if [ "v$VERSION" != "$LATEST_TAG" ]; then
-            echo "Version bump detected!"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "bump=true" >> $GITHUB_OUTPUT
+          echo "Workspace version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "Force mode (workflow_dispatch input): proceeding regardless of tag state."
+            echo "proceed=true" >> $GITHUB_OUTPUT
           else
-            echo "No version bump detected."
-            echo "bump=false" >> $GITHUB_OUTPUT
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            echo "Latest tag: $LATEST_TAG"
+            if [ "v$VERSION" != "$LATEST_TAG" ]; then
+              echo "Version bump detected ($LATEST_TAG -> v$VERSION)."
+              echo "proceed=true" >> $GITHUB_OUTPUT
+            else
+              echo "No version bump (latest tag matches workspace version)."
+              echo "proceed=false" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Run tests
-        if: steps.check_version.outputs.bump == 'true'
+        if: steps.check_version.outputs.proceed == 'true'
         run: cargo test --all-features
 
-      - name: Create Git Tag
-        if: steps.check_version.outputs.bump == 'true'
+      - name: Create or confirm git tag
+        if: steps.check_version.outputs.proceed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -eu
           VERSION=${{ steps.check_version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
+          git fetch --tags --force
+          if git rev-parse "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists locally or on origin — leaving it as-is."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "v$VERSION" -m "Release v$VERSION"
+            git push origin "v$VERSION"
+          fi
 
-      - name: Create Release
-        if: steps.check_version.outputs.bump == 'true'
+      - name: Create or update draft release
+        if: steps.check_version.outputs.proceed == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ steps.check_version.outputs.version }}
@@ -71,15 +89,33 @@ jobs:
           prerelease: false
           generate_release_notes: true
 
-      - name: Publish to crates.io
-        if: steps.check_version.outputs.bump == 'true'
+      - name: Publish to crates.io (idempotent per crate)
+        if: steps.check_version.outputs.proceed == 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
         run: |
-          # Publish in order of dependency
-          cargo publish -p abyss-core
-          # Wait a bit for crates.io to propagate
-          sleep 30
-          cargo publish -p abyss-interpreter
-          sleep 30
-          cargo publish -p abyss-lang
+          set -eu
+          VERSION=${{ steps.check_version.outputs.version }}
+
+          publish_if_missing() {
+            local crate=$1
+            local current
+            current=$(curl -fsS "https://crates.io/api/v1/crates/$crate" \
+              | python3 -c "import json,sys; d=json.load(sys.stdin); print('' if 'errors' in d else d['crate']['max_version'])" \
+              || echo "")
+            if [ "$current" = "$VERSION" ]; then
+              echo "$crate v$VERSION already on crates.io, skipping."
+              return
+            fi
+            echo "Publishing $crate v$VERSION (crates.io currently at: ${current:-<unpublished>})."
+            cargo publish -p "$crate"
+            # Let the crates.io index propagate before the next dependent crate.
+            sleep 30
+          }
+
+          # Publish in dependency order. abyss-interpreter depends on abyss-core;
+          # abyss-lang depends on both.
+          publish_if_missing abyss-core
+          publish_if_missing abyss-interpreter
+          publish_if_missing abyss-lang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Skip the version-bump check and re-run the release steps. Use after a partial failure (each step is idempotent: tag creation, draft release, and crates.io publishes skip when already done)."
+        description: "Skip the version-bump check and re-run the release steps. Must be triggered from the `main` branch (other refs are ignored). Use after a partial failure — each step is idempotent: tag creation, draft release, and crates.io publishes skip when already done."
         type: boolean
         default: false
 
@@ -18,6 +18,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Defensive guard: this workflow must only ever produce a release from
+    # the `main` branch. `workflow_dispatch` lets the operator pick any
+    # ref from the UI, so without this check a manual retry from `develop`
+    # could publish prerelease content to crates.io.
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,7 +48,7 @@ jobs:
           echo "Workspace version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          if [ "${{ inputs.force }}" = "true" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
             echo "Force mode (workflow_dispatch input): proceeding regardless of tag state."
             echo "proceed=true" >> $GITHUB_OUTPUT
           else
@@ -95,15 +100,22 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          set -eu
+          # `pipefail` is essential here: the version probe is `curl | python3`,
+          # and we must not let curl's failure be hidden by python3 emitting an
+          # empty string — that would make us assume the crate is unpublished
+          # and re-attempt `cargo publish`, which fails with `already uploaded`
+          # and reintroduces the very mid-flight failure this workflow guards
+          # against. With pipefail, a transient API failure stops the step.
+          set -euo pipefail
           VERSION=${{ steps.check_version.outputs.version }}
 
           publish_if_missing() {
             local crate=$1
             local current
-            current=$(curl -fsS "https://crates.io/api/v1/crates/$crate" \
-              | python3 -c "import json,sys; d=json.load(sys.stdin); print('' if 'errors' in d else d['crate']['max_version'])" \
-              || echo "")
+            # `--retry 3 --retry-delay 5` rides out brief crates.io API hiccups
+            # before we let the step fail.
+            current=$(curl -fsS --retry 3 --retry-delay 5 "https://crates.io/api/v1/crates/$crate" \
+              | python3 -c "import json,sys; d=json.load(sys.stdin); print('' if 'errors' in d else d['crate']['max_version'])")
             if [ "$current" = "$VERSION" ]; then
               echo "$crate v$VERSION already on crates.io, skipping."
               return

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AbySS is a magic-themed scripting language with its own interpreter, formatter, 
 - Default branch is `develop`; `main` is release-only. Direct pushes to either branch are blocked by branch protection — always branch off with a verb-led kebab-case topic branch (`add-…`, `fix-…`, `refactor-…`) and open a PR. `develop` → `main` promotion also goes through a PR.
 - PR titles and bodies are written in English, matching the established practice on the repository, even when the originating conversation is in another language.
 - CI (`build.yml`) runs `cargo check`, `cargo test` with coverage, `cargo fmt --check`, `cargo clippy -D warnings`, version-sync validation, and the VS Code extension type-check + package step. All must pass before merge.
-- Releases are driven by `release.yml` on push to `main`: when the root `Cargo.toml` `[workspace.package].version` differs from the latest tag, the workflow tags, drafts a GitHub release, and publishes `abyss-core` → `abyss-interpreter` → `abyss-lang` to crates.io in that order.
+- Releases are driven by `release.yml` on push to `main`: when the root `Cargo.toml` `[workspace.package].version` differs from the latest tag, the workflow tags, drafts a GitHub release, and publishes `abyss-core` → `abyss-interpreter` → `abyss-lang` to crates.io in that order. Each step is idempotent (tag creation, draft release, and per-crate publishes skip work already done), and the workflow can be re-run manually via `workflow_dispatch` with the `force` input to recover from a partial failure.
 
 ### Pre-commit hooks (`.pre-commit-config.yaml`)
 - `cargo fmt`, `cargo clippy -D warnings`, `cargo check`, `cargo test` on any `.rs` change.


### PR DESCRIPTION
## Summary

Harden the release workflow so a mid-flight failure (the canonical recent example: an expired \`CARGO_REGISTRY_TOKEN\` taking down the first \`cargo publish\` while the v0.4.0 tag and draft release were already in place) is recoverable without destructive operations on the remote. Adds a manual retry path and makes every release step idempotent.

The motivation was learned the hard way during the v0.4.0 release: once \`release.yml\` had pushed the tag and drafted the release, the version-bump check started returning \`bump=false\` on every subsequent re-run, leaving no way to retry the publish step. Recovery required deleting the tag, deleting the draft, force-pushing an empty commit through a PR, and re-triggering — far more friction than the actual fix (rotate the token).

## What changes

### Workflow (`release.yml`)

- **`workflow_dispatch` trigger** with a single `force` boolean input. Setting `force=true` bypasses the version-bump comparison so the rest of the steps run even when `v$VERSION` already matches the latest tag.
- **Gate output renamed** from `bump` to `proceed` so the semantics fit both the push-with-bump and dispatch-with-force entry paths.
- **Tags fetched eagerly** (`git fetch --tags --force`) before the gate and before tag creation, so a tag pushed by an earlier failed run is visible on retry.
- **Tag step skips when the tag already exists** (`git rev-parse refs/tags/v$VERSION`), instead of failing with `tag '…' already exists`.
- **Release step unchanged** — `softprops/action-gh-release@v3` already upserts a draft release for an existing tag.
- **Publish step queries crates.io per crate** before invoking `cargo publish`. If `max_version` already equals the target version, skip; otherwise publish and sleep 30s for index propagation before the next dependent crate. Avoids `crate version already uploaded` failures when retrying mid-flight.

### Docs (`AGENTS.md`)

- Add one sentence to the Git workflow section noting the idempotency guarantees and the `workflow_dispatch` + `force=true` retry path, so contributors find the recovery mechanism without reading the workflow file.

## Test plan

A real exercise of the workflow has to wait for the next version bump (likely v0.4.1 or v0.5.0). Pre-merge checks:

- [x] `release.yml` parses (the diff is small, structure-preserving; visual review against the prior valid file).
- [x] All four idempotent paths covered:
  - Tag missing → create + push.
  - Tag present → log and continue.
  - Crate not on crates.io → publish + sleep.
  - Crate already at target version → skip.
- [x] `workflow_dispatch` input declared with `default: false` so push-triggered runs still see `force=false` and behave like today.
- [ ] CI green on this PR.
- [ ] First future-release smoke test (next version bump) confirms the happy path is unchanged.

## Notes / non-goals

- This PR does not change anything about the publish order or the 30-second propagation sleep.
- Binary attachment to the GitHub release (the v0.4.0 follow-up Item C in the post-release plan) is intentionally left for a separate PR.
- The version-sync drift guard in \`scripts/check_version_sync.py\` (added in PR #379) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)