### PR TITLE
feat(diag): 'did you mean?' for methods and artifact fields

### DIFF
--- a/crates/abyss-interpreter/src/diagnostics.rs
+++ b/crates/abyss-interpreter/src/diagnostics.rs
@@ -1,11 +1,19 @@
 //! Lightweight helpers shared between error-reporting sites.
 //!
 //! The interpreter raises errors as `EvalError` strings; this module supplies
-//! the bits of formatting reused across several call sites — currently the
+//! the bits of formatting reused across several call sites — chiefly the
 //! Levenshtein-based "did you mean?" suggestion logic that enriches messages
-//! about undefined identifiers (variables and functions). The same primitives
-//! are intended to be reused as more diagnostic flavours land (methods,
-//! artifact fields).
+//! about undefined identifiers (variables, functions, methods, and artifact
+//! fields). Two rendering modes are exposed so callers can pick the form that
+//! reads best in their message:
+//!
+//! - [`label_with_suggestions`] — appends the hint after a bare identifier
+//!   (`foo (did you mean: bar?)`); used where the identifier is the whole
+//!   message subject (e.g. `EvalError::UndefinedVariable`).
+//! - [`format_suggestions_hint`] / [`did_you_mean_hint`] — return just the
+//!   parenthesised suffix so the caller can splice it inside a longer
+//!   message that already wraps the identifier in punctuation
+//!   (`Field 'fild' (did you mean: field?) does not exist on …`).
 
 /// Compute the Levenshtein edit distance between two strings.
 ///
@@ -72,28 +80,56 @@ where
     scored.into_iter().map(|(_, name)| name).collect()
 }
 
-/// Append a parenthesised "did you mean: …" hint to `name` when at least one
-/// suggestion is available. Renders as:
+/// Render just the parenthesised "did you mean: …" suffix — without any
+/// preceding identifier. Returns `None` when the suggestion list is empty so
+/// callers can decide where to splice the hint into a larger message (e.g.
+/// outside of single quotes around a field name).
 ///
-/// - one suggestion: `"X"`
-/// - two suggestions: `"X or Y"`
-/// - three or more: `"X, Y, or Z"` (Oxford comma followed by `"or"`)
-///
-/// When the suggestion list is empty the original `name` is returned
-/// unchanged, so call sites can hand the result straight to
-/// `EvalError::UndefinedVariable(...)` without further branching.
-pub(crate) fn label_with_suggestions(name: &str, suggestions: &[String]) -> String {
+/// Format mirrors [`label_with_suggestions`]:
+/// - one suggestion: `"(did you mean: X?)"`
+/// - two suggestions: `"(did you mean: X or Y?)"`
+/// - three or more: `"(did you mean: X, Y, or Z?)"` (Oxford comma)
+pub(crate) fn format_suggestions_hint(suggestions: &[String]) -> Option<String> {
     match suggestions {
-        [] => name.to_string(),
-        [only] => format!("{} (did you mean: {}?)", name, only),
-        [first, second] => format!("{} (did you mean: {} or {}?)", name, first, second),
+        [] => None,
+        [only] => Some(format!("(did you mean: {}?)", only)),
+        [first, second] => Some(format!("(did you mean: {} or {}?)", first, second)),
         many => {
-            // Three or more — comma-separated with an Oxford comma before
-            // the final `"or"`, e.g. "a, b, or c".
             let (last, rest) = many.split_last().expect("non-empty in this arm");
-            format!("{} (did you mean: {}, or {}?)", name, rest.join(", "), last)
+            Some(format!("(did you mean: {}, or {}?)", rest.join(", "), last))
         }
     }
+}
+
+/// Append a parenthesised "did you mean: …" hint to `name` when at least one
+/// suggestion is available. When the suggestion list is empty the original
+/// `name` is returned unchanged, so call sites can hand the result straight to
+/// an `EvalError` variant without further branching.
+pub(crate) fn label_with_suggestions(name: &str, suggestions: &[String]) -> String {
+    match format_suggestions_hint(suggestions) {
+        None => name.to_string(),
+        Some(hint) => format!("{} {}", name, hint),
+    }
+}
+
+/// Convenience composition of [`did_you_mean`] and
+/// [`format_suggestions_hint`]: pick suggestions from `candidates` and return
+/// just the parenthesised "(did you mean: …)" suffix (or `None`).
+///
+/// Used when the call site needs to splice the hint into a larger message
+/// that already wraps the target identifier — for example, after a closing
+/// single quote around a field name in
+/// `Field 'fild' (did you mean: field?) does not exist on …`.
+pub(crate) fn did_you_mean_hint<'a, I>(
+    target: &str,
+    candidates: I,
+    max_count: usize,
+) -> Option<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let suggestions = did_you_mean(target, candidates, max_count);
+    format_suggestions_hint(&suggestions)
 }
 
 #[cfg(test)]
@@ -181,5 +217,44 @@ mod tests {
         // Regardless of input order, alphabetical tie-break gives "abc" first.
         assert_eq!(did_you_mean("abz", ["abx", "abc"], 2), vec!["abc", "abx"]);
         assert_eq!(did_you_mean("abz", ["abc", "abx"], 2), vec!["abc", "abx"]);
+    }
+
+    #[test]
+    fn did_you_mean_hint_renders_parenthetical_when_close_match_exists() {
+        assert_eq!(
+            did_you_mean_hint("fild", ["name", "field", "level"], 3).as_deref(),
+            Some("(did you mean: field?)")
+        );
+    }
+
+    #[test]
+    fn did_you_mean_hint_returns_none_when_no_close_match() {
+        assert!(did_you_mean_hint("xyz", ["name", "field"], 3).is_none());
+    }
+
+    #[test]
+    fn format_suggestions_hint_returns_none_for_empty() {
+        assert!(format_suggestions_hint(&[]).is_none());
+    }
+
+    #[test]
+    fn format_suggestions_hint_renders_two_with_or() {
+        assert_eq!(
+            format_suggestions_hint(&["health".to_string(), "heat".to_string()]).as_deref(),
+            Some("(did you mean: health or heat?)")
+        );
+    }
+
+    #[test]
+    fn format_suggestions_hint_renders_three_or_more_with_oxford_comma() {
+        assert_eq!(
+            format_suggestions_hint(&[
+                "counter".to_string(),
+                "counted".to_string(),
+                "counters".to_string()
+            ])
+            .as_deref(),
+            Some("(did you mean: counter, counted, or counters?)")
+        );
     }
 }

--- a/crates/abyss-interpreter/src/eval/artifacts.rs
+++ b/crates/abyss-interpreter/src/eval/artifacts.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use super::result::{EvalError, EvalResult};
 use super::values::describe_value;
+use crate::diagnostics::did_you_mean_hint;
 
 pub(crate) fn ensure_type_known(
     ty: &Type,
@@ -151,11 +152,15 @@ pub(crate) fn missing_field_error(
     field: &str,
     line_info: &Option<LineInfo>,
 ) -> EvalError {
-    let available = schema.field_names().join(", ");
+    let available_names = schema.field_names();
+    let hint = did_you_mean_hint(field, available_names.iter().map(String::as_str), 3)
+        .map(|h| format!(" {}", h))
+        .unwrap_or_default();
+    let available = available_names.join(", ");
     EvalError::InvalidOperation(
         format!(
-            "Field '{}' does not exist on artifact {} (available: [{}])",
-            field, schema.name, available
+            "Field '{}'{} does not exist on artifact {} (available: [{}])",
+            field, hint, schema.name, available
         ),
         line_info.clone(),
     )
@@ -506,5 +511,47 @@ mod tests {
 
         let lex_c = lexicon(vec![("key", rune("beta"))]);
         assert!(!values_equal(&env, &lex_a, &lex_c, &None).unwrap());
+    }
+
+    #[test]
+    fn missing_field_error_appends_did_you_mean_for_close_match() {
+        let env = env_with_schema(
+            "Player",
+            vec![
+                ("name", Type::Rune),
+                ("hp", Type::Arcana),
+                ("mp", Type::Arcana),
+            ],
+        );
+        let schema = lookup_schema_by_name(&env, "Player", &None).unwrap();
+        let err = missing_field_error(schema, "nmae", &None);
+        match err {
+            EvalError::InvalidOperation(msg, _) => {
+                assert!(
+                    msg.contains(
+                        "Field 'nmae' (did you mean: name?) does not exist on artifact Player"
+                    ),
+                    "missing did-you-mean hint in: {msg}"
+                );
+                // The "available" listing should still be present so users can
+                // see the full schema even when a close match is suggested.
+                assert!(msg.contains("(available: [name, hp, mp])"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn missing_field_error_omits_hint_when_no_close_match() {
+        let env = env_with_schema("Player", vec![("name", Type::Rune), ("hp", Type::Arcana)]);
+        let schema = lookup_schema_by_name(&env, "Player", &None).unwrap();
+        let err = missing_field_error(schema, "completely_unrelated_field", &None);
+        match err {
+            EvalError::InvalidOperation(msg, _) => {
+                assert!(!msg.contains("did you mean"), "msg: {msg}");
+                assert!(msg.contains("(available: [name, hp])"));
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        }
     }
 }

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+use crate::diagnostics::did_you_mean_hint;
 use crate::env::{CallArg, Callable, EngravedFunction, RuntimeEnv, Value};
 use crate::stdlib::methods;
 use abyss_core::ast::{AST, LineInfo, Type};
@@ -526,11 +527,19 @@ fn evaluate_artifact_method_call(
 ) -> Result<EvalResult, EvalError> {
     let schema = lookup_schema_from_handle(env, &receiver_handle, line_info)?;
     let artifact_name = schema.name.clone();
+    let method_candidates: Vec<String> = schema.methods.keys().cloned().collect();
     let artifact_method = env
         .get_artifact_method(&artifact_name, method_name)
         .ok_or_else(|| {
+            let hint =
+                did_you_mean_hint(method_name, method_candidates.iter().map(String::as_str), 3)
+                    .map(|h| format!(" {}", h))
+                    .unwrap_or_default();
             EvalError::InvalidOperation(
-                format!("Method {}::{} is not defined", artifact_name, method_name),
+                format!(
+                    "Method {}::{} is not defined{}",
+                    artifact_name, method_name, hint
+                ),
                 line_info.clone(),
             )
         })?;

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -527,14 +527,14 @@ fn evaluate_artifact_method_call(
 ) -> Result<EvalResult, EvalError> {
     let schema = lookup_schema_from_handle(env, &receiver_handle, line_info)?;
     let artifact_name = schema.name.clone();
-    let method_candidates: Vec<String> = schema.methods.keys().cloned().collect();
     let artifact_method = env
         .get_artifact_method(&artifact_name, method_name)
         .ok_or_else(|| {
-            let hint =
-                did_you_mean_hint(method_name, method_candidates.iter().map(String::as_str), 3)
-                    .map(|h| format!(" {}", h))
-                    .unwrap_or_default();
+            // Build candidate names lazily on the error path so the happy
+            // path does not iterate the schema's method table.
+            let hint = did_you_mean_hint(method_name, schema.methods.keys().map(String::as_str), 3)
+                .map(|h| format!(" {}", h))
+                .unwrap_or_default();
             EvalError::InvalidOperation(
                 format!(
                     "Method {}::{} is not defined{}",

--- a/crates/abyss-interpreter/src/stdlib/methods/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/mod.rs
@@ -2,6 +2,7 @@ mod lexicon;
 mod materia;
 mod scroll;
 
+use crate::diagnostics::did_you_mean_hint;
 use crate::env::{BuiltinMethodHandler, BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::artifacts::collect_field_chain;
 use crate::eval::values::describe_value;
@@ -34,11 +35,27 @@ pub fn dispatch_builtin_method(
     let handler = lookup_handler(registry, &receiver_type, method_name)
         .or_else(|| lookup_handler(registry, &fallback_type, method_name))
         .ok_or_else(|| {
+            // Pull candidate method names from both the receiver type's table
+            // and the Materia fallback table — the lookup itself walks both,
+            // so the suggestion list should mirror that surface.
+            let mut candidates: Vec<&str> = Vec::new();
+            if let Some(table) = registry.get(&receiver_type) {
+                candidates.extend(table.keys().map(String::as_str));
+            }
+            if receiver_type != fallback_type
+                && let Some(table) = registry.get(&fallback_type)
+            {
+                candidates.extend(table.keys().map(String::as_str));
+            }
+            let hint = did_you_mean_hint(method_name, candidates, 3)
+                .map(|h| format!(" {}", h))
+                .unwrap_or_default();
             EvalError::InvalidOperation(
                 format!(
-                    "Method {} is not defined for {}",
+                    "Method {} is not defined for {}{}",
                     method_name,
-                    describe_value(&receiver_value)
+                    describe_value(&receiver_value),
+                    hint
                 ),
                 line_info.clone(),
             )
@@ -171,6 +188,12 @@ mod tests {
     use super::*;
     use crate::env::Value;
 
+    fn env_with_builtin_methods() -> RuntimeEnv {
+        let mut env = RuntimeEnv::new();
+        env.set_builtin_methods(get_all_builtin_methods());
+        env
+    }
+
     #[test]
     fn test_dispatch_unknown_method() {
         let mut env = RuntimeEnv::new();
@@ -188,5 +211,79 @@ mod tests {
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("Method unknown_method is not defined")
         ));
+    }
+
+    #[test]
+    fn dispatch_unknown_method_suggests_close_match_from_receiver_table() {
+        // `Type::Scroll`'s real method table includes `scribe` — a typo of
+        // `"scrieb"` should surface that as a suggestion.
+        let mut env = env_with_builtin_methods();
+        let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
+        let err = dispatch_builtin_method(
+            &mut env,
+            &AST::Abyss(None),
+            None,
+            scroll_value,
+            "scrieb",
+            vec![],
+            &None,
+        )
+        .unwrap_err();
+
+        match err {
+            EvalError::InvalidOperation(msg, _) => {
+                assert!(msg.contains("scrieb"), "msg: {msg}");
+                assert!(msg.contains("did you mean: scribe"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dispatch_unknown_method_falls_back_to_materia_table_for_suggestions() {
+        // `trans` lives on the Materia fallback table; a typo on a non-Materia
+        // receiver should still surface it as a suggestion.
+        let mut env = env_with_builtin_methods();
+        let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
+        let err = dispatch_builtin_method(
+            &mut env,
+            &AST::Abyss(None),
+            None,
+            scroll_value,
+            "tarns",
+            vec![],
+            &None,
+        )
+        .unwrap_err();
+
+        match err {
+            EvalError::InvalidOperation(msg, _) => {
+                assert!(msg.contains("did you mean: trans"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dispatch_unknown_method_omits_hint_when_no_close_match() {
+        let mut env = env_with_builtin_methods();
+        let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
+        let err = dispatch_builtin_method(
+            &mut env,
+            &AST::Abyss(None),
+            None,
+            scroll_value,
+            "completely_unrelated_method_name",
+            vec![],
+            &None,
+        )
+        .unwrap_err();
+
+        match err {
+            EvalError::InvalidOperation(msg, _) => {
+                assert!(!msg.contains("did you mean"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        }
     }
 }

--- a/crates/abyss-interpreter/tests/test_artifacts.rs
+++ b/crates/abyss-interpreter/tests/test_artifacts.rs
@@ -237,3 +237,78 @@ hero.level;
         other => panic!("expected arcana result, found {:?}", other),
     }
 }
+
+#[test]
+fn artifact_field_typo_suggests_close_match() {
+    let input = r#"
+artifact Player { name: rune; health: arcana; };
+forge hero: Player = Player { name: "Ardyn", health: 100 };
+hero.helth;
+"#;
+
+    match test_base(input) {
+        Ok(_) => panic!("expected unknown-field error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(message, _)) => {
+                assert!(
+                    message.contains("Field 'helth'") && message.contains("did you mean: health"),
+                    "missing did-you-mean hint: {}",
+                    message
+                );
+            }
+            other => panic!("expected invalid operation error, found {:?}", other),
+        },
+    }
+}
+
+#[test]
+fn artifact_method_typo_suggests_close_match() {
+    let input = r#"
+artifact Player { level: arcana; };
+engrave Player::get_level(core) -> arcana {
+    reveal core.level;
+};
+forge hero: Player = Player { level: 7 };
+hero.get_levle();
+"#;
+
+    match test_base(input) {
+        Ok(_) => panic!("expected unknown-method error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(message, _)) => {
+                assert!(
+                    message.contains("Method Player::get_levle is not defined")
+                        && message.contains("did you mean: get_level"),
+                    "missing did-you-mean hint: {}",
+                    message
+                );
+            }
+            other => panic!("expected invalid operation error, found {:?}", other),
+        },
+    }
+}
+
+#[test]
+fn builtin_method_typo_suggests_close_match() {
+    // `scribe` lives on the Scroll table; a typo on a scroll receiver should
+    // surface it as a suggestion via the dispatch error path.
+    let input = r#"
+forge morph items: scroll = [1, 2, 3];
+items.scrieb(4);
+"#;
+
+    match test_base(input) {
+        Ok(_) => panic!("expected unknown-method error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(message, _)) => {
+                assert!(
+                    message.contains("Method scrieb is not defined")
+                        && message.contains("did you mean: scribe"),
+                    "missing did-you-mean hint: {}",
+                    message
+                );
+            }
+            other => panic!("expected invalid operation error, found {:?}", other),
+        },
+    }
+}


### PR DESCRIPTION
## Summary

Extends PR4-A (#397)'s Levenshtein suggestions to three more runtime-error sites:

- **Artifact field reads** — `Field 'fild' (did you mean: field?) does not exist on artifact Player (available: [name, hp, mp])`
- **Builtin method dispatch** — searches both the receiver type's method table and the Materia fallback table (mirroring the lookup itself), so e.g. `[1,2,3].scrieb(...)` surfaces `did you mean: scribe?`
- **Artifact-defined method dispatch** — suggests close matches from the schema's own method registry, e.g. `hero.get_levle()` → `did you mean: get_level?`

The `(available: [...])` listing on the field error is preserved as a fallback diagnostic for cases where Levenshtein finds no close match.

A new `did_you_mean_hint` helper returns just the parenthesised suffix so call sites can splice the hint into a longer message that already wraps the identifier in punctuation (e.g. single quotes around field names) without putting the suggestion inside the quotes.

## Why non-breaking

- `EvalError::InvalidOperation(String, _)` is reused unchanged at all three sites
- Only the error *message string* gets enriched; existing `assert!(msg.contains("..."))` based tests in this PR's suite still pass

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full workspace)
- [x] Unit tests in `diagnostics.rs` cover the new `format_suggestions_hint` / `did_you_mean_hint` helpers, including 1/2/3+ suggestion rendering
- [x] Unit tests in `artifacts.rs` cover hint emission and pass-through for `missing_field_error`
- [x] Unit tests in `stdlib/methods/mod.rs` cover receiver-table, Materia-fallback, and "no close match" paths
- [x] Integration tests in `tests/test_artifacts.rs` exercise the full parse → eval pipeline for field, artifact-method, and builtin-method typos

🤖 Generated with [Claude Code](https://claude.com/claude-code)