### PR TITLE
feat(parser+eval): artifact field destructuring patterns for oracle match arms

### DIFF
--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -80,6 +80,18 @@ pub enum AST {
         name: Option<String>,
         line_info: Option<LineInfo>,
     },
+    /// Artifact-shape pattern that matches a `TypeName { field, … }`
+    /// scrutinee. Each `(field_name, sub_pattern)` entry pulls the named
+    /// field out of the artifact and matches it against `sub_pattern`
+    /// (typically `Var` for binding, a literal for compare, or
+    /// `OracleDontCareItem` to ignore). Fields not listed here are not
+    /// matched against — the pattern is non-exhaustive by default, so
+    /// users can pick out only the fields they care about.
+    OracleArtifactPattern {
+        type_name: String,
+        fields: Vec<(String, AST)>,
+        line_info: Option<LineInfo>,
+    },
     Block(Vec<AST>, Option<LineInfo>),
     Comment(String, Option<LineInfo>),
     Orbit {

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -220,14 +220,15 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                     ..
                 } = branch
                 {
-                    // Top-level scroll pattern (`[…] =>`) keeps its bracket
-                    // form rather than getting re-wrapped in `(…)`. A single
-                    // `OracleScrollPattern` element formats itself with
-                    // brackets already, so the outer parens would be
-                    // redundant noise on round-trip.
+                    // Top-level scroll / artifact patterns keep their natural
+                    // form (`[…] =>`, `Player { name } =>`) rather than
+                    // getting re-wrapped in `(…)`. The single-element AST
+                    // already self-formats in the right shape, so the outer
+                    // parens would be redundant noise on round-trip.
                     let pattern_text = match pattern.as_slice() {
                         [] => "_".to_string(),
-                        [only @ AST::OracleScrollPattern { .. }] => {
+                        [only @ AST::OracleScrollPattern { .. }]
+                        | [only @ AST::OracleArtifactPattern { .. }] => {
                             format_ast(only, indent_level + 1)
                         }
                         elems => {
@@ -270,6 +271,21 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             Some(name) => format!("..{}", name),
             None => "..".to_string(),
         },
+        AST::OracleArtifactPattern {
+            type_name, fields, ..
+        } => {
+            let inner = fields
+                .iter()
+                .map(|(name, sub)| match sub {
+                    // Shorthand `{ name }` keeps its compact form when the
+                    // sub-pattern is just `Var(name)` with the same name.
+                    AST::Var(var_name, _) if var_name == name => name.clone(),
+                    other => format!("{}: {}", name, format_ast(other, indent_level)),
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{} {{ {} }}", type_name, inner)
+        }
         AST::Orbit { params, body, .. } => {
             let mut result = "orbit".to_string();
             if !params.is_empty() {

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -274,17 +274,24 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
         AST::OracleArtifactPattern {
             type_name, fields, ..
         } => {
-            let inner = fields
-                .iter()
-                .map(|(name, sub)| match sub {
-                    // Shorthand `{ name }` keeps its compact form when the
-                    // sub-pattern is just `Var(name)` with the same name.
-                    AST::Var(var_name, _) if var_name == name => name.clone(),
-                    other => format!("{}: {}", name, format_ast(other, indent_level)),
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{} {{ {} }}", type_name, inner)
+            if fields.is_empty() {
+                // `Type {}` matches by type alone (any artifact of this
+                // type). Mirror `ArtifactLiteral`'s empty-fields formatting
+                // rather than emitting `Type {  }` with double spaces.
+                format!("{} {{}}", type_name)
+            } else {
+                let inner = fields
+                    .iter()
+                    .map(|(name, sub)| match sub {
+                        // Shorthand `{ name }` keeps its compact form when the
+                        // sub-pattern is just `Var(name)` with the same name.
+                        AST::Var(var_name, _) if var_name == name => name.clone(),
+                        other => format!("{}: {}", name, format_ast(other, indent_level)),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{} {{ {} }}", type_name, inner)
+            }
         }
         AST::Orbit { params, body, .. } => {
             let mut result = "orbit".to_string();

--- a/crates/abyss-core/src/parser/grammar.rs
+++ b/crates/abyss-core/src/parser/grammar.rs
@@ -776,7 +776,17 @@ fn oracle_branch_parser<'src>(
         .map(|(ast, _)| Box::new(ast))
         .or_not();
 
-    pattern_parser(ctx.clone(), expression.clone())
+    // The pattern element parser is mutually recursive with the scroll- and
+    // artifact-pattern parsers (since a scroll element or an artifact field
+    // value may itself be a scroll / artifact / wildcard pattern). Build it
+    // once via `recursive` and thread it into both the top-level pattern
+    // recogniser and the inner sub-parsers so nested patterns like
+    // `Player { items: [head, ..rest] }` actually parse into the AST nodes
+    // the evaluator already knows how to match.
+    let pattern_element = pattern_element_parser(ctx.clone(), expression.clone());
+    let pattern = pattern_parser(ctx.clone(), expression.clone(), pattern_element);
+
+    pattern
         .then(guard)
         .then_ignore(just(Token::FatArrow))
         .then(body)
@@ -801,6 +811,7 @@ fn oracle_branch_parser<'src>(
 fn pattern_parser<'src>(
     ctx: ParserContext,
     expression: BoxedParser<'src, SpannedAst>,
+    pattern_element: BoxedParser<'src, AST>,
 ) -> BoxedParser<'src, (Vec<AST>, SimpleSpan<usize>)> {
     let wildcard = select! { Token::Identifier(name) if name == "_" => () }
         .map_with(|_, extra| (Vec::new(), extra.span()));
@@ -808,7 +819,8 @@ fn pattern_parser<'src>(
     let list = just(Token::OpenParen)
         .map_with(|_, extra| extra.span())
         .then(
-            pattern_element_parser(ctx.clone(), expression.clone())
+            pattern_element
+                .clone()
                 .separated_by(just(Token::Comma))
                 .at_least(1)
                 .collect::<Vec<_>>(),
@@ -821,23 +833,23 @@ fn pattern_parser<'src>(
 
     // A scroll pattern `[…]` at the top of an arm targets a single-scrutinee
     // oracle and is wrapped in a one-element pattern vector to match the
-    // shape produced by `wildcard` and `list`. The same parser is also
-    // available inside `pattern_element_parser` so a scroll pattern can sit
+    // shape produced by `wildcard` and `list`. The same scroll-pattern parser
+    // is also referenced through `pattern_element` so scroll patterns can sit
     // alongside other elements in a multi-scrutinee tuple pattern.
-    let scroll = scroll_pattern_parser(ctx.clone(), expression.clone()).map_with(|ast, extra| {
-        let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
-        (vec![ast], span)
-    });
+    let scroll = scroll_pattern_parser(ctx.clone(), pattern_element.clone(), expression.clone())
+        .map_with(|ast, extra| {
+            let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
+            (vec![ast], span)
+        });
 
     // An artifact pattern `TypeName { … }` at the top of an arm — same shape
-    // wrapping logic as `scroll`. The same parser is reused inside
-    // `pattern_element_parser` (and `scroll_pattern_parser`) so an artifact
-    // pattern can also sit nested inside a multi-scrutinee tuple pattern or
-    // alongside elements inside a scroll pattern.
-    let artifact = artifact_pattern_parser(ctx.clone(), expression).map_with(|ast, extra| {
-        let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
-        (vec![ast], span)
-    });
+    // wrapping logic as `scroll`. The recursive `pattern_element` lets each
+    // field value itself be a nested scroll / artifact / wildcard pattern.
+    let artifact =
+        artifact_pattern_parser(ctx, pattern_element, expression).map_with(|ast, extra| {
+            let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
+            (vec![ast], span)
+        });
 
     wildcard.or(list).or(scroll).or(artifact).boxed()
 }
@@ -846,22 +858,27 @@ fn pattern_element_parser<'src>(
     ctx: ParserContext,
     expression: BoxedParser<'src, SpannedAst>,
 ) -> BoxedParser<'src, AST> {
-    let ctx_for_wild = ctx.clone();
-    let dont_care =
-        select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
-            let span = extra.span();
-            AST::OracleDontCareItem(ctx_for_wild.info(span))
-        });
+    recursive(|pattern_elem: RecursiveParser<'src, AST>| {
+        let ctx_for_wild = ctx.clone();
+        let dont_care =
+            select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
+                let span = extra.span();
+                AST::OracleDontCareItem(ctx_for_wild.info(span))
+            });
 
-    let scroll = scroll_pattern_parser(ctx.clone(), expression.clone());
-    // Run before the generic expression branch so `Player { … }` is parsed
-    // as a destructuring pattern rather than the artifact literal it would
-    // be in expression position.
-    let artifact = artifact_pattern_parser(ctx.clone(), expression.clone());
+        let pattern_elem_boxed = pattern_elem.clone().boxed();
+        let scroll =
+            scroll_pattern_parser(ctx.clone(), pattern_elem_boxed.clone(), expression.clone());
+        // Run before the generic expression branch so `Player { … }` is
+        // parsed as a destructuring pattern rather than the artifact literal
+        // it would be in expression position.
+        let artifact = artifact_pattern_parser(ctx.clone(), pattern_elem_boxed, expression.clone());
 
-    let expr = expression.map(|(ast, _)| ast);
+        let expr = expression.clone().map(|(ast, _)| ast);
 
-    dont_care.or(scroll).or(artifact).or(expr).boxed()
+        dont_care.or(scroll).or(artifact).or(expr).boxed()
+    })
+    .boxed()
 }
 
 /// Parses an artifact-shape pattern `TypeName { f0, f1: pat, … }` for an
@@ -883,25 +900,21 @@ fn pattern_element_parser<'src>(
 /// would be in expression position.
 fn artifact_pattern_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
+    pattern_element: BoxedParser<'src, AST>,
+    _expression: BoxedParser<'src, SpannedAst>,
 ) -> BoxedParser<'src, AST> {
-    let ctx_for_inner_wild = ctx.clone();
-    let inner_dont_care =
-        select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
-            let span = extra.span();
-            AST::OracleDontCareItem(ctx_for_inner_wild.info(span))
-        });
-
-    let inner_expr = expression.map(|(ast, _)| ast);
-    let field_value = inner_dont_care.or(inner_expr);
-
-    let ctx_for_field = ctx.clone();
     // Each field entry is `name (: value)?`. The shorthand expands to a
     // `Var(name)` so the evaluator's existing `Var`-as-binding path applies
-    // uniformly with tuple and scroll patterns.
+    // uniformly with tuple and scroll patterns. The explicit `: value` form
+    // accepts any pattern element (wildcard, nested scroll/artifact patterns,
+    // bindings, literal expressions), so nested destructuring like
+    // `Player { items: [head, ..rest], friend: Enemy { name } }` parses into
+    // the `OracleScrollPattern` / `OracleArtifactPattern` nodes the evaluator
+    // already knows how to match.
+    let ctx_for_field = ctx.clone();
     let field = select! { Token::Identifier(name) => name }
         .map_with(move |name, extra| (name, extra.span()))
-        .then(just(Token::Colon).ignore_then(field_value).or_not())
+        .then(just(Token::Colon).ignore_then(pattern_element).or_not())
         .map(move |((name, name_span), value)| {
             let pattern = value.unwrap_or_else(|| {
                 AST::Var(
@@ -949,15 +962,9 @@ fn artifact_pattern_parser<'src>(
 /// than the list literal it would be in expression position.
 fn scroll_pattern_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
+    pattern_element: BoxedParser<'src, AST>,
+    _expression: BoxedParser<'src, SpannedAst>,
 ) -> BoxedParser<'src, AST> {
-    let ctx_for_inner_wild = ctx.clone();
-    let inner_dont_care =
-        select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
-            let span = extra.span();
-            AST::OracleDontCareItem(ctx_for_inner_wild.info(span))
-        });
-
     let ctx_for_rest = ctx.clone();
     let rest = just(Token::RangeExclusive)
         .map_with(|_, extra| extra.span())
@@ -976,13 +983,11 @@ fn scroll_pattern_parser<'src>(
             }
         });
 
-    // Artifact patterns can appear inside scroll patterns
-    // (`[Player { name }, ..rest]` etc.); run before the generic expression
-    // branch so the brace form is destructuring, not an artifact literal.
-    let inner_artifact = artifact_pattern_parser(ctx.clone(), expression.clone());
-
-    let inner_expr = expression.map(|(ast, _)| ast);
-    let element = inner_dont_care.or(rest).or(inner_artifact).or(inner_expr);
+    // Non-rest scroll elements use the recursive `pattern_element`, which
+    // already covers wildcards, nested scroll patterns, nested artifact
+    // patterns, and arbitrary expressions. `rest` is scroll-specific so it
+    // lives here as the alternation's first branch.
+    let element = rest.or(pattern_element);
 
     let ctx_for_outer = ctx;
     just(Token::OpenBracket)

--- a/crates/abyss-core/src/parser/grammar.rs
+++ b/crates/abyss-core/src/parser/grammar.rs
@@ -824,12 +824,22 @@ fn pattern_parser<'src>(
     // shape produced by `wildcard` and `list`. The same parser is also
     // available inside `pattern_element_parser` so a scroll pattern can sit
     // alongside other elements in a multi-scrutinee tuple pattern.
-    let scroll = scroll_pattern_parser(ctx.clone(), expression).map_with(|ast, extra| {
+    let scroll = scroll_pattern_parser(ctx.clone(), expression.clone()).map_with(|ast, extra| {
         let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
         (vec![ast], span)
     });
 
-    wildcard.or(list).or(scroll).boxed()
+    // An artifact pattern `TypeName { … }` at the top of an arm — same shape
+    // wrapping logic as `scroll`. The same parser is reused inside
+    // `pattern_element_parser` (and `scroll_pattern_parser`) so an artifact
+    // pattern can also sit nested inside a multi-scrutinee tuple pattern or
+    // alongside elements inside a scroll pattern.
+    let artifact = artifact_pattern_parser(ctx.clone(), expression).map_with(|ast, extra| {
+        let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
+        (vec![ast], span)
+    });
+
+    wildcard.or(list).or(scroll).or(artifact).boxed()
 }
 
 fn pattern_element_parser<'src>(
@@ -844,10 +854,84 @@ fn pattern_element_parser<'src>(
         });
 
     let scroll = scroll_pattern_parser(ctx.clone(), expression.clone());
+    // Run before the generic expression branch so `Player { … }` is parsed
+    // as a destructuring pattern rather than the artifact literal it would
+    // be in expression position.
+    let artifact = artifact_pattern_parser(ctx.clone(), expression.clone());
 
     let expr = expression.map(|(ast, _)| ast);
 
-    dont_care.or(scroll).or(expr).boxed()
+    dont_care.or(scroll).or(artifact).or(expr).boxed()
+}
+
+/// Parses an artifact-shape pattern `TypeName { f0, f1: pat, … }` for an
+/// oracle match-mode arm. Each field entry is one of:
+///
+/// - `field_name` — shorthand binding; the field value is bound to a fresh
+///   variable named after the field.
+/// - `field_name: _` — explicit wildcard; the field is matched but its
+///   value is discarded.
+/// - `field_name: ident` — explicit binding; the field value is bound to
+///   `ident` (which may differ from the field name).
+/// - `field_name: <expr>` — literal compare against the field value.
+///
+/// Fields not listed here are not matched against — the pattern is
+/// non-exhaustive by default, so users can pick out only the fields they
+/// care about. We must run before the generic expression branch in
+/// `pattern_element_parser` so `Player { name }` in pattern position is
+/// parsed as a destructuring pattern rather than the artifact literal it
+/// would be in expression position.
+fn artifact_pattern_parser<'src>(
+    ctx: ParserContext,
+    expression: BoxedParser<'src, SpannedAst>,
+) -> BoxedParser<'src, AST> {
+    let ctx_for_inner_wild = ctx.clone();
+    let inner_dont_care =
+        select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
+            let span = extra.span();
+            AST::OracleDontCareItem(ctx_for_inner_wild.info(span))
+        });
+
+    let inner_expr = expression.map(|(ast, _)| ast);
+    let field_value = inner_dont_care.or(inner_expr);
+
+    let ctx_for_field = ctx.clone();
+    // Each field entry is `name (: value)?`. The shorthand expands to a
+    // `Var(name)` so the evaluator's existing `Var`-as-binding path applies
+    // uniformly with tuple and scroll patterns.
+    let field = select! { Token::Identifier(name) => name }
+        .map_with(move |name, extra| (name, extra.span()))
+        .then(just(Token::Colon).ignore_then(field_value).or_not())
+        .map(move |((name, name_span), value)| {
+            let pattern = value.unwrap_or_else(|| {
+                AST::Var(
+                    name.clone(),
+                    ctx_for_field.info(SimpleSpan::new(name_span.start(), name_span.end())),
+                )
+            });
+            (name, pattern)
+        });
+
+    let ctx_for_outer = ctx;
+    select! { Token::Identifier(name) => name }
+        .map_with(|name, extra| (name, extra.span()))
+        .then_ignore(just(Token::OpenBrace))
+        .then(
+            field
+                .separated_by(just(Token::Comma))
+                .allow_trailing()
+                .collect::<Vec<_>>(),
+        )
+        .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
+        .map(move |(((type_name, type_span), fields), close_span)| {
+            let span = SimpleSpan::new(type_span.start(), close_span.end());
+            AST::OracleArtifactPattern {
+                type_name,
+                fields,
+                line_info: ctx_for_outer.info(span),
+            }
+        })
+        .boxed()
 }
 
 /// Parses a scroll-shape pattern `[e0, e1, …, ..rest]` for an oracle
@@ -892,8 +976,13 @@ fn scroll_pattern_parser<'src>(
             }
         });
 
+    // Artifact patterns can appear inside scroll patterns
+    // (`[Player { name }, ..rest]` etc.); run before the generic expression
+    // branch so the brace form is destructuring, not an artifact literal.
+    let inner_artifact = artifact_pattern_parser(ctx.clone(), expression.clone());
+
     let inner_expr = expression.map(|(ast, _)| ast);
-    let element = inner_dont_care.or(rest).or(inner_expr);
+    let element = inner_dont_care.or(rest).or(inner_artifact).or(inner_expr);
 
     let ctx_for_outer = ctx;
     just(Token::OpenBracket)

--- a/crates/abyss-core/tests/test_format.rs
+++ b/crates/abyss-core/tests/test_format.rs
@@ -305,6 +305,54 @@ fn format_control_flow_and_functions() {
         oracle_with_scroll_pattern_expected
     );
 
+    let oracle_with_artifact_pattern = AST::Oracle {
+        is_match: true,
+        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+            variable: "__match_0".into(),
+            expression: var("hero"),
+            line_info: None,
+        }],
+        branches: vec![
+            // Shorthand `Player { name }` (one binding, sub-pattern is
+            // `Var(name)` matching the field name).
+            AST::OracleBranch {
+                pattern: vec![AST::OracleArtifactPattern {
+                    type_name: "Player".into(),
+                    fields: vec![("name".into(), AST::Var("name".into(), None))],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(var("name"), None)),
+                line_info: None,
+            },
+            // Explicit field with literal compare and a trailing binding.
+            AST::OracleBranch {
+                pattern: vec![AST::OracleArtifactPattern {
+                    type_name: "Player".into(),
+                    fields: vec![
+                        ("name".into(), AST::Rune("Ardyn".into(), None)),
+                        ("health".into(), AST::Var("health".into(), None)),
+                    ],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(var("health"), None)),
+                line_info: None,
+            },
+        ],
+        line_info: None,
+    };
+    let oracle_with_artifact_pattern_expected = concat!(
+        "oracle (hero) {\n",
+        "    Player { name } => reveal name\n",
+        "    Player { name: \"Ardyn\", health } => reveal health\n",
+        "}"
+    );
+    assert_eq!(
+        format_ast(&oracle_with_artifact_pattern, 0),
+        oracle_with_artifact_pattern_expected
+    );
+
     let orbit = AST::Orbit {
         params: vec![AST::OrbitParam {
             name: "i".into(),

--- a/crates/abyss-interpreter/src/eval/artifacts.rs
+++ b/crates/abyss-interpreter/src/eval/artifacts.rs
@@ -252,7 +252,7 @@ pub(crate) fn collect_field_chain(ast: &AST) -> Option<(String, Vec<String>)> {
     }
 }
 
-fn values_equal(
+pub(crate) fn values_equal(
     env: &RuntimeEnv,
     left: &Value,
     right: &Value,

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -604,6 +604,13 @@ fn evaluate_oracle(
             // outer value, matching the existing aliasing semantics for the
             // `scroll` type elsewhere in the interpreter.
             EvalResult::Data(Value::Scroll(handle)) => Value::Scroll(handle.clone()),
+            // Artifacts (typed records) flow through similarly so an
+            // artifact pattern arm sees the same handle the user passed
+            // in. The `EvalResult::Artifact` variant is also accepted so
+            // the helper can be invoked equally from places that hand
+            // through the dedicated artifact result.
+            EvalResult::Data(Value::Artifact(handle)) => Value::Artifact(handle.clone()),
+            EvalResult::Artifact(handle) => Value::Artifact(handle.clone()),
             other => {
                 return Err(EvalError::InvalidOperation(
                     format!("Unsupported type in oracle scrutinee: {:?}", other),
@@ -722,6 +729,24 @@ fn evaluate_oracle_branch(
             } = pattern_elem
             {
                 if !match_scroll_pattern(elements, scrutinee_value, scroll_line, env)? {
+                    matched = false;
+                    break;
+                }
+                continue;
+            }
+
+            // Artifact-shape pattern destructures the scrutinee — which must
+            // be an artifact of the named type — by pulling out the listed
+            // fields. Fields not listed are not matched against, so partial
+            // patterns like `Player { name }` are valid.
+            if let AST::OracleArtifactPattern {
+                type_name,
+                fields,
+                line_info: artifact_line,
+            } = pattern_elem
+            {
+                if !match_artifact_pattern(type_name, fields, scrutinee_value, artifact_line, env)?
+                {
                     matched = false;
                     break;
                 }
@@ -921,6 +946,15 @@ fn match_scroll_pattern(
                     var_line.clone(),
                 );
             }
+            AST::OracleArtifactPattern {
+                type_name,
+                fields,
+                line_info: artifact_line,
+            } => {
+                if !match_artifact_pattern(type_name, fields, elem_value, artifact_line, env)? {
+                    return Ok(false);
+                }
+            }
             other => {
                 let pattern_result = evaluate(other, env)?;
                 if !values_match_for_pattern(elem_value, &pattern_result, line_info)? {
@@ -945,6 +979,132 @@ fn match_scroll_pattern(
             false,
             rest_line.clone(),
         );
+    }
+
+    Ok(true)
+}
+
+/// Match an artifact-shape pattern against a scrutinee `Value`, performing
+/// any field-level bindings into the caller's scope as side-effects.
+///
+/// Returns `Ok(true)` when the scrutinee is an artifact of the named type
+/// whose listed fields satisfy their sub-patterns (and any bindings have
+/// been applied). Returns `Ok(false)` in two no-match cases:
+///
+/// - the scrutinee is an artifact, but of a different type than the
+///   pattern names — falling through here lets users dispatch by writing
+///   one arm per artifact type;
+/// - the scrutinee is the right artifact type but a field-level
+///   sub-pattern (a literal compare, a nested scroll pattern, etc.) did
+///   not match.
+///
+/// Returns `Err` when the scrutinee is not an artifact at all, when the
+/// pattern's `type_name` is not a defined artifact in scope, or when a
+/// listed field name is not declared on that artifact's schema (in which
+/// case the existing `did_you_mean` infrastructure from PR4-B surfaces a
+/// "did you mean: …" hint via [`super::artifacts::missing_field_error`]).
+///
+/// Fields not mentioned in the pattern are intentionally unrestricted —
+/// the pattern is non-exhaustive, mirroring the per-field "pick what you
+/// need" ergonomics that Rust spells with `..` and OCaml requires
+/// exhaustively. Adding an explicit rest marker can come later if the
+/// distinction proves valuable.
+fn match_artifact_pattern(
+    type_name: &str,
+    fields: &[(String, AST)],
+    scrutinee_value: &Value,
+    line_info: &Option<LineInfo>,
+    env: &mut RuntimeEnv,
+) -> Result<bool, EvalError> {
+    let handle = match scrutinee_value {
+        Value::Artifact(handle) => handle.clone(),
+        _ => {
+            return Err(EvalError::InvalidOperation(
+                format!(
+                    "Artifact pattern requires an artifact scrutinee, found {:?}",
+                    scrutinee_value
+                ),
+                line_info.clone(),
+            ));
+        }
+    };
+
+    if env.get_artifact(type_name).is_none() {
+        return Err(EvalError::InvalidOperation(
+            format!("Artifact pattern references undefined type {}", type_name),
+            line_info.clone(),
+        ));
+    }
+
+    let actual_type = handle.borrow().type_name.clone();
+    if actual_type != type_name {
+        // Different artifact type — fall through so a sibling arm can
+        // dispatch on the actual type (`Player {…} =>` vs `Enemy {…} =>`).
+        return Ok(false);
+    }
+
+    let schema = lookup_schema_from_handle(env, &handle, line_info)?;
+    let schema_field_names: Vec<String> = schema.field_names();
+    let schema_name = schema.name.clone();
+
+    for (field_name, sub_pattern) in fields {
+        if !schema_field_names.iter().any(|n| n == field_name) {
+            return Err(super::artifacts::missing_field_error(
+                env.get_artifact(&schema_name).expect("schema present"),
+                field_name,
+                line_info,
+            ));
+        }
+
+        let field_value = handle
+            .borrow()
+            .fields
+            .get(field_name)
+            .cloned()
+            .expect("schema-validated field must be present in artifact value");
+
+        match sub_pattern {
+            AST::OracleDontCareItem(_) => continue,
+            AST::Var(name, var_line) => {
+                let bound_type = type_of_scrutinee(&field_value);
+                env.set_var(
+                    name.clone(),
+                    field_value,
+                    bound_type,
+                    false,
+                    var_line.clone(),
+                );
+            }
+            AST::OracleScrollPattern {
+                elements,
+                line_info: scroll_line,
+            } => {
+                if !match_scroll_pattern(elements, &field_value, scroll_line, env)? {
+                    return Ok(false);
+                }
+            }
+            AST::OracleArtifactPattern {
+                type_name: nested_type,
+                fields: nested_fields,
+                line_info: nested_line,
+            } => {
+                if !match_artifact_pattern(
+                    nested_type,
+                    nested_fields,
+                    &field_value,
+                    nested_line,
+                    env,
+                )? {
+                    return Ok(false);
+                }
+            }
+            other => {
+                let pattern_result = evaluate(other, env)?;
+                if !values_match_for_pattern(&field_value, &pattern_result, line_info)? {
+                    return Ok(false);
+                }
+            }
+        }
     }
 
     Ok(true)

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -5,7 +5,8 @@ use std::rc::Rc;
 
 use super::artifacts::{
     build_artifact_schema, collect_field_chain, ensure_field_exists, ensure_type_known,
-    expect_artifact_handle, lookup_schema_from_handle, missing_field_error,
+    expect_artifact_handle, lookup_schema_from_handle, missing_field_error, read_artifact_field,
+    values_equal,
 };
 use super::collections::{collect_index_chain, expect_arcana_index, expect_rune_key};
 use super::expressions::try_evaluate_expression;
@@ -1056,12 +1057,12 @@ fn match_artifact_pattern(
             ));
         }
 
-        let field_value = handle
-            .borrow()
-            .fields
-            .get(field_name)
-            .cloned()
-            .expect("schema-validated field must be present in artifact value");
+        // `read_artifact_field` re-validates the field against the schema and
+        // returns a recoverable `EvalError` if the runtime value is missing
+        // the field for any reason — preferable to the previous
+        // `expect("schema-validated field must be present in artifact value")`
+        // panic if a future malformed artifact slips through.
+        let field_value = read_artifact_field(env, &handle, field_name, line_info)?;
 
         match sub_pattern {
             AST::OracleDontCareItem(_) => continue,
@@ -1099,8 +1100,25 @@ fn match_artifact_pattern(
                 }
             }
             other => {
+                // For literal-compare on an artifact field we want a deep,
+                // type-aware equality so nested scrolls / lexicons / artifacts
+                // compare by structure (matching the existing `==` semantics
+                // in `eval/artifacts::values_equal`). The scroll-specific
+                // `values_match_for_pattern` would only handle scalars and
+                // emit a misleading "Scroll pattern element" error for any
+                // non-scalar field.
                 let pattern_result = evaluate(other, env)?;
-                if !values_match_for_pattern(&field_value, &pattern_result, line_info)? {
+                let pattern_value = match pattern_result {
+                    EvalResult::Data(value) => value,
+                    EvalResult::Artifact(handle) => Value::Artifact(handle),
+                    EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
+                        return Err(EvalError::InvalidOperation(
+                            "Artifact field pattern compare must yield a value".to_string(),
+                            line_info.clone(),
+                        ));
+                    }
+                };
+                if !values_equal(env, &field_value, &pattern_value, line_info)? {
                     return Ok(false);
                 }
             }

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -668,6 +668,56 @@ fn test_oracle_artifact_pattern_against_non_artifact_errors() {
 }
 
 #[test]
+fn test_oracle_artifact_pattern_nested_artifact_and_scroll() {
+    // Field values may themselves be destructuring patterns (scroll
+    // head/tail, nested artifact). All bindings flow into the same
+    // per-branch scope and are visible in the body.
+    let input = r#"
+    artifact Inventory { items: scroll; gold: arcana; };
+    artifact Player { name: rune; bag: Inventory; };
+    forge inv: Inventory = Inventory { items: ["sword", "shield"], gold: 50 };
+    forge hero: Player = Player { name: "Ardyn", bag: inv };
+    forge label: rune = oracle (hero) {
+        Player { name, bag: Inventory { items: [first, ..rest], gold } } =>
+            reveal(name + " carries " + first + " and " + gold.trans(rune) + " gold");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => {
+            // 4 forges + 1 expression statement
+            assert!(matches!(
+                &results[5],
+                EvalResult::Data(Value::Rune(s))
+                    if s.as_ref() == "Ardyn carries sword and 50 gold"
+            ));
+        }
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_empty_fields_matches_by_type() {
+    // `Tag {}` matches any artifact of type `Tag` regardless of field
+    // values — useful for type-only dispatch.
+    let input = r#"
+    artifact Tag { value: arcana; };
+    forge t: Tag = Tag { value: 7 };
+    forge label: rune = oracle (t) {
+        Tag {} => reveal("a tag");
+        _ => reveal("other");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[3], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "a tag")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -518,6 +518,156 @@ fn test_oracle_scroll_pattern_against_non_scroll_scrutinee_errors() {
 }
 
 #[test]
+fn test_oracle_artifact_pattern_shorthand_binds_each_field() {
+    // `Player { name, health }` shorthand binds both fields by their
+    // declared names.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge hero: Player = Player { name: "Ardyn", health: 100 };
+    forge result: arcana = oracle (hero) {
+        Player { name, health } => reveal(health);
+    };
+    result;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[3], EvalResult::Data(Value::Arcana(100)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_partial_field_list() {
+    // Listing only some fields is allowed — the pattern is non-exhaustive
+    // by default, so `Player { name }` matches without mentioning `health`.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge hero: Player = Player { name: "Ardyn", health: 100 };
+    forge greeting: rune = oracle (hero) {
+        Player { name } => reveal("hello, " + name);
+    };
+    greeting;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[3], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "hello, Ardyn")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_literal_field_value() {
+    // Explicit `field_name: <expr>` compares the field by value rather
+    // than binding it; the binding next to it still captures.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge hero: Player = Player { name: "Ardyn", health: 100 };
+    forge label: rune = oracle (hero) {
+        Player { name: "Ardyn", health } => reveal("chosen, hp=" + health.trans(rune));
+        Player { name } => reveal("someone: " + name);
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[3], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "chosen, hp=100")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_dispatches_on_type() {
+    // Wrong artifact type falls through so sibling arms can match.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    artifact Enemy { name: rune; damage: arcana; };
+    forge foe: Enemy = Enemy { name: "Goblin", damage: 7 };
+    forge label: rune = oracle (foe) {
+        Player { name } => reveal("hero " + name);
+        Enemy { name, damage } => reveal("foe " + name + " (" + damage.trans(rune) + ")");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[4], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "foe Goblin (7)")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_binding_visible_in_ward() {
+    // Bindings introduced by an artifact pattern are visible to the same
+    // arm's ward expression.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge weak: Player = Player { name: "Frail", health: 20 };
+    forge label: rune = oracle (weak) {
+        Player { name, health } ward health < 50 => reveal("run, " + name + "!");
+        Player { name } => reveal("hello, " + name);
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[3], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "run, Frail!")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_unknown_field_errors_with_hint() {
+    // A misspelled field surfaces the existing PR4-B did-you-mean hint via
+    // `missing_field_error`.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge hero: Player = Player { name: "Ardyn", health: 100 };
+    oracle (hero) {
+        Player { helt } => reveal("never");
+    };
+    "#;
+    match test_base(input) {
+        Ok(results) => panic!("expected unknown-field error, got {:?}", results),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Field 'helt'") && msg.contains("did you mean: health"),
+                "unexpected error: {}",
+                msg
+            )
+        }
+    }
+}
+
+#[test]
+fn test_oracle_artifact_pattern_against_non_artifact_errors() {
+    // A non-artifact scrutinee is a clear programmer mistake and surfaces
+    // a runtime error rather than silently falling through.
+    let input = r#"
+    artifact Player { name: rune; health: arcana; };
+    forge n: arcana = 5;
+    oracle (n) {
+        Player { name } => reveal("never");
+        _ => reveal("never either");
+    };
+    "#;
+    match test_base(input) {
+        Ok(results) => panic!("expected non-artifact scrutinee error, got {:?}", results),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Artifact pattern requires an artifact scrutinee"),
+                "unexpected error: {}",
+                msg
+            )
+        }
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;


### PR DESCRIPTION
## Summary

Fourth piece of the v0.5.0 Pattern Matching Enhancements cycle. After PR #414 (`ward`), PR #417 (bindings), and PR #420 (scroll destructuring), oracle match arms can now destructure an artifact scrutinee:

```aby
artifact Player { name: rune; health: arcana; };
forge hero: Player = Player { name: \"Ardyn\", health: 100 };
oracle (hero) {
    Player { name, health } ward health < 50 => warn(name);
    Player { name }                          => greet(name);
};
```

Each field entry is:

- `field_name` — shorthand binding (field value bound to a fresh variable named after the field).
- `field_name: _` — explicit wildcard.
- `field_name: ident` — explicit binding to a different name.
- `field_name: <expr>` — literal compare against the field value.

Fields not listed are not matched against — the pattern is **non-exhaustive by default**, so users pick out only the fields they care about. No `..` is required.

## Type dispatch

When the scrutinee is an artifact whose type does not match the pattern's `type_name`, the arm falls through and a sibling arm with the right type can fire:

```aby
forge foe: Enemy = Enemy { name: \"Goblin\", damage: 7 };
oracle (foe) {
    Player { name } => unveil(\"hero \" + name);          // skipped
    Enemy { name, damage } => unveil(\"foe \" + name);   // fires
};
```

Errors are raised only when the scrutinee is not an artifact at all, the pattern's `type_name` is undefined, or a listed field name is not declared on the schema. The unknown-field path reuses PR4-B's `missing_field_error`, so the existing did-you-mean hint composes for free:

```
Field 'helt' (did you mean: health?) does not exist on artifact Player (available: [name, health])
```

## Concrete changes

- **AST**: new `OracleArtifactPattern { type_name, fields: Vec<(String, AST)> }` variant. Field entries are `(name, sub_pattern)`; shorthand `{ name }` is parsed as `(\"name\", Var(\"name\"))` so the evaluator's existing `Var`-as-binding path applies uniformly.
- **Parser**: `artifact_pattern_parser` parses `TypeName { … }` and is wired into `pattern_parser` (top-level), `pattern_element_parser` (tuple position), and `scroll_pattern_parser` (scroll element position). Must run before the generic expression branch so `Player { name }` becomes a destructuring pattern rather than the artifact literal it would be in expression position.
- **Evaluator**: new `match_artifact_pattern` helper following the same `Ok(true) / Ok(false) / Err` shape as `match_scroll_pattern`. Returns `Ok(false)` when the scrutinee is an artifact of a different type (allowing sibling-arm dispatch); raises errors for non-artifact scrutinee, undefined pattern type, or unknown field. The oracle scrutinee setup now also accepts `Value::Artifact` (and the `EvalResult::Artifact` variant) so artifact values can flow through.
- **Formatter**: renders `OracleArtifactPattern` as `Type { … }`, detects the shorthand case where the sub-pattern is a `Var` with the same name as the field and emits just the field name. The top-level pattern recogniser leaves single-artifact-pattern arms without re-wrapping in `(…)` (same as the scroll case).

## Tests

- **7 new integration tests** in `test_oracle.rs` (oracle suite is now **33 tests**):
  - shorthand `Player { name, health }` binding
  - partial field lists (`Player { name }` ignores `health`)
  - literal field compares (`Player { name: \"Ardyn\", health }`)
  - type dispatch (`Player {…}` falls through, `Enemy {…}` fires)
  - binding visible to `ward`
  - unknown-field did-you-mean error
  - non-artifact scrutinee error
- **New formatter test** asserts shorthand and explicit-form artifact patterns round-trip cleanly.

## Test plan

- [x] \`cargo test --workspace\` — 33 oracle integration tests pass; library suite remains green (109 tests including the existing scope-leak regression).
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Manual smoke (`/tmp/artifact_smoke.aby`, `/tmp/artifact_errors.aby`) covers: shorthand binding, ward + binding, literal compare, type dispatch via fall-through, undefined-pattern-type error, did-you-mean hint on field typo.
- [ ] CI green on this PR.

## Out of scope (deferred to subsequent PRs in the v0.5.0 cycle)

- Lexicon key destructuring `{ \"name\": n }` (PR5).
- VS Code TextMate grammar update + Starlight reference page (batched in the cycle's docs/tooling PR once all four match-arm pieces are in).
- An explicit `..` rest marker for artifact patterns (current default is non-exhaustive without one).