### PR TITLE
Promote crates.io probe User-Agent fix to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,16 @@ jobs:
             # `curl -f` (which would exit 22 on the 404 and break first-time
             # publishes of any new crate added to the workspace).
             # `--retry 3 --retry-delay 5` still rides out transient hiccups.
+            #
+            # `--user-agent` is required: crates.io's data-access policy
+            # rejects requests without an identifying User-Agent (the
+            # default `curl/x.y.z` UA is treated as anonymous bot traffic
+            # and refused with 403, which is what knocked over a previous
+            # backfill run from this very workflow). Identify the workflow
+            # plus a contact URL so crates.io can reach the maintainer if
+            # this workflow ever misbehaves.
             http_code=$(curl -sS --retry 3 --retry-delay 5 \
+              --user-agent "abyss-lang-release-workflow (+https://github.com/$GITHUB_REPOSITORY)" \
               -w "%{http_code}" -o "$resp" \
               "https://crates.io/api/v1/crates/$crate")
             case "$http_code" in


### PR DESCRIPTION
## Summary

Promote the User-Agent fix (PR #390) and one Renovate digest update (PR #391) from \`develop\` to \`main\` so the v0.4.0 backfill can succeed on the next \`workflow_dispatch\` run. No version bump, no behavioural change beyond what the linked PRs already covered.

## What's landing

### PR #390 — `ci(release): identify crates.io probe with a User-Agent`
The first v0.4.0 backfill ([run 24992941112](https://github.com/liebe-magi/abyss-lang/actions/runs/24992941112)) died at \`Publish to crates.io\` with HTTP 403 from crates.io's data-access policy:

\`\`\`
Unexpected HTTP 403 probing crates.io for abyss-core
"We are unable to process your request at this time. … in violation of our API data access policy"
\`\`\`

Cause: the manual probe was using the default \`curl/x.y.z\` User-Agent, which crates.io treats as anonymous bot traffic — strict on cloud / GitHub-runner IP ranges. \`cargo publish\` already sets a proper UA (so the actual publishes have always worked); only the manual probe was unidentified.

Fix: \`--user-agent "abyss-lang-release-workflow (+https://github.com/\$GITHUB_REPOSITORY)"\` on the probe \`curl\` call.

### PR #391 — `chore(deps): update taiki-e/install-action digest to 481c34c`
Routine Renovate-driven SHA bump for \`taiki-e/install-action\` in \`.github/workflows/build.yml\`.

## Verification

- [x] PRs #390 and #391 each green and Copilot-clean on \`develop\`.
- [ ] CI green on this promotion PR.

## Post-merge action: re-trigger the v0.4.0 backfill

\`\`\`fish
gh workflow run release.yml --ref main -f force=true
\`\`\`

Expected trace this time:
- \`release\` job: probe returns HTTP 200 for all three crates → all publishes skip cleanly. Tag and release exist → skip. Tests still run.
- \`build-binaries\` / \`attach-binaries\`: 12 assets attached to v0.4.0.
- \`publish-extension\`: Marketplace at 0.3.1 → publishes 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)