### PR TITLE
Fix release.yml: handle 404 in crates.io probe and LF-terminate Windows .sha256

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,11 +134,29 @@ jobs:
 
           publish_if_missing() {
             local crate=$1
-            local current
-            # `--retry 3 --retry-delay 5` rides out brief crates.io API hiccups
-            # before we let the step fail.
-            current=$(curl -fsS --retry 3 --retry-delay 5 "https://crates.io/api/v1/crates/$crate" \
-              | python3 -c "import json,sys; d=json.load(sys.stdin); print('' if 'errors' in d else d['crate']['max_version'])")
+            local current http_code resp
+            resp=$(mktemp)
+            # crates.io returns HTTP 404 + `{"errors": [...]}` for an
+            # unpublished crate, which is a legitimate "publish me" signal —
+            # not an error. Capture the status code separately so we can
+            # distinguish it from real failures (5xx, network), and avoid
+            # `curl -f` (which would exit 22 on the 404 and break first-time
+            # publishes of any new crate added to the workspace).
+            # `--retry 3 --retry-delay 5` still rides out transient hiccups.
+            http_code=$(curl -sS --retry 3 --retry-delay 5 \
+              -w "%{http_code}" -o "$resp" \
+              "https://crates.io/api/v1/crates/$crate")
+            case "$http_code" in
+              200) current=$(python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['max_version'])" < "$resp") ;;
+              404) current="" ;;
+              *)
+                echo "Unexpected HTTP $http_code probing crates.io for $crate; aborting." >&2
+                cat "$resp" >&2
+                rm -f "$resp"
+                return 1
+                ;;
+            esac
+            rm -f "$resp"
             if [ "$current" = "$VERSION" ]; then
               echo "$crate v$VERSION already on crates.io, skipping."
               return
@@ -255,8 +273,10 @@ jobs:
           Copy-Item "README.md" "$stage\"
           Compress-Archive -Path $stage -DestinationPath "$stage.zip"
           $hash = Get-FileHash "$stage.zip" -Algorithm SHA256
-          # Match `sha256sum` output format: "<hex>  <filename>"
-          "$($hash.Hash.ToLower())  $stage.zip" | Out-File -Encoding ASCII -NoNewline "$stage.zip.sha256"
+          # Match GNU `sha256sum` output format: "<hex>  <filename>\n".
+          # Use WriteAllText so we get an LF-terminated record on Windows
+          # (Out-File would emit CRLF, which strict checksum tooling rejects).
+          [System.IO.File]::WriteAllText("$stage.zip.sha256", "$($hash.Hash.ToLower())  $stage.zip`n")
           Get-ChildItem "$stage.zip", "$stage.zip.sha256"
           Add-Content -Path $env:GITHUB_ENV -Value "ASSET=$stage.zip"
           Add-Content -Path $env:GITHUB_ENV -Value "ASSET_SHA=$stage.zip.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,19 +123,26 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          # `pipefail` is essential here: the version probe is `curl | python3`,
-          # and we must not let curl's failure be hidden by python3 emitting an
-          # empty string — that would make us assume the crate is unpublished
-          # and re-attempt `cargo publish`, which fails with `already uploaded`
-          # and reintroduces the very mid-flight failure this workflow guards
-          # against. With pipefail, a transient API failure stops the step.
+          # `pipefail` is essential here: the version probe pipes curl into
+          # python3, and we must not let curl's failure be hidden by python3
+          # emitting an empty string — that would make us assume the crate is
+          # unpublished and re-attempt `cargo publish`, which fails with
+          # `already uploaded` and reintroduces the very mid-flight failure
+          # this workflow guards against. With pipefail, a transient API
+          # failure stops the step.
           set -euo pipefail
           VERSION=${{ steps.check_version.outputs.version }}
+
+          # Single tempdir for every per-crate response, cleaned up on any
+          # exit path (success, set -e abort, signal). Avoids leaking files
+          # if a probe fails between mktemp and the explicit cleanup.
+          TMP=$(mktemp -d)
+          trap 'rm -rf "$TMP"' EXIT
 
           publish_if_missing() {
             local crate=$1
             local current http_code resp
-            resp=$(mktemp)
+            resp="$TMP/$crate.json"
             # crates.io returns HTTP 404 + `{"errors": [...]}` for an
             # unpublished crate, which is a legitimate "publish me" signal —
             # not an error. Capture the status code separately so we can
@@ -152,11 +159,9 @@ jobs:
               *)
                 echo "Unexpected HTTP $http_code probing crates.io for $crate; aborting." >&2
                 cat "$resp" >&2
-                rm -f "$resp"
                 return 1
                 ;;
             esac
-            rm -f "$resp"
             if [ "$current" = "$VERSION" ]; then
               echo "$crate v$VERSION already on crates.io, skipping."
               return
@@ -273,9 +278,11 @@ jobs:
           Copy-Item "README.md" "$stage\"
           Compress-Archive -Path $stage -DestinationPath "$stage.zip"
           $hash = Get-FileHash "$stage.zip" -Algorithm SHA256
-          # Match GNU `sha256sum` output format: "<hex>  <filename>\n".
-          # Use WriteAllText so we get an LF-terminated record on Windows
-          # (Out-File would emit CRLF, which strict checksum tooling rejects).
+          # Match GNU `sha256sum` output format exactly: "<hex>  <filename>\n".
+          # Use WriteAllText to force a single LF terminator on Windows;
+          # earlier approaches could either omit the final newline entirely
+          # (`Out-File -NoNewline`) or emit CRLF (`Out-File` defaults), and
+          # strict checksum tooling expects exactly one LF-terminated record.
           [System.IO.File]::WriteAllText("$stage.zip.sha256", "$($hash.Hash.ToLower())  $stage.zip`n")
           Get-ChildItem "$stage.zip", "$stage.zip.sha256"
           Add-Content -Path $env:GITHUB_ENV -Value "ASSET=$stage.zip"


### PR DESCRIPTION
## Summary

Two latent bugs surfaced by Copilot review on the develop→main promotion PR (#388). Both are forward-compatibility fixes — they do not affect the immediate v0.4.0 backfill plan but would have caused real failures the next time someone exercised the affected paths.

### 1. crates.io probe failed on first-time publish (release.yml)

The `publish_if_missing` helper used `curl -fsS` against `https://crates.io/api/v1/crates/<crate>`. crates.io returns **HTTP 404 with `{"errors": [...]}` body** for an unpublished crate — which is the legitimate "publish me" signal we needed to read as such. With `-f` the step failed with curl exit 22 *before* Python ran, the `${current:-<unpublished>}` log branch was unreachable, and the first publish of any future workspace crate (e.g. a hypothetical `abyss-lsp` or `abyss-wasm`) would have crashed the release pipeline at the same step the v0.4.0 release exercised.

Switch to capturing the HTTP status with `--write-out`:

- **200** → parse `max_version` from body (existing happy path).
- **404** → treat as unpublished (`current=""`).
- **anything else** → abort loudly, dump the body to stderr.

This means a transient 5xx is no longer silently rewritten as "unpublished" — `cargo publish` is no longer reattempted on top of an already-published version.

The existing three crates (`abyss-core`, `abyss-interpreter`, `abyss-lang`) all already have versions on crates.io, so this is purely a forward-compat fix.

### 2. Windows .sha256 sidecar lacked a trailing newline

The Windows packaging step wrote the checksum file via `Out-File -Encoding ASCII -NoNewline`. Strict `sha256sum -c` implementations expect newline-terminated records and reject files without them. Replace with `[System.IO.File]::WriteAllText("$stage.zip.sha256", "...\`n")` so the sidecar emits an **LF terminator** regardless of the runner's line-ending defaults — same convention as `sha256sum` on Linux/macOS so verification works the same across platforms.

## Verification

- [x] `uv run --with pyyaml --no-project python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML still parses.
- [x] HTTP 404 path verified live: `curl -sS -o /dev/null -w "%{http_code}\n" https://crates.io/api/v1/crates/this-crate-zzzzz-12345-does-not-exist` → `404`; `curl -fsS …` → `exit 22`. Confirms the original `-f` behaviour was wrong for unpublished crates.
- [ ] CI green on this PR.
- [ ] After merge, PR #388 picks up these fixes automatically (its head is `develop`); the develop→main promotion proceeds.

## Why a separate PR

PR #388's head is `develop`, which is branch-protected, so direct push isn't possible. Routing the fix through `develop` first means PR #388 just absorbs it on the next CI run and the diff Copilot reviewed is fully addressed before the merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)