### PR TITLE
feat(parser+eval): lexicon key destructuring patterns for oracle match arms

### DIFF
--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -92,6 +92,16 @@ pub enum AST {
         fields: Vec<(String, AST)>,
         line_info: Option<LineInfo>,
     },
+    /// Lexicon-shape pattern that matches a `{ "key": value, … }`
+    /// scrutinee. Each `(key, sub_pattern)` entry pulls the named entry
+    /// out of the lexicon and matches it against `sub_pattern`. Keys not
+    /// listed here are not matched against — the pattern is
+    /// non-exhaustive by default, mirroring the artifact pattern's
+    /// "pick what you need" ergonomics.
+    OracleLexiconPattern {
+        entries: Vec<(String, AST)>,
+        line_info: Option<LineInfo>,
+    },
     Block(Vec<AST>, Option<LineInfo>),
     Comment(String, Option<LineInfo>),
     Orbit {

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -228,7 +228,8 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                     let pattern_text = match pattern.as_slice() {
                         [] => "_".to_string(),
                         [only @ AST::OracleScrollPattern { .. }]
-                        | [only @ AST::OracleArtifactPattern { .. }] => {
+                        | [only @ AST::OracleArtifactPattern { .. }]
+                        | [only @ AST::OracleLexiconPattern { .. }] => {
                             format_ast(only, indent_level + 1)
                         }
                         elems => {
@@ -291,6 +292,19 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("{} {{ {} }}", type_name, inner)
+            }
+        }
+        AST::OracleLexiconPattern { entries, .. } => {
+            if entries.is_empty() {
+                // `{}` matches any lexicon (the "by shape" catch-all).
+                "{}".to_string()
+            } else {
+                let inner = entries
+                    .iter()
+                    .map(|(key, sub)| format!("\"{}\": {}", key, format_ast(sub, indent_level)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{{ {} }}", inner)
             }
         }
         AST::Orbit { params, body, .. } => {

--- a/crates/abyss-core/src/parser/grammar.rs
+++ b/crates/abyss-core/src/parser/grammar.rs
@@ -846,12 +846,32 @@ fn pattern_parser<'src>(
     // wrapping logic as `scroll`. The recursive `pattern_element` lets each
     // field value itself be a nested scroll / artifact / wildcard pattern.
     let artifact =
-        artifact_pattern_parser(ctx, pattern_element, expression).map_with(|ast, extra| {
+        artifact_pattern_parser(ctx.clone(), pattern_element.clone(), expression.clone()).map_with(
+            |ast, extra| {
+                let span: SimpleSpan<usize> =
+                    SimpleSpan::new(extra.span().start(), extra.span().end());
+                (vec![ast], span)
+            },
+        );
+
+    // A lexicon pattern `{ "key": value, … }` at the top of an arm — same
+    // shape wrapping logic. Distinguished from artifact pattern by the
+    // absence of a leading identifier, and from a generic block `{ stmt; }`
+    // by the rune-literal-and-colon entries. Each value uses the recursive
+    // `pattern_element`, so nested patterns work the same way as inside
+    // artifact patterns.
+    let lexicon =
+        lexicon_pattern_parser(ctx, pattern_element, expression).map_with(|ast, extra| {
             let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
             (vec![ast], span)
         });
 
-    wildcard.or(list).or(scroll).or(artifact).boxed()
+    wildcard
+        .or(list)
+        .or(scroll)
+        .or(artifact)
+        .or(lexicon)
+        .boxed()
 }
 
 fn pattern_element_parser<'src>(
@@ -872,11 +892,24 @@ fn pattern_element_parser<'src>(
         // Run before the generic expression branch so `Player { … }` is
         // parsed as a destructuring pattern rather than the artifact literal
         // it would be in expression position.
-        let artifact = artifact_pattern_parser(ctx.clone(), pattern_elem_boxed, expression.clone());
+        let artifact =
+            artifact_pattern_parser(ctx.clone(), pattern_elem_boxed.clone(), expression.clone());
+        // Lexicon pattern shares the brace token but starts directly with a
+        // rune-literal key followed by `:`, which neither an empty block
+        // nor an artifact literal (which needs a leading identifier) can
+        // start with. Run before the expression branch so `{ "k": v }` in
+        // pattern position becomes a destructuring pattern rather than the
+        // map literal it would otherwise be.
+        let lexicon = lexicon_pattern_parser(ctx.clone(), pattern_elem_boxed, expression.clone());
 
         let expr = expression.clone().map(|(ast, _)| ast);
 
-        dont_care.or(scroll).or(artifact).or(expr).boxed()
+        dont_care
+            .or(scroll)
+            .or(artifact)
+            .or(lexicon)
+            .or(expr)
+            .boxed()
     })
     .boxed()
 }
@@ -941,6 +974,49 @@ fn artifact_pattern_parser<'src>(
             AST::OracleArtifactPattern {
                 type_name,
                 fields,
+                line_info: ctx_for_outer.info(span),
+            }
+        })
+        .boxed()
+}
+
+/// Parses a lexicon-shape pattern `{ "k0": v0, "k1": v1, … }` for an
+/// oracle match-mode arm. Each entry's value is a recursive pattern
+/// element (binding, wildcard, nested scroll/artifact pattern, literal
+/// expression). Keys not listed here are not matched against — the pattern
+/// is non-exhaustive by default, mirroring the artifact pattern's
+/// "pick what you need" ergonomics.
+///
+/// Empty `{}` matches any lexicon (a "match by shape" catch-all), reusing
+/// the same brace tokens as the lexicon literal it would be in expression
+/// position. Disambiguation: the parser tries this before the generic
+/// expression branch in `pattern_element_parser`, so the brace form in
+/// pattern position is a destructuring pattern rather than the map literal.
+fn lexicon_pattern_parser<'src>(
+    ctx: ParserContext,
+    pattern_element: BoxedParser<'src, AST>,
+    _expression: BoxedParser<'src, SpannedAst>,
+) -> BoxedParser<'src, AST> {
+    let entry = select! { Token::Rune(key) => key }
+        .map_with(|key, extra| (key, extra.span()))
+        .then_ignore(just(Token::Colon))
+        .then(pattern_element)
+        .map(|((key, _), value)| (key, value));
+
+    let ctx_for_outer = ctx;
+    just(Token::OpenBrace)
+        .map_with(|_, extra| extra.span())
+        .then(
+            entry
+                .separated_by(just(Token::Comma))
+                .allow_trailing()
+                .collect::<Vec<_>>(),
+        )
+        .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
+        .map(move |((open_span, entries), close_span)| {
+            let span = SimpleSpan::new(open_span.start(), close_span.end());
+            AST::OracleLexiconPattern {
+                entries,
                 line_info: ctx_for_outer.info(span),
             }
         })

--- a/crates/abyss-core/tests/test_format.rs
+++ b/crates/abyss-core/tests/test_format.rs
@@ -353,6 +353,51 @@ fn format_control_flow_and_functions() {
         oracle_with_artifact_pattern_expected
     );
 
+    let oracle_with_lexicon_pattern = AST::Oracle {
+        is_match: true,
+        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+            variable: "__match_0".into(),
+            expression: var("config"),
+            line_info: None,
+        }],
+        branches: vec![
+            // Empty `{}` — matches any lexicon.
+            AST::OracleBranch {
+                pattern: vec![AST::OracleLexiconPattern {
+                    entries: vec![],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(rune("a lexicon"), None)),
+                line_info: None,
+            },
+            // Two-key shape with a binding and a literal compare.
+            AST::OracleBranch {
+                pattern: vec![AST::OracleLexiconPattern {
+                    entries: vec![
+                        ("name".into(), AST::Var("n".into(), None)),
+                        ("port".into(), AST::Arcana(8080, None)),
+                    ],
+                    line_info: None,
+                }],
+                guard: None,
+                body: Box::new(AST::Reveal(var("n"), None)),
+                line_info: None,
+            },
+        ],
+        line_info: None,
+    };
+    let oracle_with_lexicon_pattern_expected = concat!(
+        "oracle (config) {\n",
+        "    {} => reveal \"a lexicon\"\n",
+        "    { \"name\": n, \"port\": 8080 } => reveal n\n",
+        "}"
+    );
+    assert_eq!(
+        format_ast(&oracle_with_lexicon_pattern, 0),
+        oracle_with_lexicon_pattern_expected
+    );
+
     let orbit = AST::Orbit {
         params: vec![AST::OrbitParam {
             name: "i".into(),

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -612,6 +612,11 @@ fn evaluate_oracle(
             // through the dedicated artifact result.
             EvalResult::Data(Value::Artifact(handle)) => Value::Artifact(handle.clone()),
             EvalResult::Artifact(handle) => Value::Artifact(handle.clone()),
+            // Lexicons flow through as their shared handle so a lexicon
+            // pattern arm sees the same entries the user passed in. Mutating
+            // the lexicon inside the arm body therefore visibly mutates the
+            // outer value, matching the existing aliasing semantics.
+            EvalResult::Data(Value::Lexicon(handle)) => Value::Lexicon(handle.clone()),
             other => {
                 return Err(EvalError::InvalidOperation(
                     format!("Unsupported type in oracle scrutinee: {:?}", other),
@@ -748,6 +753,22 @@ fn evaluate_oracle_branch(
             {
                 if !match_artifact_pattern(type_name, fields, scrutinee_value, artifact_line, env)?
                 {
+                    matched = false;
+                    break;
+                }
+                continue;
+            }
+
+            // Lexicon-shape pattern destructures the scrutinee — which must
+            // be a `lexicon` — by pulling out the listed keys. Keys not
+            // listed are not matched against, so partial patterns like
+            // `{ "name": n }` are valid; an absent key falls through.
+            if let AST::OracleLexiconPattern {
+                entries,
+                line_info: lexicon_line,
+            } = pattern_elem
+            {
+                if !match_lexicon_pattern(entries, scrutinee_value, lexicon_line, env)? {
                     matched = false;
                     break;
                 }
@@ -956,6 +977,14 @@ fn match_scroll_pattern(
                     return Ok(false);
                 }
             }
+            AST::OracleLexiconPattern {
+                entries,
+                line_info: lexicon_line,
+            } => {
+                if !match_lexicon_pattern(entries, elem_value, lexicon_line, env)? {
+                    return Ok(false);
+                }
+            }
             other => {
                 let pattern_result = evaluate(other, env)?;
                 if !values_match_for_pattern(elem_value, &pattern_result, line_info)? {
@@ -1099,6 +1128,14 @@ fn match_artifact_pattern(
                     return Ok(false);
                 }
             }
+            AST::OracleLexiconPattern {
+                entries: nested_entries,
+                line_info: nested_line,
+            } => {
+                if !match_lexicon_pattern(nested_entries, &field_value, nested_line, env)? {
+                    return Ok(false);
+                }
+            }
             other => {
                 // For literal-compare on an artifact field we want a deep,
                 // type-aware equality so nested scrolls / lexicons / artifacts
@@ -1119,6 +1156,120 @@ fn match_artifact_pattern(
                     }
                 };
                 if !values_equal(env, &field_value, &pattern_value, line_info)? {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}
+
+/// Match a lexicon-shape pattern against a scrutinee `Value`, performing
+/// any entry-level bindings into the caller's scope as side-effects.
+///
+/// Returns `Ok(true)` when the scrutinee is a lexicon whose listed entries
+/// satisfy their sub-patterns (and any bindings have been applied).
+/// Returns `Ok(false)` in two no-match cases:
+///
+/// - the scrutinee is a lexicon that lacks one of the listed keys —
+///   missing keys are not an error, they just disqualify this arm so
+///   sibling arms with different shapes can match;
+/// - the scrutinee is a lexicon with all listed keys present but a
+///   sub-pattern (literal compare, nested scroll/artifact/lexicon
+///   pattern, etc.) does not match.
+///
+/// Returns `Err` when the scrutinee is not a lexicon at all. Empty
+/// `{}` matches any lexicon (a "match by shape" catch-all), the same way
+/// `Tag {}` matches any artifact of type `Tag`. Keys not mentioned in the
+/// pattern are intentionally unrestricted.
+fn match_lexicon_pattern(
+    entries: &[(String, AST)],
+    scrutinee_value: &Value,
+    line_info: &Option<LineInfo>,
+    env: &mut RuntimeEnv,
+) -> Result<bool, EvalError> {
+    let lexicon_handle = match scrutinee_value {
+        Value::Lexicon(handle) => handle.clone(),
+        _ => {
+            return Err(EvalError::InvalidOperation(
+                format!(
+                    "Lexicon pattern requires a lexicon scrutinee, found {:?}",
+                    scrutinee_value
+                ),
+                line_info.clone(),
+            ));
+        }
+    };
+
+    for (key, sub_pattern) in entries {
+        // Snapshot the value out of the lexicon so we are not holding a
+        // borrow across the recursive `match_*` calls (which themselves
+        // may borrow the same handle, e.g. for nested lexicon patterns).
+        let entry_value = match lexicon_handle.borrow().get(key).cloned() {
+            Some(value) => value,
+            None => return Ok(false),
+        };
+
+        match sub_pattern {
+            AST::OracleDontCareItem(_) => continue,
+            AST::Var(name, var_line) => {
+                let bound_type = type_of_scrutinee(&entry_value);
+                env.set_var(
+                    name.clone(),
+                    entry_value,
+                    bound_type,
+                    false,
+                    var_line.clone(),
+                );
+            }
+            AST::OracleScrollPattern {
+                elements,
+                line_info: scroll_line,
+            } => {
+                if !match_scroll_pattern(elements, &entry_value, scroll_line, env)? {
+                    return Ok(false);
+                }
+            }
+            AST::OracleArtifactPattern {
+                type_name: nested_type,
+                fields: nested_fields,
+                line_info: nested_line,
+            } => {
+                if !match_artifact_pattern(
+                    nested_type,
+                    nested_fields,
+                    &entry_value,
+                    nested_line,
+                    env,
+                )? {
+                    return Ok(false);
+                }
+            }
+            AST::OracleLexiconPattern {
+                entries: nested_entries,
+                line_info: nested_line,
+            } => {
+                if !match_lexicon_pattern(nested_entries, &entry_value, nested_line, env)? {
+                    return Ok(false);
+                }
+            }
+            other => {
+                // Same deep-equality strategy as `match_artifact_pattern`'s
+                // literal-compare path so non-scalar entry values compare
+                // structurally and match the runtime `==` semantics.
+                let pattern_result = evaluate(other, env)?;
+                let pattern_value = match pattern_result {
+                    EvalResult::Data(value) => value,
+                    EvalResult::Artifact(handle) => Value::Artifact(handle),
+                    EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
+                        return Err(EvalError::InvalidOperation(
+                            "Lexicon entry pattern compare must yield a value".to_string(),
+                            line_info.clone(),
+                        ));
+                    }
+                };
+                if !values_equal(env, &entry_value, &pattern_value, line_info)? {
                     return Ok(false);
                 }
             }

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -718,6 +718,137 @@ fn test_oracle_artifact_pattern_empty_fields_matches_by_type() {
 }
 
 #[test]
+fn test_oracle_lexicon_pattern_binds_listed_keys() {
+    // Listing keys with bindings pulls each value out and binds it for
+    // the body, similar to artifact patterns but keyed by rune literals.
+    let input = r#"
+    forge config: lexicon = { "name": "Ardyn", "port": 8080 };
+    forge label: rune = oracle (config) {
+        { "name": n, "port": p } => reveal(n + "@" + p.trans(rune));
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "Ardyn@8080")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_lexicon_pattern_literal_value_compare() {
+    // Explicit `key: <expr>` compares the entry by value; a binding next
+    // to it still captures.
+    let input = r#"
+    forge config: lexicon = { "name": "Ardyn", "active": boon };
+    forge label: rune = oracle (config) {
+        { "name": "Ardyn", "active": boon } => reveal("the chosen one is online");
+        _ => reveal("someone else");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(
+            &results[2],
+            EvalResult::Data(Value::Rune(s))
+                if s.as_ref() == "the chosen one is online"
+        )),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_lexicon_pattern_falls_through_on_missing_key() {
+    // A pattern that lists a key absent from the scrutinee falls through
+    // so a sibling arm with a smaller key set can match. Compatible with
+    // the artifact pattern's "non-exhaustive by default" ergonomics.
+    let input = r#"
+    forge solo: lexicon = { "name": "alone" };
+    forge label: rune = oracle (solo) {
+        { "name": n, "port": p } => reveal("got both");
+        { "name": n } => reveal("just name: " + n);
+        _ => reveal("none");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "just name: alone")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_lexicon_pattern_empty_matches_any_lexicon() {
+    // `{}` is the catch-all "match any lexicon" form, mirroring `Tag {}`
+    // for artifacts. Useful at the end of a lexicon-dispatch chain.
+    let input = r#"
+    forge anything: lexicon = { "x": 1, "y": 2 };
+    forge label: rune = oracle (anything) {
+        {} => reveal("a lexicon");
+        _ => reveal("other");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(
+            matches!(&results[2], EvalResult::Data(Value::Rune(s)) if s.as_ref() == "a lexicon")
+        ),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
+fn test_oracle_lexicon_pattern_against_non_lexicon_errors() {
+    // A non-lexicon scrutinee surfaces a runtime error rather than
+    // silently falling through, matching the artifact pattern's
+    // type-mismatch behaviour.
+    let input = r#"
+    forge n: arcana = 5;
+    oracle (n) {
+        { "key": v } => reveal("never");
+        _ => reveal("never either");
+    };
+    "#;
+    match test_base(input) {
+        Ok(results) => panic!("expected non-lexicon scrutinee error, got {:?}", results),
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            assert!(
+                msg.contains("Lexicon pattern requires a lexicon scrutinee"),
+                "unexpected error: {}",
+                msg
+            )
+        }
+    }
+}
+
+#[test]
+fn test_oracle_lexicon_pattern_nested_value_destructure() {
+    // Lexicon entries can themselves be nested patterns — here the
+    // "items" entry is destructured as a scroll head/tail and the
+    // bindings flow into the same arm scope.
+    let input = r#"
+    forge bag: lexicon = { "name": "satchel", "items": ["sword", "shield", "rune"] };
+    forge label: rune = oracle (bag) {
+        { "name": n, "items": [first, ..rest] } =>
+            reveal(n + " holds " + first + " plus " + rest.tally().trans(rune) + " more");
+    };
+    label;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(
+            &results[2],
+            EvalResult::Data(Value::Rune(s))
+                if s.as_ref() == "satchel holds sword plus 2 more"
+        )),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;


### PR DESCRIPTION
## Summary

Fifth piece of the v0.5.0 Pattern Matching Enhancements cycle. Oracle match arms can now destructure a `lexicon` scrutinee:

```aby
forge config: lexicon = { \"name\": \"Ardyn\", \"port\": 8080, \"active\": boon };
oracle (config) {
    { \"name\": \"Ardyn\", \"active\": boon } => unveil(\"the chosen one online\");
    { \"name\": n, \"port\": p }            => unveil(n + \"@\" + p.trans(rune));
    {}                                       => unveil(\"any other lexicon\");
};
```

Each entry is `\"key\": <pattern>` where the value can be a binding, wildcard, nested scroll/artifact/lexicon pattern, or literal expression. **Keys not listed are not matched** (non-exhaustive by default, mirroring artifact patterns). A missing key **falls through** so sibling arms with different key sets can match. Empty `{}` matches any lexicon — the catch-all form, parallel to `Tag {}` for artifacts.

## Concrete changes

- **AST**: new `OracleLexiconPattern { entries: Vec<(String, AST)> }` variant.
- **Parser**: `lexicon_pattern_parser` parses `{ \"k\": v, … }`. Wired into `pattern_parser` (top-level) and the recursive `pattern_element_parser` (nested). Disambiguation: a rune-literal key followed by `:` cannot start a generic block or an artifact literal, so the brace form in pattern position is unambiguously a lexicon pattern.
- **Evaluator**: new `match_lexicon_pattern` helper following the same `Ok(true) / Ok(false) / Err` shape as `match_artifact_pattern`. Missing keys fall through; only a non-lexicon scrutinee raises `Lexicon pattern requires a lexicon scrutinee`. Sub-patterns recurse through `match_scroll_pattern` / `match_artifact_pattern` / `match_lexicon_pattern` / `values_equal`. The oracle scrutinee setup now also accepts `Value::Lexicon` (handle flows through by `clone()` to preserve aliasing).
- `match_scroll_pattern` and `match_artifact_pattern` both gained an `OracleLexiconPattern` arm in their sub-pattern dispatch, so a lexicon pattern can sit inside any other destructuring form (`[{ \"id\": id }, ..rest]`, `Player { bag: { \"items\": items } }`).
- **Formatter**: renders `OracleLexiconPattern` as `{ \"k\": v, … }`, empty case as `{}`. Top-level pattern recogniser leaves single-lexicon-pattern arms without re-wrapping in `(…)`.

## Tests

- **6 new integration tests** in `test_oracle.rs` (oracle suite is now **41 tests**):
  - shorthand binding for two keys
  - literal value compare on a key (composed with an omen literal)
  - missing-key fall-through to a sibling arm
  - empty `{}` matches any lexicon
  - non-lexicon scrutinee surfaces a runtime error
  - nested value destructuring (`{ \"items\": [head, ..tail] }`)
- **New formatter test** asserts empty-form and two-key-form lexicon patterns round-trip cleanly.

## Test plan

- [x] \`cargo test --workspace\` — 41 oracle tests pass; library suite remains green.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Manual smoke (\`/tmp/lexicon_smoke.aby\`) covers all scenarios above and prints the expected outputs end-to-end.
- [x] Formatter round-trip via \`cargo run -p abyss-lang -- align /tmp/lexicon_smoke.aby\` reproduces the source.
- [ ] CI green on this PR.

## Cycle progress

This completes the **language-side** of v0.5.0 Pattern Matching Enhancements. Remaining work in the cycle:

- **Docs / tooling PR** — VS Code TextMate grammar update + Starlight reference page covering all five match-arm pieces (`ward`, bindings, scroll, artifact, lexicon).
- **Release PR** — version bump 0.4.1 → 0.5.0 + develop→main promotion to fire `release.yml`.