### PR TITLE
chore(release): bump workspace and extension to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ A diagnostics-polish release. Runtime errors now render through the same `ariadn
 
 ### Added
 
-- **"Did you mean?" hints for undefined identifiers** ([#397](https://github.com/liebe-magi/abyss-lang/pull/397)) — `forge x = 1; reveal y;` now reports `Variable y is not defined! (did you mean: x?)` when a close lexical match exists in scope. Suggestions are deterministic, capped at three, and ordered by Levenshtein distance.
+- **"Did you mean?" hints for undefined identifiers** ([#397](https://github.com/liebe-magi/abyss-lang/pull/397)) — `forge x = 1; reveal y;` now reports `Variable y (did you mean: x?) is not defined!` when a close lexical match exists in scope. Suggestions are deterministic, capped at three, and ordered by Levenshtein distance.
 - **"Did you mean?" + available-alternatives hints for methods and artifact fields** ([#401](https://github.com/liebe-magi/abyss-lang/pull/401)) — three new error sites enrich their messages: missing artifact field, missing artifact method, and missing builtin method on a value type. The artifact-field error additionally lists every defined field name so the schema is obvious without re-reading the declaration.
 - **Runtime errors render through `ariadne`** ([#404](https://github.com/liebe-magi/abyss-lang/pull/404)) — when an `EvalError` carries a source position, the offending column is underlined in the same labelled, coloured report style the parser uses, so the visual treatment is consistent across parser and runtime diagnostics. A plain `Error: …` line is still printed when no position is attached.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-03
+
+A diagnostics-polish release. Runtime errors now render through the same `ariadne` reporter the parser already uses, and three new "did you mean?" / "available alternatives" hint paths fire when AbySS programs reference identifiers, artifact fields, or methods that nearly match a known name. **Language semantics are unchanged from 0.4.0**; existing scripts continue to work without modification.
+
+### Added
+
+- **"Did you mean?" hints for undefined identifiers** ([#397](https://github.com/liebe-magi/abyss-lang/pull/397)) — `forge x = 1; reveal y;` now reports `Variable y is not defined! (did you mean: x?)` when a close lexical match exists in scope. Suggestions are deterministic, capped at three, and ordered by Levenshtein distance.
+- **"Did you mean?" + available-alternatives hints for methods and artifact fields** ([#401](https://github.com/liebe-magi/abyss-lang/pull/401)) — three new error sites enrich their messages: missing artifact field, missing artifact method, and missing builtin method on a value type. The artifact-field error additionally lists every defined field name so the schema is obvious without re-reading the declaration.
+- **Runtime errors render through `ariadne`** ([#404](https://github.com/liebe-magi/abyss-lang/pull/404)) — when an `EvalError` carries a source position, the offending column is underlined in the same labelled, coloured report style the parser uses, so the visual treatment is consistent across parser and runtime diagnostics. A plain `Error: …` line is still printed when no position is attached.
+
+### Changed
+
+- `EvalError` is now `#[non_exhaustive]` ([#404](https://github.com/liebe-magi/abyss-lang/pull/404)). The crate is pre-1.0, but the marker future-proofs it against the planned span-tracking refactor — downstream `match` on the error enum now needs a wildcard arm.
+
+### Removed
+
+- The redundant Claude Code Review GitHub workflow has been retired ([#408](https://github.com/liebe-magi/abyss-lang/pull/408)). It was failing on every Renovate PR ("Workflow initiated by non-human actor"), which had been blocking dependency-bump auto-merge. Copilot review covers the same feedback loop, so the duplicate stage was net cost.
+
+For the full diff including Renovate-driven dependency-lock-file updates, see the [GitHub compare v0.4.0...v0.4.1](https://github.com/liebe-magi/abyss-lang/compare/v0.4.0...v0.4.1).
+
 ## [0.4.0] - 2026-04-25
 
 A major housekeeping release: the Rust crate layout becomes a 3-crate workspace published in lockstep, the release pipeline is fully automated end-to-end (crates.io publish, GitHub Release with binary archives, VS Code Marketplace publish), and the spec-driven OpenSpec workflow is retired in favour of a leaner contributor guide. **Language semantics are unchanged from 0.3.1**; existing scripts continue to work without modification.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-interpreter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "abyss-core",
  "ariadne",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-lang"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/abyss-core", "crates/abyss-interpreter", "crates/abyss-cli"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/liebe-magi/abyss-lang"
 homepage = "https://abyss-lang.dev"
 
 [workspace.dependencies]
-abyss-core = { path = "crates/abyss-core", version = "0.4.0" }
-abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.4.0" }
+abyss-core = { path = "crates/abyss-core", version = "0.4.1" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.4.1" }
 
 [workspace.metadata.release]
 shared-version = true

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -12,7 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Bumped the extension version to 0.4.1 to stay in lockstep with the `abyss-lang` crate release. The 0.4.1 cycle was diagnostics polish ("did you mean?" hints, ariadne-rendered runtime errors) on the language side; **the grammar surface is unchanged from 0.4.0**, so existing snippets and completions continue to cover the current language surface.
 
-## [v0.4.0] - 2025-11-23
+## [v0.4.0] - 2026-04-25
 
 ### Changed
 

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [v0.4.1] - 2026-05-03
+
+### Changed
+
+- Bumped the extension version to 0.4.1 to stay in lockstep with the `abyss-lang` crate release. The 0.4.1 cycle was diagnostics polish ("did you mean?" hints, ariadne-rendered runtime errors) on the language side; **the grammar surface is unchanged from 0.4.0**, so existing snippets and completions continue to cover the current language surface.
+
 ## [v0.4.0] - 2025-11-23
 
 ### Changed

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -30,6 +30,10 @@ None at the moment. Please report any issues via GitHub.
 
 ## Release Notes
 
+### 0.4.1
+
+- Version bumped to track `abyss-lang` 0.4.1, a diagnostics-polish release ("did you mean?" hints for undefined identifiers, available-alternatives hints for missing artifact fields and methods, and ariadne-rendered runtime errors). No grammar changes since 0.4.0 — existing snippets and completions continue to cover the current language surface.
+
 ### 0.4.0
 
 - Version bumped to track `abyss-lang` 0.4.0 (multi-crate workspace split and release-automation milestone on the Rust side). No grammar changes since 0.3.0 — existing snippets and completions continue to cover the current language surface.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-codex-familiar",
   "displayName": "AbySS Codex Familiar",
   "description": "Custom syntax highlighting for the AbySS programming language.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "liebe-magi",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Lockstep version bump for the v0.4.1 milestone. Workspace, intra-workspace dependency pins, the VS Code extension `package.json`, and both CHANGELOGs / extension `README.md` move from `0.4.0` to `0.4.1` together — `scripts/check_version_sync.py` enforces this.

The 0.4.1 cycle is a **diagnostics-polish release**; language semantics are unchanged from 0.4.0. The CHANGELOG entry summarizes the four sub-PRs already on `develop`:

- #397 — "did you mean?" hints for undefined identifiers
- #401 — "did you mean?" + available-alternatives hints for missing artifact fields, artifact methods, and builtin methods
- #404 — runtime errors render through ariadne; `EvalError` marked `#[non_exhaustive]`
- #408 — redundant Claude Code Review workflow retired (was blocking Renovate auto-merge)

## What happens after this merges

This PR only lands the version bump on `develop`. A subsequent `Release v0.4.1` PR (`develop → main`, no additional code) will promote the bumped tree to `main` and trigger `.github/workflows/release.yml`, which:

1. Detects `0.4.0 → 0.4.1` in the root `Cargo.toml`.
2. Re-runs the test suite, creates the `v0.4.1` tag, drafts a GitHub release with auto-generated notes, attaches per-target binary archives.
3. Publishes `abyss-core` → `abyss-interpreter` → `abyss-lang` to crates.io with index-propagation sleeps.
4. Publishes the VS Code extension to the Marketplace.

## Verification on this branch

- [x] `cargo check --workspace` clean; `Cargo.lock` updated.
- [x] `cargo test --workspace` — all suites green (parser + interpreter + integration).
- [x] `python3 scripts/check_version_sync.py` — `0.4.1 / 0.4.1` match, workspace dependency versions aligned.
- [x] Pre-commit hooks: `bun run compile` and `check version sync` both passed.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, open the `Release v0.4.1` promotion PR.