### PR TITLE
chore(release): bump workspace and extension to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-06
+
+A pattern-matching milestone. The `oracle` match-mode arms grew five new powers — guard clauses with `ward`, fresh bindings, and three destructuring shapes (`scroll`, `artifact`, `lexicon`) — composing freely so a single arm can pull values out of nested structured data without follow-up index access. The cycle is intentionally additive: every script that compiled on 0.4.1 keeps compiling.
+
+### Added
+
+- **`ward` keyword for guard clauses** ([#414](https://github.com/liebe-magi/abyss-lang/pull/414)) — `(x) ward x > 0 => …` lets a match arm carry an extra condition that must hold for the arm to fire. The arm's pattern is evaluated as before, and the ward expression is only evaluated if the pattern matched. A non-omen ward expression surfaces a runtime error (`Oracle ward must evaluate to an omen, found …`).
+- **Bare-identifier bindings in match-mode patterns** ([#417](https://github.com/liebe-magi/abyss-lang/pull/417)) — a bare identifier in a match-mode pattern position introduces a fresh binding to the scrutinee value, scoped to that arm. Visible in the ward expression and the body, gone when the arm finishes. Wildcards (`_`) and literal patterns are unaffected; if-else mode still treats bare identifiers as boolean expressions.
+- **Scroll head/tail destructuring** ([#420](https://github.com/liebe-magi/abyss-lang/pull/420)) — `[head, ..rest]`, `[a, b]`, `[]`, `[..]`, `[..rest]` shapes against scroll scrutinees, with element-level bindings, wildcards, literal compares, and a named or anonymous trailing rest segment that captures the unmatched tail as a fresh sub-scroll.
+- **Artifact field destructuring** ([#421](https://github.com/liebe-magi/abyss-lang/pull/421)) — `Player { name, health }` (shorthand binding), `Player { name: "Ardyn", health }` (literal compare + binding), `Player { name: _ }` (explicit wildcard), and the empty `Type {}` for type-only dispatch. Pattern types fall through when the scrutinee is the wrong artifact type so sibling arms can dispatch by type. Unknown field names raise the existing "did you mean?" hint via `missing_field_error`.
+- **Lexicon key destructuring** ([#423](https://github.com/liebe-magi/abyss-lang/pull/423)) — `{ "name": n, "port": p }`, partial key sets, literal compares, and the empty `{}` for "any lexicon". Listed keys not present in the scrutinee fall through so chained arms with progressively smaller key sets compose naturally.
+- **Pattern Matching reference page + `examples/pattern.aby`** ([#424](https://github.com/liebe-magi/abyss-lang/pull/424)) — dedicated [Pattern Matching](https://abyss-lang.dev/reference/pattern-matching/) page covering all five features in one place, plus a single example file exercising every match-arm shape end-to-end. The example is locked down by `tests/test_examples.rs::pattern_example_executes`.
+- **Roadmap published with v0.5–v0.8 plan** ([#412](https://github.com/liebe-magi/abyss-lang/pull/412)) — the [Roadmap](https://abyss-lang.dev/roadmap/) replaces the previous topic-grouped wishlist with an ordered Release Plan: v0.5 Pattern Matching, v0.6 Web Playground & Wasm, v0.6.x Standard Library Growth, v0.7 First-class Error Handling (Option / Result + `?` operator), v0.8 Span-tracking Refactor, v0.8.1+ LSP MVP. Generics + user-defined enums sit in *Later*, tied together because their canonical motivating examples need both.
+
+### Changed
+
+- **Oracle evaluator refactored for scope cleanup** ([#415](https://github.com/liebe-magi/abyss-lang/pull/415)) — the `AST::Oracle` arm now pushes its scope, delegates to a `evaluate_oracle` helper that uses `?` freely, and pops on every exit (including error paths). Previously five hand-written `env.pop_scope(); return Err(...)` branches were prone to drift; consolidating them removes a real scope-leak class observable in the REPL after a runtime error inside an oracle.
+- **`AST::Var` in match-mode pattern position now binds rather than looks up** ([#417](https://github.com/liebe-magi/abyss-lang/pull/417)) — semantically additive on the example surface (no existing script in the repository used a bare identifier as a match-mode pattern), but worth noting because users wanting to compare against an existing variable's value should now use a ward, e.g. `(any) ward any == existing_var =>`.
+- **VS Code TextMate grammar and keyword completion gain `ward`** ([#424](https://github.com/liebe-magi/abyss-lang/pull/424)) — highlighted in the same `keyword.control` group as `forge` / `oracle` / `engrave` and offered by the static keyword-completion provider.
+- **`reference/conditionals.mdx`** ([#412](https://github.com/liebe-magi/abyss-lang/pull/412), [#424](https://github.com/liebe-magi/abyss-lang/pull/424)) — the bare match-mode summary now points readers at the dedicated Pattern Matching page for the richer arm shapes; the stale "future enums" reference was dropped because v0.5.0's artifact-pattern type-dispatch already covers the original use case.
+
+### Fixed
+
+- **CHANGELOG forge example was syntactically invalid AbySS** ([#411](https://github.com/liebe-magi/abyss-lang/pull/411)) — the v0.4.1 entry illustrated the new "did you mean?" hint with `forge x = 1;`, which actually fails at parse time because `forge` requires an explicit type annotation. Corrected to `forge x: arcana = 1;` and added an `AGENTS.md` rule mandating that every AbySS snippet in user-facing text be executed against the local interpreter before publishing.
+
+For the full diff including Renovate-driven dependency-lock-file updates, see the [GitHub compare v0.4.1...v0.5.0](https://github.com/liebe-magi/abyss-lang/compare/v0.4.1...v0.5.0).
+
 ## [0.4.1] - 2026-05-03
 
 A diagnostics-polish release. Runtime errors now render through the same `ariadne` reporter the parser already uses, and three new "did you mean?" / "available alternatives" hint paths fire when AbySS programs reference identifiers, artifact fields, or methods that nearly match a known name. **Language semantics are unchanged from 0.4.0**; existing scripts continue to work without modification.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-interpreter"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "abyss-core",
  "ariadne",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-lang"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/abyss-core", "crates/abyss-interpreter", "crates/abyss-cli"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/liebe-magi/abyss-lang"
 homepage = "https://abyss-lang.dev"
 
 [workspace.dependencies]
-abyss-core = { path = "crates/abyss-core", version = "0.4.1" }
-abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.4.1" }
+abyss-core = { path = "crates/abyss-core", version = "0.5.0" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.5.0" }
 
 [workspace.metadata.release]
 shared-version = true

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [v0.5.0] - 2026-05-06
+
+### Added
+
+- New `ward` keyword in the `keyword.control` highlight group, matching the syntax landed in the `abyss-lang` crate's pattern-matching cycle. The static keyword-completion provider also offers `ward` so it auto-completes alongside `forge`, `oracle`, `engrave`, etc.
+
+### Changed
+
+- Bumped the extension version to 0.5.0 to stay in lockstep with the `abyss-lang` crate. The 0.5.0 cycle introduces guard clauses (`ward`), bare-identifier bindings, and scroll / artifact / lexicon destructuring patterns; these are all expressed with existing tokens (parentheses, brackets, braces, commas, colons, the new `ward` keyword) so the TextMate grammar additions stay minimal.
+
 ## [v0.4.1] - 2026-05-03
 
 ### Changed

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -30,6 +30,12 @@ None at the moment. Please report any issues via GitHub.
 
 ## Release Notes
 
+### 0.5.0
+
+- Version bumped to track `abyss-lang` 0.5.0, the Pattern Matching Enhancements milestone (`ward` guards, bare-identifier bindings, and scroll / artifact / lexicon destructuring on `oracle` match arms).
+- TextMate grammar gains the `ward` keyword in the same highlight group as `forge` / `oracle` / `engrave`. The destructuring patterns reuse existing tokens (`[ ]`, `{ }`, `:`, `,`) so no further grammar work was needed.
+- Static keyword-completion provider offers `ward` alongside the existing keywords.
+
 ### 0.4.1
 
 - Version bumped to track `abyss-lang` 0.4.1, a diagnostics-polish release ("did you mean?" hints for undefined identifiers, available-alternatives hints for missing artifact fields and methods, and ariadne-rendered runtime errors). No grammar changes since 0.4.0 — existing snippets and completions continue to cover the current language surface.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-codex-familiar",
   "displayName": "AbySS Codex Familiar",
   "description": "Custom syntax highlighting for the AbySS programming language.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "publisher": "liebe-magi",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Lockstep version bump for the **v0.5.0 Pattern Matching Enhancements** milestone. Workspace, intra-workspace dependency pins, the VS Code extension \`package.json\`, and both CHANGELOGs / extension \`README.md\` move from \`0.4.1\` to \`0.5.0\` together — \`scripts/check_version_sync.py\` enforces this.

## What landed in v0.5.0

The cycle layered five new powers on top of \`oracle\` match-mode arms:

- **\`ward\` guard clauses** ([#414](https://github.com/liebe-magi/abyss-lang/pull/414)) — \`(x) ward x > 0 => …\`
- **Bare-identifier bindings** ([#417](https://github.com/liebe-magi/abyss-lang/pull/417)) — \`(x) =>\` binds the scrutinee
- **Scroll destructuring** ([#420](https://github.com/liebe-magi/abyss-lang/pull/420)) — \`[head, ..rest]\` / \`[a, b]\` / \`[]\`
- **Artifact destructuring with type-dispatch** ([#421](https://github.com/liebe-magi/abyss-lang/pull/421)) — \`Player { name, health }\`, fall-through on wrong type
- **Lexicon destructuring** ([#423](https://github.com/liebe-magi/abyss-lang/pull/423)) — \`{ \"name\": n, \"port\": p }\`, missing-key fall-through

Plus the supporting work:

- **Oracle scope-cleanup refactor** ([#415](https://github.com/liebe-magi/abyss-lang/pull/415)) so error paths inside oracle never leak scopes.
- **Pattern Matching reference page + \`examples/pattern.aby\`** ([#424](https://github.com/liebe-magi/abyss-lang/pull/424)).
- **\`ward\` in TextMate grammar + keyword completion** ([#424](https://github.com/liebe-magi/abyss-lang/pull/424)).
- **Roadmap refresh** ([#412](https://github.com/liebe-magi/abyss-lang/pull/412), [#424](https://github.com/liebe-magi/abyss-lang/pull/424)) — v0.5–v0.8 plan with First-class Error Handling now slotted at v0.7.0.

The cycle is purely additive on the language side; every script that compiled on 0.4.1 keeps compiling. The one observable semantics change — bare identifiers in match-mode patterns now bind rather than look up — does not affect any existing script in the repo (no current example or test used a bare identifier in match-mode pattern position).

## What happens after this merges

This PR only lands the version bump on \`develop\`. A subsequent \`Release v0.5.0\` PR (\`develop → main\`, no additional code) will promote the bumped tree to \`main\` and trigger \`.github/workflows/release.yml\`, which:

1. Detects \`0.4.1 → 0.5.0\` in the root \`Cargo.toml\`.
2. Re-runs the test suite, creates the \`v0.5.0\` tag, drafts a GitHub release with auto-generated notes, attaches per-target binary archives.
3. Publishes \`abyss-core\` → \`abyss-interpreter\` → \`abyss-lang\` to crates.io with index-propagation sleeps.
4. Publishes the VS Code extension to the Marketplace.

## Verification on this branch

- [x] \`cargo check --workspace\` clean; \`Cargo.lock\` updated.
- [x] \`cargo test --workspace\` — all suites green (parser + interpreter + integration; oracle suite is now 41 tests).
- [x] \`python3 scripts/check_version_sync.py\` — \`0.5.0 / 0.5.0\` match, workspace dependency versions aligned.
- [x] \`bun run build\` in \`docs/\` succeeds (15 pages including the new Pattern Matching reference).
- [x] Pre-commit hooks: \`bun run compile\` and \`check version sync\` both passed.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, open the \`Release v0.5.0\` promotion PR.