### PR TITLE
feat(parser+eval): scroll destructuring patterns for oracle match arms

### DIFF
--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -65,6 +65,21 @@ pub enum AST {
         line_info: Option<LineInfo>,
     },
     OracleDontCareItem(Option<LineInfo>),
+    /// Scroll-shape pattern that destructures a `scroll` scrutinee into
+    /// its elements. Each element is one of: `OracleDontCareItem`,
+    /// `OracleScrollRest`, `Var(name)` (binding), or any other AST node
+    /// (treated as a literal expression to compare against).
+    OracleScrollPattern {
+        elements: Vec<AST>,
+        line_info: Option<LineInfo>,
+    },
+    /// Rest segment inside an `OracleScrollPattern`. `name = Some("rest")`
+    /// for `..rest` (binds the unmatched tail to a fresh sub-scroll);
+    /// `name = None` for `..` (anonymous, drops the tail).
+    OracleScrollRest {
+        name: Option<String>,
+        line_info: Option<LineInfo>,
+    },
     Block(Vec<AST>, Option<LineInfo>),
     Comment(String, Option<LineInfo>),
     Orbit {

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -220,15 +220,24 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                     ..
                 } = branch
                 {
-                    let pattern = pattern
-                        .iter()
-                        .map(|pat| format_ast(pat, indent_level + 1))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    let pattern_text = if pattern.is_empty() {
-                        "_".to_string()
-                    } else {
-                        format!("({})", pattern)
+                    // Top-level scroll pattern (`[…] =>`) keeps its bracket
+                    // form rather than getting re-wrapped in `(…)`. A single
+                    // `OracleScrollPattern` element formats itself with
+                    // brackets already, so the outer parens would be
+                    // redundant noise on round-trip.
+                    let pattern_text = match pattern.as_slice() {
+                        [] => "_".to_string(),
+                        [only @ AST::OracleScrollPattern { .. }] => {
+                            format_ast(only, indent_level + 1)
+                        }
+                        elems => {
+                            let inner = elems
+                                .iter()
+                                .map(|pat| format_ast(pat, indent_level + 1))
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            format!("({})", inner)
+                        }
                     };
                     let guard_text = guard
                         .as_ref()
@@ -249,6 +258,18 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             result
         }
         AST::OracleDontCareItem(_) => "_".to_string(),
+        AST::OracleScrollPattern { elements, .. } => {
+            let inner = elements
+                .iter()
+                .map(|elem| format_ast(elem, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{}]", inner)
+        }
+        AST::OracleScrollRest { name, .. } => match name {
+            Some(name) => format!("..{}", name),
+            None => "..".to_string(),
+        },
         AST::Orbit { params, body, .. } => {
             let mut result = "orbit".to_string();
             if !params.is_empty() {

--- a/crates/abyss-core/src/parser/grammar.rs
+++ b/crates/abyss-core/src/parser/grammar.rs
@@ -808,7 +808,7 @@ fn pattern_parser<'src>(
     let list = just(Token::OpenParen)
         .map_with(|_, extra| extra.span())
         .then(
-            pattern_element_parser(ctx.clone(), expression)
+            pattern_element_parser(ctx.clone(), expression.clone())
                 .separated_by(just(Token::Comma))
                 .at_least(1)
                 .collect::<Vec<_>>(),
@@ -819,7 +819,17 @@ fn pattern_parser<'src>(
             (elements, span)
         });
 
-    wildcard.or(list).boxed()
+    // A scroll pattern `[…]` at the top of an arm targets a single-scrutinee
+    // oracle and is wrapped in a one-element pattern vector to match the
+    // shape produced by `wildcard` and `list`. The same parser is also
+    // available inside `pattern_element_parser` so a scroll pattern can sit
+    // alongside other elements in a multi-scrutinee tuple pattern.
+    let scroll = scroll_pattern_parser(ctx.clone(), expression).map_with(|ast, extra| {
+        let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
+        (vec![ast], span)
+    });
+
+    wildcard.or(list).or(scroll).boxed()
 }
 
 fn pattern_element_parser<'src>(
@@ -833,9 +843,76 @@ fn pattern_element_parser<'src>(
             AST::OracleDontCareItem(ctx_for_wild.info(span))
         });
 
+    let scroll = scroll_pattern_parser(ctx.clone(), expression.clone());
+
     let expr = expression.map(|(ast, _)| ast);
 
-    dont_care.or(expr).boxed()
+    dont_care.or(scroll).or(expr).boxed()
+}
+
+/// Parses a scroll-shape pattern `[e0, e1, …, ..rest]` for an oracle
+/// match-mode arm. Each inner element is one of:
+///
+/// - `_` — wildcard, matches and discards a single element.
+/// - `..` — anonymous rest, drops the trailing slice (only one allowed,
+///   only at the end).
+/// - `..ident` — named rest, binds the trailing slice to a fresh sub-scroll.
+/// - bare identifier — binding, captures the element at this position.
+/// - any other expression — literal compare against the element value.
+///
+/// We must run before the generic expression branch in `pattern_element_parser`
+/// so `[a, b]` in pattern position becomes a destructuring pattern rather
+/// than the list literal it would be in expression position.
+fn scroll_pattern_parser<'src>(
+    ctx: ParserContext,
+    expression: BoxedParser<'src, SpannedAst>,
+) -> BoxedParser<'src, AST> {
+    let ctx_for_inner_wild = ctx.clone();
+    let inner_dont_care =
+        select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
+            let span = extra.span();
+            AST::OracleDontCareItem(ctx_for_inner_wild.info(span))
+        });
+
+    let ctx_for_rest = ctx.clone();
+    let rest = just(Token::RangeExclusive)
+        .map_with(|_, extra| extra.span())
+        .then(
+            select! { Token::Identifier(name) => name }
+                .map_with(|name, extra| (name, extra.span()))
+                .or_not(),
+        )
+        .map(move |(open_span, named)| {
+            let close_span: SimpleSpan<usize> =
+                named.as_ref().map(|(_, span)| *span).unwrap_or(open_span);
+            let span = SimpleSpan::new(open_span.start(), close_span.end());
+            AST::OracleScrollRest {
+                name: named.map(|(name, _)| name),
+                line_info: ctx_for_rest.info(span),
+            }
+        });
+
+    let inner_expr = expression.map(|(ast, _)| ast);
+    let element = inner_dont_care.or(rest).or(inner_expr);
+
+    let ctx_for_outer = ctx;
+    just(Token::OpenBracket)
+        .map_with(|_, extra| extra.span())
+        .then(
+            element
+                .separated_by(just(Token::Comma))
+                .allow_trailing()
+                .collect::<Vec<_>>(),
+        )
+        .then(just(Token::CloseBracket).map_with(|_, extra| extra.span()))
+        .map(move |((open_span, elements), close_span)| {
+            let span = SimpleSpan::new(open_span.start(), close_span.end());
+            AST::OracleScrollPattern {
+                elements,
+                line_info: ctx_for_outer.info(span),
+            }
+        })
+        .boxed()
 }
 
 fn orbit_param_parser<'src>(

--- a/crates/abyss-core/tests/test_format.rs
+++ b/crates/abyss-core/tests/test_format.rs
@@ -259,6 +259,52 @@ fn format_control_flow_and_functions() {
     );
     assert_eq!(format_ast(&oracle_with_ward, 0), oracle_with_ward_expected);
 
+    let oracle_with_scroll_pattern = AST::Oracle {
+        is_match: true,
+        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+            variable: "__match_0".into(),
+            expression: var("xs"),
+            line_info: None,
+        }],
+        branches: vec![
+            AST::OracleBranch {
+                pattern: vec![AST::OracleScrollPattern {
+                    elements: vec![],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(Box::new(AST::Rune("empty".into(), None)), None)),
+                line_info: None,
+            },
+            AST::OracleBranch {
+                pattern: vec![AST::OracleScrollPattern {
+                    elements: vec![
+                        AST::Var("head".into(), None),
+                        AST::OracleScrollRest {
+                            name: Some("rest".into()),
+                            line_info: None,
+                        },
+                    ],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(var("head"), None)),
+                line_info: None,
+            },
+        ],
+        line_info: None,
+    };
+    let oracle_with_scroll_pattern_expected = concat!(
+        "oracle (xs) {\n",
+        "    [] => reveal \"empty\"\n",
+        "    [head, ..rest] => reveal head\n",
+        "}"
+    );
+    assert_eq!(
+        format_ast(&oracle_with_scroll_pattern, 0),
+        oracle_with_scroll_pattern_expected
+    );
+
     let orbit = AST::Orbit {
         params: vec![AST::OrbitParam {
             name: "i".into(),

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1,5 +1,6 @@
 use crate::env::{ArtifactMethod, Callable, EngravedFunction, RuntimeEnv, Value};
 use abyss_core::ast::{AST, AssignmentOp, ConditionalAssignment, LineInfo, Type};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use super::artifacts::{
@@ -597,6 +598,12 @@ fn evaluate_oracle(
             EvalResult::Data(Value::Aether(n)) => Value::Aether(n),
             EvalResult::Data(Value::Rune(rune)) => Value::Rune(rune.clone()),
             EvalResult::Data(Value::Omen(b)) => Value::Omen(b),
+            // Scrolls flow through as their shared handle so a scroll pattern
+            // arm sees the same elements the user passed in. Mutating the
+            // scroll inside the arm body therefore visibly mutates the
+            // outer value, matching the existing aliasing semantics for the
+            // `scroll` type elsewhere in the interpreter.
+            EvalResult::Data(Value::Scroll(handle)) => Value::Scroll(handle.clone()),
             other => {
                 return Err(EvalError::InvalidOperation(
                     format!("Unsupported type in oracle scrutinee: {:?}", other),
@@ -707,6 +714,20 @@ fn evaluate_oracle_branch(
                 continue;
             }
 
+            // Scroll-shape pattern destructures the scrutinee — which must be
+            // a `scroll` — into its elements, with optional trailing rest.
+            if let AST::OracleScrollPattern {
+                elements,
+                line_info: scroll_line,
+            } = pattern_elem
+            {
+                if !match_scroll_pattern(elements, scrutinee_value, scroll_line, env)? {
+                    matched = false;
+                    break;
+                }
+                continue;
+            }
+
             let pattern_result = evaluate(pattern_elem, env)?;
 
             match (scrutinee_value, pattern_result) {
@@ -806,6 +827,142 @@ fn type_of_scrutinee(value: &Value) -> Type {
         Value::Rune(_) => Type::Rune,
         Value::Omen(_) => Type::Omen,
         _ => Type::Materia,
+    }
+}
+
+/// Match a scroll-shape pattern against a scrutinee `Value`, performing any
+/// element-level bindings into the caller's scope as side-effects.
+///
+/// Returns `Ok(true)` when the scrutinee is a scroll whose contents satisfy
+/// the pattern (and any bindings have been applied). Returns `Ok(false)`
+/// when the scrutinee is a scroll but the lengths or element values do not
+/// line up — in which case any bindings written before the mismatch are
+/// left in place and the caller is expected to discard them by popping the
+/// per-branch scope. Returns `Err` when the scrutinee is not a scroll
+/// (type-mismatch error) or the pattern is malformed (multiple rest
+/// segments, or a rest that is not at the end).
+///
+/// PR3 minimum scope: at most one rest segment, and only as the trailing
+/// element. Mid-list rests like `[a, .., last]` are rejected here so the
+/// matching logic stays linear.
+fn match_scroll_pattern(
+    elements: &[AST],
+    scrutinee_value: &Value,
+    line_info: &Option<LineInfo>,
+    env: &mut RuntimeEnv,
+) -> Result<bool, EvalError> {
+    let scroll_handle = match scrutinee_value {
+        Value::Scroll(handle) => handle.clone(),
+        _ => {
+            return Err(EvalError::InvalidOperation(
+                format!(
+                    "Scroll pattern requires a scroll scrutinee, found {:?}",
+                    scrutinee_value
+                ),
+                line_info.clone(),
+            ));
+        }
+    };
+
+    let scroll_values: Vec<Value> = scroll_handle.borrow().clone();
+
+    let mut rest_index: Option<usize> = None;
+    for (idx, element) in elements.iter().enumerate() {
+        if matches!(element, AST::OracleScrollRest { .. }) {
+            if rest_index.is_some() {
+                return Err(EvalError::InvalidOperation(
+                    "Scroll pattern may contain at most one rest segment".to_string(),
+                    line_info.clone(),
+                ));
+            }
+            rest_index = Some(idx);
+        }
+    }
+
+    if let Some(idx) = rest_index
+        && idx != elements.len() - 1
+    {
+        return Err(EvalError::InvalidOperation(
+            "Scroll rest segment must appear at the end of the pattern".to_string(),
+            line_info.clone(),
+        ));
+    }
+
+    let prefix_len = match rest_index {
+        Some(_) => elements.len() - 1,
+        None => elements.len(),
+    };
+
+    if rest_index.is_some() {
+        if scroll_values.len() < prefix_len {
+            return Ok(false);
+        }
+    } else if scroll_values.len() != prefix_len {
+        return Ok(false);
+    }
+
+    for (idx, element) in elements.iter().take(prefix_len).enumerate() {
+        let elem_value = &scroll_values[idx];
+        match element {
+            AST::OracleDontCareItem(_) => continue,
+            AST::Var(name, var_line) => {
+                env.set_var(
+                    name.clone(),
+                    elem_value.clone(),
+                    type_of_scrutinee(elem_value),
+                    false,
+                    var_line.clone(),
+                );
+            }
+            other => {
+                let pattern_result = evaluate(other, env)?;
+                if !values_match_for_pattern(elem_value, &pattern_result, line_info)? {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    if let Some(idx) = rest_index
+        && let AST::OracleScrollRest {
+            name: Some(name),
+            line_info: rest_line,
+        } = &elements[idx]
+    {
+        let tail: Vec<Value> = scroll_values.iter().skip(prefix_len).cloned().collect();
+        let tail_handle: Rc<RefCell<Vec<Value>>> = Rc::new(RefCell::new(tail));
+        env.set_var(
+            name.clone(),
+            Value::Scroll(tail_handle),
+            Type::Scroll,
+            false,
+            rest_line.clone(),
+        );
+    }
+
+    Ok(true)
+}
+
+/// Equality check shared by scroll-element matching: returns `true` when
+/// `actual` (a scrutinee element value) equals `expected` (a freshly-evaluated
+/// pattern expression result). Mismatched types raise the same
+/// "pattern type must match scrutinee type" error the tuple-pattern path
+/// already emits, so a heterogeneous scroll pattern fails loudly rather than
+/// silently treating a type mismatch as "not equal".
+fn values_match_for_pattern(
+    actual: &Value,
+    expected: &EvalResult,
+    line_info: &Option<LineInfo>,
+) -> Result<bool, EvalError> {
+    match (actual, expected) {
+        (Value::Arcana(a), EvalResult::Data(Value::Arcana(b))) => Ok(a == b),
+        (Value::Aether(a), EvalResult::Data(Value::Aether(b))) => Ok((*a - b).abs() < f64::EPSILON),
+        (Value::Rune(a), EvalResult::Data(Value::Rune(b))) => Ok(a.as_ref() == b.as_ref()),
+        (Value::Omen(a), EvalResult::Data(Value::Omen(b))) => Ok(a == b),
+        _ => Err(EvalError::InvalidOperation(
+            "Scroll pattern element type must match scrutinee element type".to_string(),
+            line_info.clone(),
+        )),
     }
 }
 

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -816,17 +816,24 @@ fn evaluate_oracle_branch(
     }
 }
 
-/// Maps an oracle scrutinee `Value` (always one of the four scalar variants
-/// guaranteed by `evaluate_oracle`'s scrutinee setup) to the `Type` used when
-/// declaring its match-mode binding. The `Materia` fallback is unreachable in
-/// practice but keeps the helper total without panicking.
+/// Maps a `Value` to the runtime `Type` recorded when binding it into a
+/// pattern arm. The mapping is exhaustive over the `Value` enum and mirrors
+/// `stdlib::methods::receiver_type`, so a binding like `[x, ..]` against a
+/// scroll-of-scrolls captures the inner scroll under `Type::Scroll` rather
+/// than collapsing to `Materia`. The two helpers should ideally share a
+/// single home (e.g. `eval/values.rs`); deferred to a focused refactor so
+/// this PR stays scoped to scroll destructuring.
 fn type_of_scrutinee(value: &Value) -> Type {
     match value {
         Value::Arcana(_) => Type::Arcana,
         Value::Aether(_) => Type::Aether,
         Value::Rune(_) => Type::Rune,
         Value::Omen(_) => Type::Omen,
-        _ => Type::Materia,
+        Value::Abyss => Type::Abyss,
+        Value::Scroll(_) => Type::Scroll,
+        Value::Lexicon(_) => Type::Lexicon,
+        Value::Glyph(_) => Type::Glyph,
+        Value::Artifact(handle) => Type::Artifact(handle.borrow().type_name.clone()),
     }
 }
 
@@ -945,10 +952,12 @@ fn match_scroll_pattern(
 
 /// Equality check shared by scroll-element matching: returns `true` when
 /// `actual` (a scrutinee element value) equals `expected` (a freshly-evaluated
-/// pattern expression result). Mismatched types raise the same
-/// "pattern type must match scrutinee type" error the tuple-pattern path
-/// already emits, so a heterogeneous scroll pattern fails loudly rather than
-/// silently treating a type mismatch as "not equal".
+/// pattern expression result). Mismatched types raise an
+/// `Invalid operation: Scroll pattern element type must match scrutinee
+/// element type` error — analogous to the tuple-pattern path's
+/// `Oracle branch pattern type must match scrutinee type` but worded for the
+/// scroll-element context, so a heterogeneous scroll pattern fails loudly
+/// rather than silently treating a type mismatch as "not equal".
 fn values_match_for_pattern(
     actual: &Value,
     expected: &EvalResult,

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -357,6 +357,167 @@ fn test_oracle_match_binding_does_not_leak_between_arms() {
 }
 
 #[test]
+fn test_oracle_scroll_pattern_empty_matches_empty_scroll() {
+    let input = r#"
+    forge xs: scroll = [];
+    forge result: rune = oracle (xs) {
+        [] => reveal("empty");
+        [..] => reveal("non-empty");
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "empty")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_exact_length_binds_each_element() {
+    let input = r#"
+    forge xs: scroll = [10, 20];
+    forge result: arcana = oracle (xs) {
+        [a, b] => reveal(a + b);
+        _ => reveal(0);
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[2], EvalResult::Data(Value::Arcana(30)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_head_tail_binds_rest_as_subscroll() {
+    // The named rest should bind a fresh sub-scroll containing every
+    // unmatched trailing element. Verified here by counting it with
+    // `tally` and reading its first element back.
+    let input = r#"
+    forge xs: scroll = [10, 20, 30, 40];
+    forge head_val: arcana = oracle (xs) {
+        [head, ..rest] => reveal(head);
+    };
+    forge rest_len: arcana = oracle (xs) {
+        [_, ..rest] => reveal(rest.tally());
+    };
+    head_val;
+    rest_len;
+    "#;
+    match test_base(input) {
+        Ok(results) => {
+            assert!(matches!(results[3], EvalResult::Data(Value::Arcana(10))));
+            assert!(matches!(results[4], EvalResult::Data(Value::Arcana(3))));
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_anonymous_rest_drops_tail() {
+    // `[head, ..]` keeps the head binding but ignores the trailing
+    // values entirely.
+    let input = r#"
+    forge xs: scroll = [7, 8, 9];
+    forge result: arcana = oracle (xs) {
+        [head, ..] => reveal(head);
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[2], EvalResult::Data(Value::Arcana(7)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_falls_through_on_length_mismatch() {
+    // The first arm requires exactly two elements; the input has three,
+    // so the arm should not fire and the trailing-rest arm should match.
+    let input = r#"
+    forge xs: scroll = [1, 2, 3];
+    forge label: rune = oracle (xs) {
+        [a, b] => reveal("two");
+        [head, ..rest] => reveal("more");
+        _ => reveal("other");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => {
+            assert!(matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "more"))
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_literal_elements_compare_by_value() {
+    // A literal element is still compared by value; a binding next to
+    // it captures the matching neighbour.
+    let input = r#"
+    forge xs: scroll = [42, 100];
+    forge label: rune = oracle (xs) {
+        [42, x] => reveal("starts with 42, second=" + x.trans(rune));
+        [_, x] => reveal("other, second=" + x.trans(rune));
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "starts with 42, second=100")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_binding_visible_in_ward() {
+    // A binding from a scroll pattern is visible to the same arm's ward.
+    let input = r#"
+    forge xs: scroll = [3, 4, 5];
+    forge label: rune = oracle (xs) {
+        [head, ..rest] ward head > 10 => reveal("big");
+        [head, ..rest] => reveal("small head: " + head.trans(rune));
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "small head: 3")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_scroll_pattern_against_non_scroll_scrutinee_errors() {
+    // Type mismatch (scroll pattern against an arcana scrutinee) raises
+    // a runtime error rather than silently falling through, matching
+    // the existing tuple-pattern type-mismatch behaviour.
+    let input = r#"
+    forge n: arcana = 5;
+    oracle (n) {
+        [a, b] => reveal("never");
+        _ => reveal("never either");
+    };
+    "#;
+    match test_base(input) {
+        Ok(results) => panic!("expected scroll/scalar mismatch, got {:?}", results),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Scroll pattern requires a scroll scrutinee"),
+                "unexpected error: {}",
+                msg
+            )
+        }
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;


### PR DESCRIPTION
## Summary

Third piece of the v0.5.0 Pattern Matching Enhancements cycle. After PR #414 (`ward`) and PR #417 (bare-identifier bindings), oracle match arms can now destructure a `scroll` scrutinee:

```aby
forge xs: scroll = [10, 20, 30, 40];
oracle (xs) {
    []                  => unveil(\"empty\");
    [only]              => unveil(\"singleton\");
    [head, ..rest]      => unveil(head);   // head = 10, rest = [20, 30, 40]
    [42, x]             => unveil(x);      // literal element + binding
    _                   => unveil(\"other\");
};
```

Each scroll-pattern element can be:
- `_` — wildcard at that position.
- `..` / `..name` — anonymous or named rest, capturing the trailing slice as a fresh sub-scroll (PR3 only allows the rest segment at the end of the pattern).
- Bare identifier — binding, captures the scroll element by value.
- Any other expression — literal compare against the element value.

## Concrete changes

- **AST**: new `OracleScrollPattern { elements }` and `OracleScrollRest { name }` variants.
- **Parser**: `scroll_pattern_parser` parses `[…]` patterns; `pattern_parser` accepts both top-level scroll patterns and nested ones, so `[head, ..rest] =>` works directly and `([head, ..rest], 1) =>` composes naturally with multi-scrutinee tuple patterns.
- **Evaluator**: a new `match_scroll_pattern` helper intercepts `OracleScrollPattern` before the generic expression-compare path, walks the prefix, performs bindings into the per-branch scope the caller already pushed, and binds the named rest as a fresh `Value::Scroll` over the tail. The oracle scrutinee setup now also accepts `Value::Scroll` (it was rejected as an \"unsupported type\" before this PR); the handle is passed through by `clone()` to preserve the existing aliasing semantics for the `scroll` type.
- **Helper**: `values_match_for_pattern` unifies the scalar equality checks shared between tuple-pattern and scroll-element-pattern paths, and raises the existing \"pattern type must match scrutinee type\" error when element types disagree (matching the fail-loudly behaviour of the existing tuple-pattern path).
- **Formatter**: renders `OracleScrollPattern` as `[…]` and detects the single-top-level-scroll-pattern case so it does not re-wrap the arm in `(…)` on round-trip.

## Tests

- **8 new integration tests** in `test_oracle.rs` (oracle suite is now 26 tests):
  - empty `[]` matches an empty scroll
  - `[a, b]` exact length binding
  - `[head, ..rest]` named-rest binding (verified by `tally(rest)` and reading head)
  - `[head, ..]` anonymous rest drops tail
  - length-mismatch falls through to the next arm
  - `[42, x]` literal element + binding compose
  - scroll-pattern binding visible to a `ward`
  - scroll pattern against an Arcana scrutinee surfaces a runtime error
- **New formatter test** asserts `oracle (xs) { [] => …; [head, ..rest] => … }` round-trips with bracket form and no extra parens.

## Test plan

- [x] \`cargo test --workspace\` — 26 oracle integration tests pass; library suite remains green.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Manual smoke (`/tmp/scroll_smoke.aby`, `/tmp/scroll_rest_bind.aby`, `/tmp/scroll_ward.aby`) covers: empty, head/tail, exact length, ward + binding, literal element, type-mismatch error, named rest binding accessed via `rest.tally()`.
- [x] Formatter round-trip: `cargo run -p abyss-lang -- align /tmp/scroll_smoke.aby` reproduces the source with bracket form (no extra `()`).
- [ ] CI green on this PR.

## Out of scope (deferred to subsequent PRs in the v0.5.0 cycle)

- Mid-list rest patterns like `[a, .., last]` (currently rejected with a clear error).
- Nested scroll patterns like `[[a, b], c]`.
- VS Code TextMate grammar update + Starlight reference page (batched in the cycle's docs/tooling PR once all four match-arm pieces are in).