### PR TITLE
Identify crates.io probe with a descriptive User-Agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,16 @@ jobs:
             # `curl -f` (which would exit 22 on the 404 and break first-time
             # publishes of any new crate added to the workspace).
             # `--retry 3 --retry-delay 5` still rides out transient hiccups.
+            #
+            # `--user-agent` is required: crates.io's data-access policy
+            # rejects requests without an identifying User-Agent (the
+            # default `curl/x.y.z` UA is treated as anonymous bot traffic
+            # and refused with 403, which is what knocked over a previous
+            # backfill run from this very workflow). Identify the workflow
+            # plus a contact URL so crates.io can reach the maintainer if
+            # this workflow ever misbehaves.
             http_code=$(curl -sS --retry 3 --retry-delay 5 \
+              --user-agent "abyss-lang-release-workflow (+https://github.com/$GITHUB_REPOSITORY)" \
               -w "%{http_code}" -o "$resp" \
               "https://crates.io/api/v1/crates/$crate")
             case "$http_code" in


### PR DESCRIPTION
## Summary

The v0.4.0 backfill (workflow run [24992941112](https://github.com/liebe-magi/abyss-lang/actions/runs/24992941112)) died at \`Publish to crates.io\` with:

\`\`\`
Unexpected HTTP 403 probing crates.io for abyss-core; aborting.
{"errors":[{"detail":"We are unable to process your request at this time. This usually means that you are in violation of our API data access policy (https://crates.io/data-access)…"}]}
\`\`\`

Root cause: curl in the probe was using the default \`curl/x.y.z\` User-Agent, which crates.io treats as anonymous bot traffic — especially from cloud / GitHub-runner IP ranges. The crates.io data-access policy explicitly requires an identifying User-Agent. \`cargo publish\` already sets one (so direct publishes have always worked); only this manual probe was unidentified.

## Fix

Add \`--user-agent "abyss-lang-release-workflow (+https://github.com/\$GITHUB_REPOSITORY)"\` to the probe \`curl\` invocation. The workflow tag + contact URL gives crates.io's operators a way to reach the maintainer if this workflow ever misbehaves, and it satisfies the policy on the runner IPs that triggered the 403.

## Why local repros passed

Earlier in this PR series I tested \`curl -sS https://crates.io/api/v1/crates/<crate>\` from my workstation (residential IP) and consistently got 200. crates.io applies the data-access policy more strictly to cloud / runner IP ranges, so the failure only surfaced once the workflow ran on a GitHub-hosted runner.

## Verification

- [x] YAML still parses (\`uv run --with pyyaml --no-project python3 -c 'import yaml; yaml.safe_load(open(...))'\`).
- [ ] CI green on this PR.
- [ ] After merge → develop → main, re-trigger the v0.4.0 backfill: \`gh workflow run release.yml --ref main -f force=true\`. The probe should now return HTTP 200 (since all three crates are published) and skip cleanly into the binaries / Marketplace jobs.

## Why a separate PR (and the path forward)

main needs the fix before the backfill can succeed. Same flow as the other recent fixes off develop — this PR lands on develop, then a develop → main promotion takes it to main, then the workflow_dispatch can re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)