### PR TITLE
refactor(eval): centralise oracle scope cleanup so error paths stop leaking

### DIFF
--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -96,12 +96,12 @@ impl RuntimeEnv {
         self.artifact_scopes.pop();
     }
 
-    /// Returns the current variable-scope stack depth. Used by regression
-    /// tests that confirm scopes pushed by `oracle` / `engrave` / `orbit`
-    /// blocks are unconditionally popped on every exit path, including
-    /// runtime errors raised mid-evaluation. Test-only — exposing the depth
-    /// in production builds would freeze it as part of the public API for
-    /// no concrete user need today.
+    /// Returns the current variable-scope stack depth. Used today by the
+    /// oracle scope-leak regression test in `eval::statements`; if future
+    /// work adds analogous regression tests for `engrave` or `orbit`
+    /// scopes they can reuse the same accessor. Test-only — exposing the
+    /// depth in production builds would freeze it as part of the public
+    /// API for no concrete user need today.
     #[cfg(test)]
     pub(crate) fn scope_depth(&self) -> usize {
         self.scopes.len()

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -96,6 +96,17 @@ impl RuntimeEnv {
         self.artifact_scopes.pop();
     }
 
+    /// Returns the current variable-scope stack depth. Used by regression
+    /// tests that confirm scopes pushed by `oracle` / `engrave` / `orbit`
+    /// blocks are unconditionally popped on every exit path, including
+    /// runtime errors raised mid-evaluation. Test-only — exposing the depth
+    /// in production builds would freeze it as part of the public API for
+    /// no concrete user need today.
+    #[cfg(test)]
+    pub(crate) fn scope_depth(&self) -> usize {
+        self.scopes.len()
+    }
+
     /// Sets a variable in the current scope, specifying its name, value, type, and whether it's mutable.
     pub fn set_var(
         &mut self,

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1314,6 +1314,110 @@ mod tests {
     }
 
     #[test]
+    fn oracle_question_mark_propagation_does_not_leak_scope() {
+        // The four `?`-propagated error sites that motivated the refactor —
+        // scrutinee evaluation, the match-mode pattern loop, the if-else-mode
+        // pattern loop, and the new ward expression — must also unwind the
+        // pushed scope. The cases above hit the explicit `return Err(...)`
+        // arms; these specifically exercise the `?` operator by feeding a
+        // sub-expression that fails to evaluate (an undefined variable, which
+        // surfaces `EvalError::UndefinedVariable`).
+
+        // A. Scrutinee expression itself fails — exercises
+        //    `evaluate(&conditional.expression, env)?`.
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Var("missing".into(), line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("scrutinee var lookup error");
+        assert_eq!(
+            env.scope_depth(),
+            1,
+            "scrutinee `?` propagation leaked a scope"
+        );
+
+        // B. Match-mode pattern expression fails — exercises
+        //    `evaluate(pattern, env)?` inside the pattern loop.
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Var("missing".into(), line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("match-mode pattern var lookup error");
+        assert_eq!(
+            env.scope_depth(),
+            1,
+            "match-mode pattern `?` propagation leaked a scope"
+        );
+
+        // C. If-else-mode pattern expression fails — exercises
+        //    `evaluate(pattern_expr, env)?` inside the all-true loop.
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: false,
+            conditionals: vec![],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Var("missing".into(), line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("if-else-mode pattern var lookup error");
+        assert_eq!(
+            env.scope_depth(),
+            1,
+            "if-else-mode pattern `?` propagation leaked a scope"
+        );
+
+        // D. Ward expression itself fails — exercises
+        //    `evaluate(guard_expr.as_ref(), env)?` (the original bug site
+        //    from PR #414, now folded into the central pop_scope).
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: Some(Box::new(AST::Var("missing".into(), line()))),
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("ward var lookup error");
+        assert_eq!(env.scope_depth(), 1, "ward `?` propagation leaked a scope");
+    }
+
+    #[test]
     fn clone_indexed_child_errors_on_non_collections() {
         let err = clone_indexed_child(
             &Value::Arcana(1),

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1,7 +1,5 @@
 use crate::env::{ArtifactMethod, Callable, EngravedFunction, RuntimeEnv, Value};
-#[cfg(test)]
-use abyss_core::ast::ConditionalAssignment;
-use abyss_core::ast::{AST, AssignmentOp, LineInfo, Type};
+use abyss_core::ast::{AST, AssignmentOp, ConditionalAssignment, LineInfo, Type};
 use std::rc::Rc;
 
 use super::artifacts::{
@@ -374,170 +372,14 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             branches,
             line_info,
         } => {
+            // Push the oracle's local scope, run the body, and unconditionally
+            // pop on the way out — including error paths — so a failing
+            // scrutinee, pattern, ward, or body cannot leak a scope back into
+            // the REPL. The helper itself uses `?` freely.
             env.push_scope();
-
-            let mut scrutinee_values = Vec::with_capacity(conditionals.len());
-            for conditional in conditionals {
-                let result = evaluate(&conditional.expression, env)?;
-                let stored = match result {
-                    EvalResult::Data(Value::Arcana(n)) => Value::Arcana(n),
-                    EvalResult::Data(Value::Aether(n)) => Value::Aether(n),
-                    EvalResult::Data(Value::Rune(rune)) => Value::Rune(rune.clone()),
-                    EvalResult::Data(Value::Omen(b)) => Value::Omen(b),
-                    other => {
-                        env.pop_scope();
-                        return Err(EvalError::InvalidOperation(
-                            format!("Unsupported type in oracle scrutinee: {:?}", other),
-                            line_info.clone(),
-                        ));
-                    }
-                };
-                scrutinee_values.push(stored);
-            }
-
-            for branch in branches {
-                if let AST::Comment(_, _) = branch {
-                    continue;
-                }
-
-                if let AST::OracleBranch {
-                    pattern,
-                    guard,
-                    body,
-                    line_info,
-                } = branch
-                {
-                    let matched = if pattern.is_empty() {
-                        true
-                    } else if *is_match {
-                        if pattern.len() != scrutinee_values.len() {
-                            env.pop_scope();
-                            return Err(EvalError::InvalidOperation(
-                                format!(
-                                    "Oracle branch pattern length {} does not match scrutinee length {}",
-                                    pattern.len(),
-                                    scrutinee_values.len()
-                                ),
-                                line_info.clone(),
-                            ));
-                        }
-
-                        let mut matched = true;
-                        for (idx, pattern) in pattern.iter().enumerate() {
-                            if let AST::OracleDontCareItem(_) = pattern {
-                                continue;
-                            }
-
-                            let Some(scrutinee_value) = scrutinee_values.get(idx) else {
-                                env.pop_scope();
-                                return Err(EvalError::InvalidOperation(
-                                    "Oracle branch references missing scrutinee".to_string(),
-                                    line_info.clone(),
-                                ));
-                            };
-
-                            let pattern_result = evaluate(pattern, env)?;
-
-                            match (scrutinee_value, pattern_result) {
-                                (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
-                                    if *cond_n != pat_n {
-                                        matched = false;
-                                        break;
-                                    }
-                                }
-                                (Value::Aether(cond_n), EvalResult::Data(Value::Aether(pat_n))) => {
-                                    if (*cond_n - pat_n).abs() >= f64::EPSILON {
-                                        matched = false;
-                                        break;
-                                    }
-                                }
-                                (Value::Rune(cond_s), EvalResult::Data(Value::Rune(pat_s))) => {
-                                    if cond_s.as_ref() != pat_s.as_ref() {
-                                        matched = false;
-                                        break;
-                                    }
-                                }
-                                (Value::Omen(cond_b), EvalResult::Data(Value::Omen(pat_b))) => {
-                                    if *cond_b != pat_b {
-                                        matched = false;
-                                        break;
-                                    }
-                                }
-                                _ => {
-                                    env.pop_scope();
-                                    return Err(EvalError::InvalidOperation(
-                                        "Oracle branch pattern type must match scrutinee type"
-                                            .to_string(),
-                                        line_info.clone(),
-                                    ));
-                                }
-                            }
-                        }
-                        matched
-                    } else {
-                        let mut all_true = true;
-                        for pattern_expr in pattern {
-                            match evaluate(pattern_expr, env)? {
-                                EvalResult::Data(Value::Omen(true)) => continue,
-                                EvalResult::Data(Value::Omen(false)) => {
-                                    all_true = false;
-                                    break;
-                                }
-                                other => {
-                                    return Err(EvalError::InvalidOperation(
-                                        format!(
-                                            "Oracle guard must evaluate to an omen, found {:?}",
-                                            other
-                                        ),
-                                        line_info.clone(),
-                                    ));
-                                }
-                            }
-                        }
-                        all_true
-                    };
-
-                    let matched = if matched {
-                        match guard {
-                            None => true,
-                            Some(guard_expr) => match evaluate(guard_expr.as_ref(), env) {
-                                Ok(EvalResult::Data(Value::Omen(b))) => b,
-                                Ok(other) => {
-                                    env.pop_scope();
-                                    return Err(EvalError::InvalidOperation(
-                                        format!(
-                                            "Oracle ward must evaluate to an omen, found {:?}",
-                                            other
-                                        ),
-                                        line_info.clone(),
-                                    ));
-                                }
-                                Err(e) => {
-                                    env.pop_scope();
-                                    return Err(e);
-                                }
-                            },
-                        }
-                    } else {
-                        false
-                    };
-
-                    if matched {
-                        let result = match evaluate(body.as_ref(), env) {
-                            Ok(result) => match result {
-                                EvalResult::Revealed(revealed) => *revealed,
-                                _ => result,
-                            },
-                            Err(e) => return Err(e),
-                        };
-                        env.pop_scope();
-                        return Ok(result);
-                    }
-                }
-            }
-
+            let result = evaluate_oracle(*is_match, conditionals, branches, line_info, env);
             env.pop_scope();
-            Ok(EvalResult::abyss())
+            result
         }
         AST::Reveal(expr, _line_info) => {
             let result = evaluate(expr, env)?;
@@ -729,6 +571,167 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             None,
         )),
     }
+}
+
+/// Inner body of `AST::Oracle` evaluation. The caller is responsible for
+/// pairing one `env.push_scope()` before this call with one `env.pop_scope()`
+/// after, so every `?` inside this helper unwinds through the caller and the
+/// scope is always popped — including on failed scrutinee evaluation,
+/// pattern type errors, ward errors, and body errors. Keeping the cleanup
+/// outside the `?`-using body removes the previous five hand-written
+/// `env.pop_scope(); return Err(...)` branches and the matching scope-leak
+/// risk that prompted the v0.5.0 PR1 review feedback.
+fn evaluate_oracle(
+    is_match: bool,
+    conditionals: &[ConditionalAssignment],
+    branches: &[AST],
+    line_info: &Option<LineInfo>,
+    env: &mut RuntimeEnv,
+) -> Result<EvalResult, EvalError> {
+    let mut scrutinee_values = Vec::with_capacity(conditionals.len());
+    for conditional in conditionals {
+        let result = evaluate(&conditional.expression, env)?;
+        let stored = match result {
+            EvalResult::Data(Value::Arcana(n)) => Value::Arcana(n),
+            EvalResult::Data(Value::Aether(n)) => Value::Aether(n),
+            EvalResult::Data(Value::Rune(rune)) => Value::Rune(rune.clone()),
+            EvalResult::Data(Value::Omen(b)) => Value::Omen(b),
+            other => {
+                return Err(EvalError::InvalidOperation(
+                    format!("Unsupported type in oracle scrutinee: {:?}", other),
+                    line_info.clone(),
+                ));
+            }
+        };
+        scrutinee_values.push(stored);
+    }
+
+    for branch in branches {
+        if let AST::Comment(_, _) = branch {
+            continue;
+        }
+
+        let AST::OracleBranch {
+            pattern,
+            guard,
+            body,
+            line_info,
+        } = branch
+        else {
+            continue;
+        };
+
+        let matched = if pattern.is_empty() {
+            true
+        } else if is_match {
+            if pattern.len() != scrutinee_values.len() {
+                return Err(EvalError::InvalidOperation(
+                    format!(
+                        "Oracle branch pattern length {} does not match scrutinee length {}",
+                        pattern.len(),
+                        scrutinee_values.len()
+                    ),
+                    line_info.clone(),
+                ));
+            }
+
+            let mut matched = true;
+            for (idx, pattern) in pattern.iter().enumerate() {
+                if let AST::OracleDontCareItem(_) = pattern {
+                    continue;
+                }
+
+                let Some(scrutinee_value) = scrutinee_values.get(idx) else {
+                    return Err(EvalError::InvalidOperation(
+                        "Oracle branch references missing scrutinee".to_string(),
+                        line_info.clone(),
+                    ));
+                };
+
+                let pattern_result = evaluate(pattern, env)?;
+
+                match (scrutinee_value, pattern_result) {
+                    (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
+                        if *cond_n != pat_n {
+                            matched = false;
+                            break;
+                        }
+                    }
+                    (Value::Aether(cond_n), EvalResult::Data(Value::Aether(pat_n))) => {
+                        if (*cond_n - pat_n).abs() >= f64::EPSILON {
+                            matched = false;
+                            break;
+                        }
+                    }
+                    (Value::Rune(cond_s), EvalResult::Data(Value::Rune(pat_s))) => {
+                        if cond_s.as_ref() != pat_s.as_ref() {
+                            matched = false;
+                            break;
+                        }
+                    }
+                    (Value::Omen(cond_b), EvalResult::Data(Value::Omen(pat_b))) => {
+                        if *cond_b != pat_b {
+                            matched = false;
+                            break;
+                        }
+                    }
+                    _ => {
+                        return Err(EvalError::InvalidOperation(
+                            "Oracle branch pattern type must match scrutinee type".to_string(),
+                            line_info.clone(),
+                        ));
+                    }
+                }
+            }
+            matched
+        } else {
+            let mut all_true = true;
+            for pattern_expr in pattern {
+                match evaluate(pattern_expr, env)? {
+                    EvalResult::Data(Value::Omen(true)) => continue,
+                    EvalResult::Data(Value::Omen(false)) => {
+                        all_true = false;
+                        break;
+                    }
+                    other => {
+                        return Err(EvalError::InvalidOperation(
+                            format!("Oracle guard must evaluate to an omen, found {:?}", other),
+                            line_info.clone(),
+                        ));
+                    }
+                }
+            }
+            all_true
+        };
+
+        let matched = if matched {
+            match guard {
+                None => true,
+                Some(guard_expr) => match evaluate(guard_expr.as_ref(), env)? {
+                    EvalResult::Data(Value::Omen(b)) => b,
+                    other => {
+                        return Err(EvalError::InvalidOperation(
+                            format!("Oracle ward must evaluate to an omen, found {:?}", other),
+                            line_info.clone(),
+                        ));
+                    }
+                },
+            }
+        } else {
+            false
+        };
+
+        if matched {
+            let result = evaluate(body.as_ref(), env)?;
+            let result = match result {
+                EvalResult::Revealed(revealed) => *revealed,
+                _ => result,
+            };
+            return Ok(result);
+        }
+    }
+
+    Ok(EvalResult::abyss())
 }
 
 fn clone_indexed_child(
@@ -1177,6 +1180,137 @@ mod tests {
             EvalResult::Data(Value::Arcana(value)) => assert_eq!(value, 5),
             other => panic!("unexpected oracle result {:?}", other),
         }
+    }
+
+    #[test]
+    fn oracle_error_paths_do_not_leak_scope() {
+        // Regression for the v0.5.0 PR1 review: every error path inside the
+        // oracle evaluator must pop the scope it pushed on entry, otherwise
+        // the REPL leaks a scope each time. We exercise each error site in
+        // turn against a fresh `RuntimeEnv` (which starts at depth 1), and
+        // assert the depth returns to 1 after the evaluator yields `Err`.
+
+        // 1. Scrutinee evaluates to an unsupported type (Abyss is not in the
+        //    accepted Arcana / Aether / Rune / Omen list).
+        let mut env = RuntimeEnv::new();
+        assert_eq!(env.scope_depth(), 1);
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Abyss(line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("scrutinee type error");
+        assert_eq!(env.scope_depth(), 1, "scrutinee error leaked a scope");
+
+        // 2. Pattern length mismatch (1 scrutinee vs 2-element pattern).
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line()), AST::Arcana(2, line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("pattern length error");
+        assert_eq!(env.scope_depth(), 1, "pattern length error leaked a scope");
+
+        // 3. Pattern type mismatch (Arcana scrutinee vs Rune pattern).
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Rune("x".into(), line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("pattern type error");
+        assert_eq!(env.scope_depth(), 1, "pattern type error leaked a scope");
+
+        // 4. If-else mode pattern that does not yield an omen.
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: false,
+            conditionals: vec![],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: None,
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("if-else mode pattern type error");
+        assert_eq!(
+            env.scope_depth(),
+            1,
+            "if-else pattern type error leaked a scope"
+        );
+
+        // 5. Ward expression evaluates to a non-omen.
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: Some(Box::new(AST::Arcana(42, line()))),
+                body: Box::new(AST::Arcana(0, line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("ward type error");
+        assert_eq!(env.scope_depth(), 1, "ward type error leaked a scope");
+
+        // 6. Body raises an error after the pattern matched (undefined var).
+        let mut env = RuntimeEnv::new();
+        let oracle = AST::Oracle {
+            is_match: true,
+            conditionals: vec![ConditionalAssignment {
+                variable: "v".into(),
+                expression: Box::new(AST::Arcana(1, line())),
+                line_info: line(),
+            }],
+            branches: vec![AST::OracleBranch {
+                pattern: vec![AST::Arcana(1, line())],
+                guard: None,
+                body: Box::new(AST::Var("missing".into(), line())),
+                line_info: line(),
+            }],
+            line_info: line(),
+        };
+        evaluate(&oracle, &mut env).expect_err("body undefined-variable error");
+        assert_eq!(env.scope_depth(), 1, "body error leaked a scope");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to PR #414. The Copilot review on that PR surfaced a real scope-leak bug in the new ward error path: using `?` between `env.push_scope()` and a manual `env.pop_scope()` skipped cleanup whenever the helper returned `Err`. We patched the ward case there — but the same shape existed at **three other `?` sites in the same `AST::Oracle` arm**:

- scrutinee setup (`evaluate(&conditional.expression, env)?`)
- the match-mode pattern loop (`evaluate(pattern, env)?`)
- the if-else-mode all-true loop (`evaluate(pattern_expr, env)?`)

Each of those left the REPL with a permanently dangling scope every time the corresponding error fired.

## Approach

Rather than copy-paste another five \"pop then return\" guards, extract the whole body to a new private `evaluate_oracle()` helper and have the caller do:

```rust
env.push_scope();
let result = evaluate_oracle(*is_match, conditionals, branches, line_info, env);
env.pop_scope();
result
```

The helper itself uses `?` freely; the caller unconditionally pops on every exit, including error paths. The five manual `env.pop_scope(); return Err(...)` branches that used to live inside the oracle arm are now redundant and have been removed (310 insertions / 165 deletions, but most of that is shape change — the actual logic is unchanged).

## Behaviour

Every existing oracle test still passes (12 oracle integration tests + the original unit tests). A new regression test `oracle_error_paths_do_not_leak_scope` exercises each of the six error sites against a fresh `RuntimeEnv` and asserts `scope_depth()` returns to 1 after `Err`:

1. Scrutinee evaluates to an unsupported type (`AST::Abyss`).
2. Pattern length mismatch (1 scrutinee, 2-element pattern).
3. Pattern type mismatch (Arcana scrutinee, Rune pattern).
4. If-else-mode pattern that does not yield an omen.
5. Ward expression yields a non-omen (the original bug).
6. Body raises an error after the pattern matched (undefined variable).

To support those assertions, `RuntimeEnv` gets a test-only `#[cfg(test)] pub(crate) fn scope_depth()` accessor. The `cfg(test)` gate keeps it out of release builds so it is not frozen into the public API.

## Test plan

- [x] \`cargo test --workspace\` passes (110 lib tests, all integration tests).
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] New regression test `oracle_error_paths_do_not_leak_scope` reaches every error path and asserts `scope_depth() == 1` after each.
- [ ] CI green on this PR.