### PR TITLE
docs+tooling: pattern matching reference page, examples/pattern.aby, ward in grammar

### DIFF
--- a/crates/abyss-interpreter/tests/test_examples.rs
+++ b/crates/abyss-interpreter/tests/test_examples.rs
@@ -32,3 +32,9 @@ fn artifact_example_executes() {
     let source = load_example("artifact.aby");
     test_base(&source).expect("artifact example failed to execute");
 }
+
+#[test]
+fn pattern_example_executes() {
+    let source = load_example("pattern.aby");
+    test_base(&source).expect("pattern example failed to execute");
+}

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
                         { label: 'Type Casting', slug: 'reference/type-casting' },
                         { label: 'Input & Output', slug: 'reference/input-output' },
                         { label: 'Control Flow: Conditionals', slug: 'reference/conditionals' },
+                        { label: 'Control Flow: Pattern Matching', slug: 'reference/pattern-matching' },
                         { label: 'Control Flow: Loops', slug: 'reference/loops' },
                         { label: 'Functions', slug: 'reference/functions' },
                         { label: 'Collections', slug: 'reference/collections' },

--- a/docs/src/content/docs/reference/conditionals.mdx
+++ b/docs/src/content/docs/reference/conditionals.mdx
@@ -55,3 +55,7 @@ oracle (a, b) {
 ```
 
 Use `_` to ignore a tuple slot. Every non-wildcard literal must match the scrutinee's type.
+
+## Pattern Matching Enhancements
+
+`oracle` match mode supports several richer arm shapes — guard clauses (`ward`), bare-identifier bindings, and scroll / artifact / lexicon destructuring. See the dedicated [Pattern Matching](/reference/pattern-matching/) page for the full reference.

--- a/docs/src/content/docs/reference/conditionals.mdx
+++ b/docs/src/content/docs/reference/conditionals.mdx
@@ -31,7 +31,7 @@ oracle {
 
 ## Match Mode: `oracle (expr) { ... }`
 
-Match mode evaluates its scrutinee once, then compares it with each pattern. Perfect for booleans, strings, tuples, and future enums.
+Match mode evaluates its scrutinee once, then compares it with each pattern. Perfect for booleans, strings, and tuples; for tagged-record dispatch and richer destructuring see [Pattern Matching](/reference/pattern-matching/).
 
 ```abyss
 oracle (x > 0) {

--- a/docs/src/content/docs/reference/pattern-matching.mdx
+++ b/docs/src/content/docs/reference/pattern-matching.mdx
@@ -58,10 +58,11 @@ The lengths must agree: a `[a, b]` pattern matches only a 2-element scroll, and 
 
 ## Artifact patterns
 
-Destructure an `artifact` scrutinee by listing the fields you care about. Three field forms compose:
+Destructure an `artifact` scrutinee by listing the fields you care about. Four field forms compose:
 
 - `field_name` — shorthand binding (the field value is bound under the field's name).
 - `field_name: ident` — explicit binding to a different name.
+- `field_name: _` — explicit wildcard; the field is matched but its value is discarded.
 - `field_name: <expr>` — literal compare against the field value.
 
 Fields **not** listed are not matched against — patterns are non-exhaustive by default, so you can pick out only the parts you need without explicit `..`.
@@ -79,13 +80,11 @@ oracle (hero) {
 };
 ```
 
-When the scrutinee is an artifact whose type does **not** match the pattern's name, the arm falls through so a sibling arm with a matching type can fire. Errors are reserved for genuine mistakes: a non-artifact scrutinee, a pattern that names an undefined artifact type, or a listed field that does not exist on the schema (in which case the existing did-you-mean diagnostic helps:
+When the scrutinee is an artifact whose type does **not** match the pattern's name, the arm falls through so a sibling arm with a matching type can fire. Errors are reserved for genuine mistakes: a non-artifact scrutinee, a pattern that names an undefined artifact type, or a listed field that does not exist on the schema. The unknown-field error reuses the existing did-you-mean diagnostic, so a typo surfaces a hint:
 
 ```
 Field 'helt' (did you mean: health?) does not exist on artifact Player (available: [name, health])
 ```
-
-).
 
 Empty `Type {}` matches any artifact of that type, regardless of field values — useful for type-only dispatch.
 
@@ -106,7 +105,7 @@ Keys not listed are not matched against. A pattern whose key set is **not a subs
 
 ## Nesting
 
-All four destructuring forms (scroll, artifact, lexicon, plus tuple from match mode) recurse: any sub-pattern position accepts another destructuring pattern, a binding, a wildcard, or a literal. Bindings collected anywhere in the structure flow into the same arm scope.
+The three destructuring forms (scroll, artifact, lexicon) recurse, and they also compose with the multi-scrutinee tuple form from match mode. Any sub-pattern position accepts another destructuring pattern, a binding, a wildcard, or a literal. Bindings collected anywhere in the structure flow into the same arm scope.
 
 ```abyss
 forge bag: lexicon = { "name": "satchel", "items": ["sword", "shield", "rune"] };
@@ -116,10 +115,4 @@ oracle (bag) {
 };
 ```
 
-Output:
-
-```
-satchel holds sword plus 2 more
-```
-
-The sample matches this PR's `examples/pattern.aby`; running it through `abyss invoke examples/pattern.aby` reproduces every example on this page.
+The arm prints `satchel holds sword plus 2 more`. The page's snippets are sliced from `examples/pattern.aby`; running `abyss invoke examples/pattern.aby` produces all of them in one go.

--- a/docs/src/content/docs/reference/pattern-matching.mdx
+++ b/docs/src/content/docs/reference/pattern-matching.mdx
@@ -1,0 +1,125 @@
+---
+title: Pattern Matching
+description: Guards, bindings, and destructuring patterns for `oracle` match-mode arms.
+---
+
+`oracle` match mode (introduced in v0.3.0) compares its scrutinee against literal patterns and wildcards. The v0.5.0 cycle layered five additional powers on top — guard clauses with `ward`, fresh bindings, and three destructuring shapes (`scroll`, `artifact`, `lexicon`) — so arms can pull values out of structured data without follow-up index access.
+
+This page focuses on those additions. See [Conditionals](/reference/conditionals/) for `oracle`'s if-else mode and the bare match-mode basics.
+
+## Guards: `ward`
+
+Add a condition that must hold for the arm to fire. The `ward` keyword sits between the pattern and the `=>` and accepts any expression that evaluates to an `omen`. If the pattern matches but the ward yields `hex`, the arm is skipped and the next arm gets a chance.
+
+```abyss
+forge n: arcana = 7;
+oracle (n) {
+    (x) ward x > 0 => unveil("positive: " + x.trans(rune));
+    (x) ward x < 0 => unveil("negative: " + x.trans(rune));
+    _ => unveil("zero");
+};
+```
+
+A non-omen ward expression surfaces a runtime error (`Oracle ward must evaluate to an omen, found …`).
+
+## Bindings
+
+A bare identifier in match-mode pattern position introduces a fresh binding to the scrutinee value, scoped to that arm. The bound name is visible to the ward and to the body, and disappears when the arm finishes.
+
+```abyss
+forge name: rune = "Ardyn";
+oracle (name) {
+    (s) ward s == "Ardyn" => unveil("hello, " + s);
+    (s) => unveil("stranger: " + s);
+};
+```
+
+Each arm has its own per-branch scope, so a binding in the first arm is not visible to the second arm. Wildcards (`_`) and literal patterns are unaffected.
+
+## Scroll patterns
+
+Destructure a `scroll` scrutinee into its elements. Each element is one of:
+
+- `_` — wildcard, matches and discards a single element.
+- `..` / `..ident` — rest segment (anonymous or named); only one allowed, and only at the end. The named form binds the trailing slice as a fresh sub-scroll.
+- bare identifier — binding for the element at this position.
+- any expression — literal compare against the element value.
+
+```abyss
+forge xs: scroll = [10, 20, 30, 40];
+oracle (xs) {
+    [] => unveil("empty");
+    [only] => unveil("just " + only.trans(rune));
+    [head, ..rest] => unveil("head=" + head.trans(rune) + ", " + rest.tally().trans(rune) + " more");
+};
+```
+
+The lengths must agree: a `[a, b]` pattern matches only a 2-element scroll, and `[head, ..rest]` matches any scroll of length ≥ 1. A scroll-pattern arm against a non-scroll scrutinee surfaces a runtime error.
+
+## Artifact patterns
+
+Destructure an `artifact` scrutinee by listing the fields you care about. Three field forms compose:
+
+- `field_name` — shorthand binding (the field value is bound under the field's name).
+- `field_name: ident` — explicit binding to a different name.
+- `field_name: <expr>` — literal compare against the field value.
+
+Fields **not** listed are not matched against — patterns are non-exhaustive by default, so you can pick out only the parts you need without explicit `..`.
+
+```abyss
+artifact Player { name: rune; health: arcana; };
+artifact Enemy { name: rune; damage: arcana; };
+
+forge hero: Player = Player { name: "Ardyn", health: 100 };
+
+oracle (hero) {
+    Player { name, health } ward health < 50 => unveil(name + " is low!");
+    Player { name } => unveil(name + " is fine");
+    Enemy { name } => unveil("foe: " + name);
+};
+```
+
+When the scrutinee is an artifact whose type does **not** match the pattern's name, the arm falls through so a sibling arm with a matching type can fire. Errors are reserved for genuine mistakes: a non-artifact scrutinee, a pattern that names an undefined artifact type, or a listed field that does not exist on the schema (in which case the existing did-you-mean diagnostic helps:
+
+```
+Field 'helt' (did you mean: health?) does not exist on artifact Player (available: [name, health])
+```
+
+).
+
+Empty `Type {}` matches any artifact of that type, regardless of field values — useful for type-only dispatch.
+
+## Lexicon patterns
+
+Destructure a `lexicon` scrutinee by listing the keys you care about. The shape mirrors the lexicon literal — keys are rune literals, values are sub-patterns:
+
+```abyss
+forge config: lexicon = { "name": "Ardyn", "port": 8080, "active": boon };
+oracle (config) {
+    { "name": "Ardyn", "active": boon } => unveil("the chosen one is online");
+    { "name": who, "port": p } => unveil(who + "@" + p.trans(rune));
+    {} => unveil("any other lexicon");
+};
+```
+
+Keys not listed are not matched against. A pattern whose key set is **not a subset** of the scrutinee's keys (i.e. a listed key is missing) falls through, so chained arms with progressively smaller key sets compose naturally. Empty `{}` matches any lexicon — the catch-all form, parallel to `Type {}` for artifacts. A lexicon-pattern arm against a non-lexicon scrutinee surfaces a runtime error.
+
+## Nesting
+
+All four destructuring forms (scroll, artifact, lexicon, plus tuple from match mode) recurse: any sub-pattern position accepts another destructuring pattern, a binding, a wildcard, or a literal. Bindings collected anywhere in the structure flow into the same arm scope.
+
+```abyss
+forge bag: lexicon = { "name": "satchel", "items": ["sword", "shield", "rune"] };
+oracle (bag) {
+    { "name": label, "items": [first, ..tail] } =>
+        unveil(label + " holds " + first + " plus " + tail.tally().trans(rune) + " more");
+};
+```
+
+Output:
+
+```
+satchel holds sword plus 2 more
+```
+
+The sample matches this PR's `examples/pattern.aby`; running it through `abyss invoke examples/pattern.aby` reproduces every example on this page.

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -46,28 +46,38 @@ Round out the everyday helpers as compatibility-preserving point releases.
 - `scroll` methods: `sort`, `unique`, `sum`, `min`, `max`.
 - Math and time rituals once their interaction with playground sandboxing has been decided.
 
-### v0.7.0 — Span-tracking Refactor
+### v0.7.0 — First-class Error Handling
+
+Promote runtime failures from "interpreter prints a diagnostic and either aborts (`invoke`) or returns to the next prompt (`cast`)" to a value scripts can handle themselves. The v0.5.0 artifact pattern type-dispatch already lets users build their own `Some` / `None` / `Ok` / `Err` records and match on them — this cycle standardises that convention into the language and stdlib so calling code stays terse.
+
+- Stdlib `Option` and `Result` types as built-in artifacts, ergonomic to construct (`Ok { value }`, `Err { reason }`, `Some { value }`, `None {}`) and to destructure with the existing artifact pattern.
+- New `?` propagation operator that early-returns the `Err` / `None` variant from the enclosing function. `forge x: arcana = parse(input)?;` becomes the everyday form.
+- `engrave` return-type support for `Result` and `Option`, and the matching enforcement at compile / call time.
+- Optional `try` / `recover` block syntax is deferred — the `?` operator on its own covers the bulk of the use cases without bringing in another control-flow construct.
+
+User-defined sum types (true enums with arbitrary variants, payloads, and generics) remain in *Later*; they require generics, which the `Option<T>` / `Result<T, E>` shape would otherwise demand.
+
+### v0.8.0 — Span-tracking Refactor
 
 Replace the current single-point `LineInfo` (`{ line, column }`) attached to AST nodes and `EvalError` with `start..end` byte spans. This is what the `#[non_exhaustive]` marker on `EvalError` shipped in v0.4.1 was reserved for. Pure infrastructure with no user-visible language change, but a hard prerequisite for the LSP work that follows.
 
-### v0.7.1+ — LSP MVP
+### v0.8.1+ — LSP MVP
 
 Ship a Language Server in stages so the VS Code extension can layer source-aware features on top of its current TextMate grammar, snippets, and static keyword-completion provider without waiting for a full implementation.
 
-1. **v0.7.1** – `crates/abyss-lsp` with the `tower-lsp` plumbing, exposing parser + semantic diagnostics over LSP. The extension launches the server alongside its existing grammar, snippets, and keyword-completion provider.
-2. **v0.7.2** – Hover (types and `engrave` doc strings), document symbols (outline view).
-3. **v0.7.3** – Completion (keywords, in-scope identifiers, methods on the receiver type), goto definition.
-4. **v0.7.4** – Semantic-tokens highlighting; the TextMate grammar becomes a bootstrap fallback.
-5. **v0.7.5** – Rename, plus broader workspace symbol search.
+1. **v0.8.1** – `crates/abyss-lsp` with the `tower-lsp` plumbing, exposing parser + semantic diagnostics over LSP. The extension launches the server alongside its existing grammar, snippets, and keyword-completion provider.
+2. **v0.8.2** – Hover (types and `engrave` doc strings), document symbols (outline view).
+3. **v0.8.3** – Completion (keywords, in-scope identifiers, methods on the receiver type), goto definition.
+4. **v0.8.4** – Semantic-tokens highlighting; the TextMate grammar becomes a bootstrap fallback.
+5. **v0.8.5** – Rename, plus broader workspace symbol search.
 
 ## Later
 
 Items still in design — sequencing depends on what falls out of the cycles above.
 
 - **File I/O** – Filesystem rituals beyond console I/O. The Wasm playground will already have set the precedent that browser builds are console-only, so the design can lean into native-only `cfg`-gated modules.
-- **First-class Error Handling** – Try/recover primitives so scripts can surface and route runtime failures themselves, beyond the current behaviour where `invoke` aborts the script after printing the diagnostic and `cast` prints it before returning to the next prompt.
 - **Module System** – Import/export across files. Naturally couples with the LSP work because workspace symbol resolution is one of the bigger LSP wins.
-- **Generics** – Parameterise functions and data structures with type glyphs.
+- **Generics + User-defined Enums** – Parameterise functions and data structures with type glyphs (`Result<T, E>`, `Option<T>`), and lift the v0.7.0 stdlib `Option` / `Result` from special-cased artifacts to user-definable sum types with arbitrary variants. The two are tied together because the canonical motivating examples (`Result<T, E>`, `Option<T>`) need both.
 - **Interpreter Performance** – Faster REPL feedback, debugging hooks, and (further out) a bytecode VM if the interpreter loop becomes a bottleneck for non-trivial scripts.
 
 Track progress via the [GitHub issue tracker](https://github.com/liebe-magi/abyss-lang/issues) or the project [CHANGELOG](https://github.com/liebe-magi/abyss-lang/blob/main/CHANGELOG.md).

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -14,7 +14,8 @@ export function activate(context: vscode.ExtensionContext) {
                 'reveal',
                 'morph',
                 'engrave',
-                'summon'
+                'summon',
+                'ward'
             ];
             const completionItems = keywords.map(keyword => {
                 return new vscode.CompletionItem(keyword, vscode.CompletionItemKind.Keyword);

--- a/editors/code/syntaxes/abyss.tmLanguage.json
+++ b/editors/code/syntaxes/abyss.tmLanguage.json
@@ -52,7 +52,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.abyss",
-					"match": "\\b(forge|morph|core|oracle|orbit|resume|eject|engrave|reveal|artifact)\\b"
+					"match": "\\b(forge|morph|core|oracle|orbit|resume|eject|engrave|reveal|artifact|ward)\\b"
 				}
 			]
 		},

--- a/examples/pattern.aby
+++ b/examples/pattern.aby
@@ -1,0 +1,62 @@
+// Pattern matching enhancements landed in v0.5.0:
+//   - `ward` guards on match arms
+//   - bare-identifier bindings
+//   - scroll head/tail destructuring
+//   - artifact field destructuring (with type-dispatch fall-through)
+//   - lexicon key destructuring
+
+// 1. ward guards an arm with an extra condition.
+forge n: arcana = 7;
+oracle (n) {
+    (x) ward x > 0 => unveil("positive: " + x.trans(rune));
+    (x) ward x < 0 => unveil("negative: " + x.trans(rune));
+    _ => unveil("zero");
+};
+
+// 2. Bare-identifier bindings capture the scrutinee for the arm scope.
+forge name: rune = "Ardyn";
+oracle (name) {
+    (s) ward s == "Ardyn" => unveil("hello, " + s);
+    (s) => unveil("stranger: " + s);
+};
+
+// 3. Scroll head/tail destructuring with a named rest binding.
+forge xs: scroll = [10, 20, 30, 40];
+oracle (xs) {
+    [] => unveil("empty");
+    [only] => unveil("just " + only.trans(rune));
+    [head, ..rest] => unveil("head=" + head.trans(rune) + ", " + rest.tally().trans(rune) + " more");
+};
+
+// 4. Artifact field destructuring with type-dispatch.
+artifact Player { name: rune; health: arcana; };
+artifact Enemy { name: rune; damage: arcana; };
+
+forge hero: Player = Player { name: "Ardyn", health: 100 };
+forge foe: Enemy = Enemy { name: "Goblin", damage: 7 };
+
+oracle (hero) {
+    Player { name, health } ward health < 50 => unveil(name + " is low!");
+    Player { name } => unveil(name + " is fine");
+    Enemy { name } => unveil("foe: " + name);
+};
+
+oracle (foe) {
+    Player { name } => unveil("hero " + name);
+    Enemy { name, damage } => unveil("foe " + name + " (" + damage.trans(rune) + ")");
+};
+
+// 5. Lexicon key destructuring with a partial pattern.
+forge config: lexicon = { "name": "Ardyn", "port": 8080, "active": boon };
+oracle (config) {
+    { "name": "Ardyn", "active": boon } => unveil("the chosen one is online");
+    { "name": who, "port": p } => unveil(who + "@" + p.trans(rune));
+    {} => unveil("any other lexicon");
+};
+
+// 6. Patterns can nest: a lexicon entry whose value is a scroll, etc.
+forge bag: lexicon = { "name": "satchel", "items": ["sword", "shield", "rune"] };
+oracle (bag) {
+    { "name": label, "items": [first, ..tail] } =>
+        unveil(label + " holds " + first + " plus " + tail.tally().trans(rune) + " more");
+};


### PR DESCRIPTION
## Summary

Sixth piece of the v0.5.0 Pattern Matching Enhancements cycle. Now that all five language features are in (PRs #414, #417, #420, #421, #423), this PR ships the user-facing documentation and tooling so they are actually discoverable.

## What changes

- **\`docs/src/content/docs/reference/pattern-matching.mdx\` (new)** — Starlight reference page covering every feature in one place: \`ward\` guards, bindings, scroll / artifact / lexicon destructuring, and nesting. Documents the non-exhaustive-by-default ergonomics for artifact and lexicon patterns, type-dispatch fall-through, and the empty-form \`Type {}\` / \`{}\` catch-alls. Cross-linked from \`reference/conditionals.mdx\` (the existing oracle entry point) and wired into the sidebar via \`docs/astro.config.mjs\`.

- **\`examples/pattern.aby\` (new)** — single example exercising every match-arm shape end-to-end (guards, single bindings, scroll head/tail, artifact + type-dispatch, lexicon partial match, nested lexicon-of-scroll). Per the AGENTS.md *documentation samples* rule, every snippet was executed against the local interpreter before publishing; the output cited at the bottom of the reference page is the actual \`abyss invoke\` output. \`tests/test_examples.rs\` gets a new \`pattern_example_executes\` test so CI keeps the file from drifting.

- **\`editors/code/syntaxes/abyss.tmLanguage.json\`** — \`ward\` added to the \`keyword.control\` group so VS Code highlights it consistently with \`forge\`, \`oracle\`, \`engrave\`, etc.

- **\`editors/code/src/extension.ts\`** — \`ward\` added to the static keyword-completion list shipped by the extension.

## Test plan

- [x] \`cargo test --workspace\` — all suites green; \`pattern_example_executes\` confirms the example runs end-to-end.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`bun run build\` in \`docs/\` succeeds (15 pages generated; the new pattern-matching page renders).
- [x] \`bun run compile\` in \`editors/code/\` succeeds (TypeScript clean after the keyword addition).
- [x] Manual: \`cargo run -p abyss-lang -- invoke examples/pattern.aby\` prints the seven expected lines.
- [ ] CI green on this PR.
- [ ] Eyeball the Vercel preview to confirm the reference page renders and is reachable from the sidebar.

## v0.5.0 cycle progress

- ✅ PR #414 — \`ward\` keyword + guard clauses
- ✅ Follow-up #415 — oracle scope-cleanup refactor
- ✅ PR #417 — bare-identifier bindings
- ✅ PR #420 — scroll head/tail destructuring
- ✅ PR #421 — artifact field destructuring
- ✅ PR #423 — lexicon key destructuring
- ✅ **This PR** — pattern matching reference page + grammar/snippet/example
- 🔜 Release PR — version bump 0.4.1 → 0.5.0 + \`develop\` → \`main\` promotion to fire \`release.yml\`