### PR TITLE
feat(eval): bind scrutinee to bare-identifier patterns in oracle match arms

### DIFF
--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -576,11 +576,12 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
 /// Inner body of `AST::Oracle` evaluation. The caller is responsible for
 /// pairing one `env.push_scope()` before this call with one `env.pop_scope()`
 /// after, so every `?` inside this helper unwinds through the caller and the
-/// scope is always popped — including on failed scrutinee evaluation,
-/// pattern type errors, ward errors, and body errors. Keeping the cleanup
-/// outside the `?`-using body removes the previous five hand-written
-/// `env.pop_scope(); return Err(...)` branches and the matching scope-leak
-/// risk that prompted the v0.5.0 PR1 review feedback.
+/// outer oracle scope is always popped.
+///
+/// Each branch additionally gets its own nested scope (push/pop) so that
+/// match-mode bindings (`(x) =>`) and any `forge` declarations in the body
+/// stay confined to the arm that produced them — without leaking sideways
+/// to subsequent arms or upward to the script.
 fn evaluate_oracle(
     is_match: bool,
     conditionals: &[ConditionalAssignment],
@@ -621,117 +622,188 @@ fn evaluate_oracle(
             continue;
         };
 
-        let matched = if pattern.is_empty() {
-            true
-        } else if is_match {
-            if pattern.len() != scrutinee_values.len() {
-                return Err(EvalError::InvalidOperation(
-                    format!(
-                        "Oracle branch pattern length {} does not match scrutinee length {}",
-                        pattern.len(),
-                        scrutinee_values.len()
-                    ),
-                    line_info.clone(),
-                ));
-            }
+        env.push_scope();
+        let outcome = evaluate_oracle_branch(
+            is_match,
+            pattern,
+            guard.as_deref(),
+            body,
+            line_info,
+            &scrutinee_values,
+            env,
+        );
+        env.pop_scope();
 
-            let mut matched = true;
-            for (idx, pattern) in pattern.iter().enumerate() {
-                if let AST::OracleDontCareItem(_) = pattern {
-                    continue;
-                }
-
-                let Some(scrutinee_value) = scrutinee_values.get(idx) else {
-                    return Err(EvalError::InvalidOperation(
-                        "Oracle branch references missing scrutinee".to_string(),
-                        line_info.clone(),
-                    ));
-                };
-
-                let pattern_result = evaluate(pattern, env)?;
-
-                match (scrutinee_value, pattern_result) {
-                    (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
-                        if *cond_n != pat_n {
-                            matched = false;
-                            break;
-                        }
-                    }
-                    (Value::Aether(cond_n), EvalResult::Data(Value::Aether(pat_n))) => {
-                        if (*cond_n - pat_n).abs() >= f64::EPSILON {
-                            matched = false;
-                            break;
-                        }
-                    }
-                    (Value::Rune(cond_s), EvalResult::Data(Value::Rune(pat_s))) => {
-                        if cond_s.as_ref() != pat_s.as_ref() {
-                            matched = false;
-                            break;
-                        }
-                    }
-                    (Value::Omen(cond_b), EvalResult::Data(Value::Omen(pat_b))) => {
-                        if *cond_b != pat_b {
-                            matched = false;
-                            break;
-                        }
-                    }
-                    _ => {
-                        return Err(EvalError::InvalidOperation(
-                            "Oracle branch pattern type must match scrutinee type".to_string(),
-                            line_info.clone(),
-                        ));
-                    }
-                }
-            }
-            matched
-        } else {
-            let mut all_true = true;
-            for pattern_expr in pattern {
-                match evaluate(pattern_expr, env)? {
-                    EvalResult::Data(Value::Omen(true)) => continue,
-                    EvalResult::Data(Value::Omen(false)) => {
-                        all_true = false;
-                        break;
-                    }
-                    other => {
-                        return Err(EvalError::InvalidOperation(
-                            format!("Oracle guard must evaluate to an omen, found {:?}", other),
-                            line_info.clone(),
-                        ));
-                    }
-                }
-            }
-            all_true
-        };
-
-        let matched = if matched {
-            match guard {
-                None => true,
-                Some(guard_expr) => match evaluate(guard_expr.as_ref(), env)? {
-                    EvalResult::Data(Value::Omen(b)) => b,
-                    other => {
-                        return Err(EvalError::InvalidOperation(
-                            format!("Oracle ward must evaluate to an omen, found {:?}", other),
-                            line_info.clone(),
-                        ));
-                    }
-                },
-            }
-        } else {
-            false
-        };
-
-        if matched {
-            let result = evaluate(body.as_ref(), env)?;
-            let result = match result {
-                EvalResult::Revealed(revealed) => *revealed,
-                _ => result,
-            };
-            return Ok(result);
+        match outcome? {
+            None => continue,
+            Some(result) => return Ok(result),
         }
     }
 
     Ok(EvalResult::abyss())
+}
+
+/// Evaluate a single `OracleBranch`. Returns:
+/// - `Ok(Some(result))` when the pattern matches, the optional ward holds,
+///   and the body has been evaluated to `result`;
+/// - `Ok(None)` when the arm does not apply (pattern mismatch or ward
+///   yielded `hex`) and the caller should try the next arm;
+/// - `Err(e)` on any evaluation error.
+///
+/// The caller is responsible for pushing and popping the per-branch scope
+/// around this call. Match-mode bindings introduced by bare-identifier
+/// patterns are written into the current (caller-pushed) scope so they are
+/// visible to the ward expression and the body, then unwound when the
+/// caller pops.
+fn evaluate_oracle_branch(
+    is_match: bool,
+    pattern: &[AST],
+    guard: Option<&AST>,
+    body: &AST,
+    line_info: &Option<LineInfo>,
+    scrutinee_values: &[Value],
+    env: &mut RuntimeEnv,
+) -> Result<Option<EvalResult>, EvalError> {
+    let matched = if pattern.is_empty() {
+        true
+    } else if is_match {
+        if pattern.len() != scrutinee_values.len() {
+            return Err(EvalError::InvalidOperation(
+                format!(
+                    "Oracle branch pattern length {} does not match scrutinee length {}",
+                    pattern.len(),
+                    scrutinee_values.len()
+                ),
+                line_info.clone(),
+            ));
+        }
+
+        let mut matched = true;
+        for (idx, pattern) in pattern.iter().enumerate() {
+            if let AST::OracleDontCareItem(_) = pattern {
+                continue;
+            }
+
+            let Some(scrutinee_value) = scrutinee_values.get(idx) else {
+                return Err(EvalError::InvalidOperation(
+                    "Oracle branch references missing scrutinee".to_string(),
+                    line_info.clone(),
+                ));
+            };
+
+            // A bare identifier in match-mode pattern position introduces a
+            // fresh binding to the scrutinee value (rather than looking the
+            // identifier up as an expression). The binding lives in the
+            // per-branch scope the caller pushed, so it is visible to the
+            // ward and body of this arm and disappears when the arm finishes.
+            if let AST::Var(name, var_line) = pattern {
+                env.set_var(
+                    name.clone(),
+                    scrutinee_value.clone(),
+                    type_of_scrutinee(scrutinee_value),
+                    false,
+                    var_line.clone(),
+                );
+                continue;
+            }
+
+            let pattern_result = evaluate(pattern, env)?;
+
+            match (scrutinee_value, pattern_result) {
+                (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
+                    if *cond_n != pat_n {
+                        matched = false;
+                        break;
+                    }
+                }
+                (Value::Aether(cond_n), EvalResult::Data(Value::Aether(pat_n))) => {
+                    if (*cond_n - pat_n).abs() >= f64::EPSILON {
+                        matched = false;
+                        break;
+                    }
+                }
+                (Value::Rune(cond_s), EvalResult::Data(Value::Rune(pat_s))) => {
+                    if cond_s.as_ref() != pat_s.as_ref() {
+                        matched = false;
+                        break;
+                    }
+                }
+                (Value::Omen(cond_b), EvalResult::Data(Value::Omen(pat_b))) => {
+                    if *cond_b != pat_b {
+                        matched = false;
+                        break;
+                    }
+                }
+                _ => {
+                    return Err(EvalError::InvalidOperation(
+                        "Oracle branch pattern type must match scrutinee type".to_string(),
+                        line_info.clone(),
+                    ));
+                }
+            }
+        }
+        matched
+    } else {
+        let mut all_true = true;
+        for pattern_expr in pattern {
+            match evaluate(pattern_expr, env)? {
+                EvalResult::Data(Value::Omen(true)) => continue,
+                EvalResult::Data(Value::Omen(false)) => {
+                    all_true = false;
+                    break;
+                }
+                other => {
+                    return Err(EvalError::InvalidOperation(
+                        format!("Oracle guard must evaluate to an omen, found {:?}", other),
+                        line_info.clone(),
+                    ));
+                }
+            }
+        }
+        all_true
+    };
+
+    let matched = if matched {
+        match guard {
+            None => true,
+            Some(guard_expr) => match evaluate(guard_expr, env)? {
+                EvalResult::Data(Value::Omen(b)) => b,
+                other => {
+                    return Err(EvalError::InvalidOperation(
+                        format!("Oracle ward must evaluate to an omen, found {:?}", other),
+                        line_info.clone(),
+                    ));
+                }
+            },
+        }
+    } else {
+        false
+    };
+
+    if matched {
+        let result = evaluate(body, env)?;
+        let result = match result {
+            EvalResult::Revealed(revealed) => *revealed,
+            _ => result,
+        };
+        Ok(Some(result))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Maps an oracle scrutinee `Value` (always one of the four scalar variants
+/// guaranteed by `evaluate_oracle`'s scrutinee setup) to the `Type` used when
+/// declaring its match-mode binding. The `Materia` fallback is unreachable in
+/// practice but keeps the helper total without panicking.
+fn type_of_scrutinee(value: &Value) -> Type {
+    match value {
+        Value::Arcana(_) => Type::Arcana,
+        Value::Aether(_) => Type::Aether,
+        Value::Rune(_) => Type::Rune,
+        Value::Omen(_) => Type::Omen,
+        _ => Type::Materia,
+    }
 }
 
 fn clone_indexed_child(
@@ -1349,7 +1421,14 @@ mod tests {
         );
 
         // B. Match-mode pattern expression fails — exercises
-        //    `evaluate(pattern, env)?` inside the pattern loop.
+        //    `evaluate(pattern, env)?` inside the pattern loop. We use
+        //    `AST::Add(Var("missing"), Arcana(1))` here rather than a bare
+        //    `AST::Var("missing", _)` because, after PR2's binding-pattern
+        //    work, a bare identifier in match-mode pattern position is
+        //    intercepted as a fresh binding and never reaches `evaluate`.
+        //    Wrapping the missing identifier inside an `Add` keeps the
+        //    pattern an expression so the inner `evaluate` actually runs and
+        //    can raise `UndefinedVariable`.
         let mut env = RuntimeEnv::new();
         let oracle = AST::Oracle {
             is_match: true,
@@ -1359,7 +1438,11 @@ mod tests {
                 line_info: line(),
             }],
             branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Var("missing".into(), line())],
+                pattern: vec![AST::Add(
+                    Box::new(AST::Var("missing".into(), line())),
+                    Box::new(AST::Arcana(1, line())),
+                    line(),
+                )],
                 guard: None,
                 body: Box::new(AST::Arcana(0, line())),
                 line_info: line(),

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -679,8 +679,8 @@ fn evaluate_oracle_branch(
         }
 
         let mut matched = true;
-        for (idx, pattern) in pattern.iter().enumerate() {
-            if let AST::OracleDontCareItem(_) = pattern {
+        for (idx, pattern_elem) in pattern.iter().enumerate() {
+            if let AST::OracleDontCareItem(_) = pattern_elem {
                 continue;
             }
 
@@ -696,7 +696,7 @@ fn evaluate_oracle_branch(
             // identifier up as an expression). The binding lives in the
             // per-branch scope the caller pushed, so it is visible to the
             // ward and body of this arm and disappears when the arm finishes.
-            if let AST::Var(name, var_line) = pattern {
+            if let AST::Var(name, var_line) = pattern_elem {
                 env.set_var(
                     name.clone(),
                     scrutinee_value.clone(),
@@ -707,7 +707,7 @@ fn evaluate_oracle_branch(
                 continue;
             }
 
-            let pattern_result = evaluate(pattern, env)?;
+            let pattern_result = evaluate(pattern_elem, env)?;
 
             match (scrutinee_value, pattern_result) {
                 (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
@@ -754,7 +754,10 @@ fn evaluate_oracle_branch(
                 }
                 other => {
                     return Err(EvalError::InvalidOperation(
-                        format!("Oracle guard must evaluate to an omen, found {:?}", other),
+                        format!(
+                            "Oracle if-else pattern must evaluate to an omen, found {:?}",
+                            other
+                        ),
                         line_info.clone(),
                     ));
                 }
@@ -1163,9 +1166,9 @@ mod tests {
     }
 
     #[test]
-    fn oracle_guard_requires_omen_values() {
+    fn oracle_if_else_pattern_requires_omen_values() {
         let mut env = RuntimeEnv::new();
-        let guard_branch = AST::OracleBranch {
+        let pattern_branch = AST::OracleBranch {
             pattern: vec![AST::Arcana(1, line())],
             guard: None,
             body: Box::new(AST::Arcana(0, line())),
@@ -1175,15 +1178,15 @@ mod tests {
         let oracle = AST::Oracle {
             is_match: false,
             conditionals: vec![],
-            branches: vec![guard_branch],
+            branches: vec![pattern_branch],
             line_info: line(),
         };
 
-        let err = evaluate(&oracle, &mut env).expect_err("guards must yield omens");
+        let err = evaluate(&oracle, &mut env).expect_err("if-else mode patterns must yield omens");
         match err {
             EvalError::InvalidOperation(message, _) => {
                 assert!(
-                    message.contains("Oracle guard must evaluate to an omen"),
+                    message.contains("Oracle if-else pattern must evaluate to an omen"),
                     "{}",
                     message
                 );

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -233,6 +233,130 @@ fn test_oracle_if_else_ward_acts_as_extra_condition() {
 }
 
 #[test]
+fn test_oracle_match_binds_bare_identifier_pattern() {
+    // A bare identifier pattern in match mode binds the scrutinee to that
+    // name in the arm's scope. The body can then read the bound value.
+    let input = r#"
+    forge n: arcana = 7;
+    forge result: arcana = oracle (n) {
+        (x) => reveal(x * 2);
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[2], EvalResult::Data(Value::Arcana(14)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_match_binding_visible_in_ward() {
+    // The bound name is visible to the ward expression of the same arm.
+    // First arm: ward succeeds, so it fires. Second arm is the fallback.
+    let input = r#"
+    forge n: arcana = 7;
+    forge result: rune = oracle (n) {
+        (x) ward x > 0 => reveal("positive");
+        (x) => reveal("non-positive");
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "positive")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_match_multiple_bindings_across_scrutinees() {
+    // Multi-scrutinee patterns bind every bare-identifier element to the
+    // matching scrutinee value.
+    let input = r#"
+    forge a: arcana = 3;
+    forge b: arcana = 4;
+    forge sum: arcana = oracle (a, b) {
+        (x, y) => reveal(x + y);
+    };
+    sum;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[3], EvalResult::Data(Value::Arcana(7)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_match_binding_mixed_with_literals_and_wildcards() {
+    // Literals still match by value, wildcards still skip, and identifiers
+    // still bind — composing freely inside the same pattern tuple.
+    let input = r#"
+    forge a: arcana = 1;
+    forge b: arcana = 99;
+    forge result: rune = oracle (a, b) {
+        (1, x) => reveal("first is one");
+        (_, x) => reveal("first is not one");
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[3], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "first is one")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_match_binding_does_not_leak_to_outer_scope() {
+    // The binding is confined to the per-branch scope, so the outer script
+    // cannot see it after the oracle finishes.
+    let input = r#"
+    forge n: arcana = 5;
+    oracle (n) {
+        (x) => reveal(x);
+    };
+    x;
+    "#;
+    match test_base(input) {
+        Ok(results) => panic!(
+            "expected the post-oracle reference to `x` to fail, got {:?}",
+            results
+        ),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("UndefinedVariable") && msg.contains('x'),
+                "unexpected error: {}",
+                msg
+            )
+        }
+    }
+}
+
+#[test]
+fn test_oracle_match_binding_does_not_leak_between_arms() {
+    // First arm binds x = the scrutinee, but its ward fails so the arm is
+    // skipped. The second arm then re-binds x to the same scrutinee in its
+    // own fresh scope; if the first arm's binding had leaked it would show
+    // up here, but each arm runs in its own scope so the second arm's body
+    // sees the value via its own binding cleanly.
+    let input = r#"
+    forge n: arcana = 5;
+    forge picked: arcana = oracle (n) {
+        (x) ward x > 100 => reveal(0);
+        (x) => reveal(x);
+    };
+    picked;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[2], EvalResult::Data(Value::Arcana(5)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;


### PR DESCRIPTION
## Summary

Second piece of the v0.5.0 Pattern Matching Enhancements cycle. After PR #414 introduced the `ward` keyword, this PR adds the missing half: bare identifiers in match-mode oracle patterns now introduce fresh bindings to the scrutinee value, so `(x) ward x > 0 => …` finally works the way the v0.5.0 roadmap example claims.

```aby
forge n: arcana = 7;
oracle (n) {
    (x) ward x > 0 => unveil(\"positive\");
    (x) => unveil(\"non-positive\");
};
```

The first arm matches every Arcana scrutinee and binds `x = 7`; the ward then sees `x` and selects the arm.

## What changes

- **Per-branch scope.** `evaluate_oracle` now pushes a fresh scope at the start of each branch iteration and pops it after the branch helper returns. Bindings introduced by a pattern cannot leak sideways to the next arm or upward to the surrounding script. `forge` declarations inside the body remain confined to the same per-branch scope they always were.
- **Bare-identifier bindings.** Inside the match-mode pattern loop, `AST::Var(name, _)` is intercepted as a binding: the scrutinee value is written into the per-branch scope under `name` (via `set_var`, marked immutable), and the loop continues to the next pattern element. A small `type_of_scrutinee` helper maps the four legal scrutinee `Value` variants back to their declaration `Type`.
- **Wildcards / literals / if-else mode unchanged.** A `_` element still skips, literal patterns still compare by value, and bare identifiers in if-else mode arms still evaluate as boolean expressions (so `(x) =>` in if-else mode keeps the existing \"x must be an omen\" semantics).
- **Refactored helper.** Extracted `evaluate_oracle_branch` returning `Result<Option<EvalResult>, EvalError>` so the caller can use a clean `outcome?` flow while still owning the per-branch push/pop.

## Backwards compatibility

`examples/oracle.aby` and every existing test use only literal or wildcard match-mode patterns, so no script in the repository relied on `(x)` being a variable lookup. The change is therefore safe in practice. Scripts that want to compare scrutinee against an existing variable's value should now use a ward, e.g. `(any) ward any == existing_var =>`.

## Tests

Six new integration tests in `test_oracle.rs`:

- **`test_oracle_match_binds_bare_identifier_pattern`** — binding visible in body.
- **`test_oracle_match_binding_visible_in_ward`** — binding visible in the ward expression of the same arm.
- **`test_oracle_match_multiple_bindings_across_scrutinees`** — `(x, y) =>` against `(a, b)` binds both.
- **`test_oracle_match_binding_mixed_with_literals_and_wildcards`** — `(1, x) =>` and `(_, x) =>` compose freely with the new binding semantics.
- **`test_oracle_match_binding_does_not_leak_to_outer_scope`** — referencing the binding after the oracle finishes raises `UndefinedVariable`.
- **`test_oracle_match_binding_does_not_leak_between_arms`** — first arm's binding is invisible to the second arm; the second arm rebinds cleanly in its own fresh scope.

The pre-existing scope-leak regression (`oracle_question_mark_propagation_does_not_leak_scope`) had its match-mode case updated: a bare `AST::Var(\"missing\", …)` in match-mode pattern position is now intercepted as a binding and never reaches `evaluate`. The fix wraps the missing identifier in `AST::Add(Var(\"missing\"), Arcana(1))` so the inner expression is still evaluated and `?` actually fires from the missing-variable lookup, preserving the original test intent.

## Test plan

- [x] \`cargo test --workspace\` passes (oracle integration suite is now 18 tests; library suite is 111 tests).
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Manual smoke: \`cargo run -p abyss-lang -- invoke /tmp/binding_smoke.aby\` runs the four canonical binding shapes (single bind, bind + ward, multi-scrutinee bind, bind mixed with literal) and prints the expected values.
- [x] Manual scope check: bindings vanish after the oracle finishes and a follow-up `unveil(x)` correctly errors with `Variable x (did you mean: n?) is not defined!` (the v0.4.1 \"did you mean?\" hint composes with the new feature out of the box).
- [ ] CI green on this PR.

## What is still out of scope (for the rest of the v0.5.0 cycle)

- Scroll head/tail destructuring (`[head, ..rest]`).
- Artifact field destructuring (`Player { name, health }`).
- Lexicon key destructuring (`{ \"name\": n }`).
- VS Code TextMate grammar update + Starlight reference page (deferred to the cycle's docs/tooling PR once all four match-arm pieces are in).