### PR TITLE
feat(diag): render runtime errors with ariadne; mark EvalError non_exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ name = "abyss-interpreter"
 version = "0.4.0"
 dependencies = [
  "abyss-core",
- "colored",
+ "ariadne",
  "ordered-float",
 ]
 

--- a/crates/abyss-cli/src/main.rs
+++ b/crates/abyss-cli/src/main.rs
@@ -4,7 +4,7 @@ use abyss_core::{
 };
 use abyss_interpreter::{
     env::Value,
-    eval::{EvalError, EvalResult, display_error_with_source, evaluate},
+    eval::{EvalResult, display_error_with_source, evaluate},
     stdlib,
 };
 use clap::{Parser, Subcommand};
@@ -95,16 +95,8 @@ fn execute_script(script: &str) {
 
     for ast in outcome.ast {
         if let Err(error) = evaluate(&ast, &mut env) {
-            let message = error.to_string();
-            match error {
-                EvalError::UndefinedVariable(_, line_info)
-                | EvalError::InvalidOperation(_, line_info)
-                | EvalError::NegativeExponent(line_info)
-                | EvalError::TypeError(_, line_info) => {
-                    display_error_with_source(script, line_info, &message);
-                    return;
-                }
-            }
+            display_error_with_source(script, &error);
+            return;
         }
     }
 }

--- a/crates/abyss-interpreter/Cargo.toml
+++ b/crates/abyss-interpreter/Cargo.toml
@@ -13,5 +13,5 @@ homepage.workspace = true
 
 [dependencies]
 abyss-core.workspace = true
-colored = "3.0.0"
+ariadne = "0.6"
 ordered-float = "5"

--- a/crates/abyss-interpreter/src/eval/mod.rs
+++ b/crates/abyss-interpreter/src/eval/mod.rs
@@ -5,5 +5,8 @@ mod result;
 mod statements;
 pub(crate) mod values;
 
-pub use result::{EvalError, EvalResult, display_error_with_source};
+pub use result::{
+    EvalError, EvalResult, RUNTIME_SOURCE_ID, display_error_with_source,
+    display_error_with_source_id,
+};
 pub use statements::evaluate;

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -80,7 +80,21 @@ impl fmt::Display for EvalError {
 
 impl std::error::Error for EvalError {}
 
-const RUNTIME_SOURCE_ID: &str = "<script>";
+/// Default source identifier used by [`display_error_with_source`]. Mirrors
+/// the placeholder the CLI passes to the parser so file invocations show a
+/// consistent header across parser and runtime diagnostics.
+pub const RUNTIME_SOURCE_ID: &str = "<script>";
+
+/// Render a runtime error against the source script using the default
+/// runtime source id (`"<script>"`).
+///
+/// For callers that want diagnostics to reflect a different context — REPL
+/// buffer, test harness input, or an actual file path — use
+/// [`display_error_with_source_id`] instead so the parser and runtime
+/// reports stay consistent.
+pub fn display_error_with_source(script: &str, error: &EvalError) {
+    display_error_with_source_id(RUNTIME_SOURCE_ID, script, error);
+}
 
 /// Render a runtime error against the source script using
 /// [`ariadne`]'s annotated report style — matching the parser's diagnostic
@@ -88,9 +102,13 @@ const RUNTIME_SOURCE_ID: &str = "<script>";
 /// the offending column is underlined; otherwise a plain "Error: …" line is
 /// printed to stderr as a fallback.
 ///
+/// `source_id` controls the label shown by the diagnostic renderer (e.g.
+/// `"<script>"`, `"<repl>"`, `"<test>"`, or a file path) so runtime reports
+/// stay consistent with the parser diagnostics produced for the same input.
+///
 /// Output goes to stderr. Any I/O failure from ariadne is swallowed (matching
 /// the pre-migration `eprintln!`-based behaviour).
-pub fn display_error_with_source(script: &str, error: &EvalError) {
+pub fn display_error_with_source_id(source_id: &str, script: &str, error: &EvalError) {
     let message = error.to_string();
     if let Some(info) = error.line_info()
         && let Some(start) = line_col_to_byte_offset(script, info.line, info.column)
@@ -101,15 +119,15 @@ pub fn display_error_with_source(script: &str, error: &EvalError) {
         // refactor planned for a later release.
         let end = (start + 1).min(script.len()).max(start);
         let span = start..end;
-        let report = Report::build(ReportKind::Error, (RUNTIME_SOURCE_ID, span.clone()))
+        let report = Report::build(ReportKind::Error, (source_id, span.clone()))
             .with_message(error.kind_label())
             .with_label(
-                Label::new((RUNTIME_SOURCE_ID, span))
+                Label::new((source_id, span))
                     .with_message(&message)
                     .with_color(Color::Red),
             )
             .finish();
-        let _ = report.eprint((RUNTIME_SOURCE_ID, Source::from(script)));
+        let _ = report.eprint((source_id, Source::from(script)));
     } else {
         eprintln!("Error: {}", message);
     }
@@ -117,8 +135,11 @@ pub fn display_error_with_source(script: &str, error: &EvalError) {
 
 /// Convert a 1-based `(line, column)` pair (where `column` is a byte offset
 /// within the line, matching the parser's `LineMap`) into a byte offset
-/// suitable for ariadne's range-based labels. Returns `None` when the
-/// position cannot be resolved against `source`.
+/// suitable for ariadne's range-based labels.
+///
+/// Returns `None` when the position cannot be resolved against `source` —
+/// this includes columns past the end of the named line, which would
+/// otherwise spill into the next line and underline an unrelated character.
 fn line_col_to_byte_offset(source: &str, line: usize, column: usize) -> Option<usize> {
     if line == 0 || column == 0 {
         return None;
@@ -130,8 +151,13 @@ fn line_col_to_byte_offset(source: &str, line: usize, column: usize) -> Option<u
         }
     }
     let line_start = *line_starts.get(line - 1)?;
+    // Stop the column at the end of its own line. For non-last lines that's
+    // the offset of the next line's first byte (just past the newline); for
+    // the last line we allow a one-past-end (EOF) position so errors
+    // attached to the final character still resolve.
+    let line_end_exclusive = line_starts.get(line).copied().unwrap_or(source.len() + 1);
     let offset = line_start + (column - 1);
-    if offset > source.len() {
+    if offset >= line_end_exclusive || offset > source.len() {
         return None;
     }
     Some(offset)
@@ -207,6 +233,16 @@ mod tests {
         assert_eq!(line_col_to_byte_offset(source, 5, 1), None);
         // Column past end of source returns None.
         assert!(line_col_to_byte_offset(source, 2, 100).is_none());
+    }
+
+    #[test]
+    fn line_col_to_byte_offset_rejects_column_past_line_end() {
+        // Line 1 contains "abc" (3 bytes) followed by a newline; column 5
+        // would otherwise spill into "def" on the next line. Reject it so
+        // the highlight cannot point at an unrelated character.
+        let source = "abc\ndef";
+        assert_eq!(line_col_to_byte_offset(source, 1, 4), Some(3));
+        assert!(line_col_to_byte_offset(source, 1, 5).is_none());
     }
 
     #[test]

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -1,6 +1,6 @@
 use crate::env::{ArtifactHandle, Value};
 use abyss_core::ast::LineInfo;
-use colored::*;
+use ariadne::{Color, Label, Report, ReportKind, Source};
 use std::fmt;
 
 /// Represents the result of an evaluation in the interpreter.
@@ -28,12 +28,41 @@ impl EvalResult {
 }
 
 /// Represents possible errors that can occur during evaluation.
+///
+/// Marked `#[non_exhaustive]` so future variants (richer span tracking,
+/// new diagnostic categories) can be added without breaking downstream
+/// matchers — they will need a wildcard arm. Within this crate the
+/// compiler still enforces full coverage.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum EvalError {
     UndefinedVariable(String, Option<LineInfo>),
     InvalidOperation(String, Option<LineInfo>),
     NegativeExponent(Option<LineInfo>),
     TypeError(String, Option<LineInfo>),
+}
+
+impl EvalError {
+    /// Returns the source-position metadata attached to this error, if any.
+    pub fn line_info(&self) -> Option<&LineInfo> {
+        match self {
+            EvalError::UndefinedVariable(_, info)
+            | EvalError::InvalidOperation(_, info)
+            | EvalError::TypeError(_, info)
+            | EvalError::NegativeExponent(info) => info.as_ref(),
+        }
+    }
+
+    /// Short, human-readable category label used as the report header in
+    /// [`display_error_with_source`].
+    fn kind_label(&self) -> &'static str {
+        match self {
+            EvalError::UndefinedVariable(_, _) => "Undefined variable",
+            EvalError::InvalidOperation(_, _) => "Invalid operation",
+            EvalError::NegativeExponent(_) => "Negative exponent",
+            EvalError::TypeError(_, _) => "Type error",
+        }
+    }
 }
 
 impl fmt::Display for EvalError {
@@ -51,35 +80,67 @@ impl fmt::Display for EvalError {
 
 impl std::error::Error for EvalError {}
 
-/// Displays an error message along with the relevant source code and line information, if available.
-pub fn display_error_with_source(script: &str, line_info: Option<LineInfo>, error_message: &str) {
-    if let Some(info) = line_info {
-        let lines: Vec<&str> = script.lines().collect();
-        if let Some(source_line) = lines.get(info.line - 1) {
-            // Line numbers start from 1, so we subtract 1
-            eprintln!(
-                "{}",
-                format!(
-                    "Error at line {}, column {}: {}",
-                    info.line, info.column, error_message
-                )
-                .red()
-            );
-            eprintln!("  {}", source_line.red());
-            eprintln!("  {}{}", " ".repeat(info.column - 1).red(), "^".red());
-        } else {
-            eprintln!("{}", format!("Error: {}", error_message).red());
-        }
+const RUNTIME_SOURCE_ID: &str = "<script>";
+
+/// Render a runtime error against the source script using
+/// [`ariadne`]'s annotated report style — matching the parser's diagnostic
+/// look. When the error carries a [`LineInfo`] that resolves into the source,
+/// the offending column is underlined; otherwise a plain "Error: …" line is
+/// printed to stderr as a fallback.
+///
+/// Output goes to stderr. Any I/O failure from ariadne is swallowed (matching
+/// the pre-migration `eprintln!`-based behaviour).
+pub fn display_error_with_source(script: &str, error: &EvalError) {
+    let message = error.to_string();
+    if let Some(info) = error.line_info()
+        && let Some(start) = line_col_to_byte_offset(script, info.line, info.column)
+    {
+        // Single-byte highlight at the reported column, clamped so the span
+        // never extends past the source. `LineInfo` carries no end position
+        // today, so finer-grained highlighting requires the larger Span
+        // refactor planned for a later release.
+        let end = (start + 1).min(script.len()).max(start);
+        let span = start..end;
+        let report = Report::build(ReportKind::Error, (RUNTIME_SOURCE_ID, span.clone()))
+            .with_message(error.kind_label())
+            .with_label(
+                Label::new((RUNTIME_SOURCE_ID, span))
+                    .with_message(&message)
+                    .with_color(Color::Red),
+            )
+            .finish();
+        let _ = report.eprint((RUNTIME_SOURCE_ID, Source::from(script)));
     } else {
-        eprintln!("{}", format!("Error: {}", error_message).red());
+        eprintln!("Error: {}", message);
     }
+}
+
+/// Convert a 1-based `(line, column)` pair (where `column` is a byte offset
+/// within the line, matching the parser's `LineMap`) into a byte offset
+/// suitable for ariadne's range-based labels. Returns `None` when the
+/// position cannot be resolved against `source`.
+fn line_col_to_byte_offset(source: &str, line: usize, column: usize) -> Option<usize> {
+    if line == 0 || column == 0 {
+        return None;
+    }
+    let mut line_starts: Vec<usize> = vec![0];
+    for (i, ch) in source.char_indices() {
+        if ch == '\n' {
+            line_starts.push(i + ch.len_utf8());
+        }
+    }
+    let line_start = *line_starts.get(line - 1)?;
+    let offset = line_start + (column - 1);
+    if offset > source.len() {
+        return None;
+    }
+    Some(offset)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::env::ArtifactValue;
-    use colored::control;
     use std::cell::RefCell;
     use std::collections::HashMap;
     use std::rc::Rc;
@@ -120,21 +181,76 @@ mod tests {
     }
 
     #[test]
-    fn display_error_with_valid_line_highlights_source() {
-        control::set_override(false);
+    fn line_info_returns_attached_position() {
+        let err = EvalError::TypeError("x".into(), Some(LineInfo::new(3, 4)));
+        let info = err.line_info().expect("line info attached");
+        assert_eq!(info.line, 3);
+        assert_eq!(info.column, 4);
+
+        let plain = EvalError::NegativeExponent(None);
+        assert!(plain.line_info().is_none());
+    }
+
+    #[test]
+    fn line_col_to_byte_offset_resolves_simple_positions() {
+        let source = "abc\ndef\nghi";
+        assert_eq!(line_col_to_byte_offset(source, 1, 1), Some(0));
+        assert_eq!(line_col_to_byte_offset(source, 2, 1), Some(4));
+        assert_eq!(line_col_to_byte_offset(source, 3, 2), Some(9));
+    }
+
+    #[test]
+    fn line_col_to_byte_offset_rejects_out_of_range() {
+        let source = "abc\ndef";
+        assert_eq!(line_col_to_byte_offset(source, 0, 1), None);
+        assert_eq!(line_col_to_byte_offset(source, 1, 0), None);
+        assert_eq!(line_col_to_byte_offset(source, 5, 1), None);
+        // Column past end of source returns None.
+        assert!(line_col_to_byte_offset(source, 2, 100).is_none());
+    }
+
+    #[test]
+    fn line_col_to_byte_offset_handles_multibyte_chars() {
+        // "あ" is 3 bytes in UTF-8; the second line starts after the newline
+        // following it.
+        let source = "あ\nb";
+        assert_eq!(line_col_to_byte_offset(source, 1, 1), Some(0));
+        assert_eq!(line_col_to_byte_offset(source, 2, 1), Some(4));
+    }
+
+    #[test]
+    fn display_error_with_valid_line_does_not_panic() {
         let script = "sigil = 1\nhex = sigil + 2";
-        display_error_with_source(script, Some(LineInfo::new(2, 5)), "invalid operation");
+        let err = EvalError::InvalidOperation("invalid op".into(), Some(LineInfo::new(2, 5)));
+        display_error_with_source(script, &err);
     }
 
     #[test]
     fn display_error_without_matching_line_falls_back_to_generic() {
-        control::set_override(false);
-        display_error_with_source("sigil = 1", Some(LineInfo::new(3, 1)), "out of range");
+        let err = EvalError::TypeError("out of range".into(), Some(LineInfo::new(99, 1)));
+        display_error_with_source("sigil = 1", &err);
     }
 
     #[test]
     fn display_error_without_line_info_still_prints_message() {
-        control::set_override(false);
-        display_error_with_source("sigil = 1", None, "missing context");
+        let err = EvalError::NegativeExponent(None);
+        display_error_with_source("sigil = 1", &err);
+    }
+
+    #[test]
+    fn kind_label_covers_every_variant() {
+        // If a new variant is added the compiler will flag this match
+        // (`#[non_exhaustive]` only restricts external matching); keeping
+        // this test guards against silently shipping a variant without a
+        // human-readable label.
+        let cases: [EvalError; 4] = [
+            EvalError::UndefinedVariable("x".into(), None),
+            EvalError::InvalidOperation("y".into(), None),
+            EvalError::NegativeExponent(None),
+            EvalError::TypeError("z".into(), None),
+        ];
+        for err in &cases {
+            assert!(!err.kind_label().is_empty());
+        }
     }
 }

--- a/crates/abyss-interpreter/tests/test_base.rs
+++ b/crates/abyss-interpreter/tests/test_base.rs
@@ -1,18 +1,20 @@
 use abyss_core::parser::{emit_diagnostics, parse};
 use abyss_interpreter::{
-    eval::{EvalResult, display_error_with_source, evaluate},
+    eval::{EvalResult, display_error_with_source_id, evaluate},
     stdlib,
 };
 
 #[allow(unused_imports)]
 pub use abyss_interpreter::env::Value;
 
+const TEST_SOURCE_ID: &str = "<test>";
+
 pub fn test_base(input: &str) -> Result<Vec<EvalResult>, Box<dyn std::error::Error>> {
     let mut env = stdlib::create_global_environment();
     let outcome = parse(input);
 
     if !outcome.diagnostics.is_empty() {
-        emit_diagnostics("<test>", input, &outcome.diagnostics)
+        emit_diagnostics(TEST_SOURCE_ID, input, &outcome.diagnostics)
             .expect("failed to emit parser diagnostics");
         panic!("Parser emitted diagnostics for test input");
     }
@@ -22,7 +24,7 @@ pub fn test_base(input: &str) -> Result<Vec<EvalResult>, Box<dyn std::error::Err
         match evaluate(&ast, &mut env) {
             Ok(result) => results.push(result),
             Err(e) => {
-                display_error_with_source(input, &e);
+                display_error_with_source_id(TEST_SOURCE_ID, input, &e);
                 return Err(Box::new(e));
             }
         }

--- a/crates/abyss-interpreter/tests/test_base.rs
+++ b/crates/abyss-interpreter/tests/test_base.rs
@@ -1,6 +1,6 @@
 use abyss_core::parser::{emit_diagnostics, parse};
 use abyss_interpreter::{
-    eval::{EvalError, EvalResult, display_error_with_source, evaluate},
+    eval::{EvalResult, display_error_with_source, evaluate},
     stdlib,
 };
 
@@ -22,15 +22,7 @@ pub fn test_base(input: &str) -> Result<Vec<EvalResult>, Box<dyn std::error::Err
         match evaluate(&ast, &mut env) {
             Ok(result) => results.push(result),
             Err(e) => {
-                let error_message = e.to_string();
-                match &e {
-                    EvalError::UndefinedVariable(_, line_info)
-                    | EvalError::InvalidOperation(_, line_info)
-                    | EvalError::NegativeExponent(line_info)
-                    | EvalError::TypeError(_, line_info) => {
-                        display_error_with_source(input, line_info.clone(), &error_message);
-                    }
-                }
+                display_error_with_source(input, &e);
                 return Err(Box::new(e));
             }
         }


### PR DESCRIPTION
## Summary

Final B4 piece (small-scope variant). Runtime errors now render through `ariadne::Report` — same look as the parser's diagnostics — with a categorised header, the offending source line, and an underline at the reported column.

## Highlights

**Display layer (`display_error_with_source`)**
- Rewritten on top of `ariadne::Report` (already used by the parser via `abyss-core`)
- Signature simplified from `(script, line_info, message)` to `(script, &EvalError)` — the helper now extracts position info itself, eliminating the variant-pattern-match dance both callers (`abyss-cli` and the test harness) had been duplicating
- 1-based `(line, column)` (column is a byte offset within the line, matching the parser's `LineMap`) is converted into a single-byte ariadne range. Multi-byte highlighting requires threading real `Span`s through the AST and is intentionally out of scope here.

**`EvalError` API**
- `#[non_exhaustive]`: future-proofs the enum so new variants don't silently break external matchers. Within `abyss-interpreter` the compiler still enforces full coverage.
- New `line_info()` and `kind_label()` helpers: callers no longer need to enumerate every variant just to extract position metadata.

**Dependencies**
- `colored` dropped from `abyss-interpreter` (its only use was in this module). `abyss-cli` keeps `colored` for REPL value formatting.
- `ariadne = \"0.6\"` added to `abyss-interpreter` (already on the workspace dep graph via `abyss-core`).

## Output sample

Before:
\`\`\`
Error at line 2, column 19: Variable undefined_var is not defined!
  forge y: arcana = undefined_var + x;
                    ^
\`\`\`

After (matches parser style):
\`\`\`
Error: Undefined variable
   ╭─[ <script>:2:19 ]
   │
 2 │ forge y: arcana = undefined_var + x;
   │                   ┬
   │                   ╰── Variable undefined_var is not defined!
───╯
\`\`\`

## Backwards compatibility

- `EvalError`'s public variant set is unchanged (only the `#[non_exhaustive]` attribute is new). External matchers will start needing a `_` arm; given the crate is pre-1.0 this is acceptable churn.
- `display_error_with_source`'s signature changed; both callers in this workspace are updated. No published consumers exist yet (function is not used in `cargo doc` examples or referenced in `crates.io` README).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full workspace) — 108 lib tests + integration suites
- [x] New unit tests cover `line_info()`, the byte-offset converter (including multi-byte UTF-8), every variant's `kind_label()`, and the three display paths (valid line, out-of-range line, no line info)
- [x] Manual smoke test: `cargo run -- invoke <script>` on undefined-variable and type-error scripts produces the expected ariadne report

🤖 Generated with [Claude Code](https://claude.com/claude-code)