### PR TITLE
fix(eval): recurse into nested scroll patterns inside scroll patterns

### DIFF
--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -968,6 +968,14 @@ fn match_scroll_pattern(
                     var_line.clone(),
                 );
             }
+            AST::OracleScrollPattern {
+                elements: nested_elements,
+                line_info: nested_line,
+            } => {
+                if !match_scroll_pattern(nested_elements, elem_value, nested_line, env)? {
+                    return Ok(false);
+                }
+            }
             AST::OracleArtifactPattern {
                 type_name,
                 fields,

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -849,6 +849,29 @@ fn test_oracle_lexicon_pattern_nested_value_destructure() {
 }
 
 #[test]
+fn test_oracle_nested_scroll_pattern_inside_scroll() {
+    // Regression: `match_scroll_pattern` previously only handled
+    // `OracleArtifactPattern` and `OracleLexiconPattern` as element
+    // sub-patterns, so `[[a, b], [c, d]]` (a scroll pattern as an element
+    // of another scroll pattern) fell into the generic-expression path
+    // and raised `Unsupported operation: OracleScrollPattern { … }`
+    // instead of recursing. Add an explicit `OracleScrollPattern` arm
+    // alongside the artifact/lexicon ones so nesting actually works,
+    // matching the page's "patterns can nest" claim.
+    let input = r#"
+    forge xss: scroll = [[1, 2], [3, 4]];
+    forge sum: arcana = oracle (xss) {
+        [[a, b], [c, d]] => reveal(a + b + c + d);
+    };
+    sum;
+    "#;
+    match test_base(input) {
+        Ok(results) => assert!(matches!(results[2], EvalResult::Data(Value::Arcana(10)))),
+        Err(e) => panic!("Error: {:?}", e),
+    }
+}
+
+#[test]
 fn test_oracle_with_block_and_reveal() {
     let input = r#"
     forge x: arcana = -10;


### PR DESCRIPTION
## Summary

PR review on the v0.5.0 release PR (#427) caught a real bug. \`match_scroll_pattern\` only had explicit arms for \`OracleArtifactPattern\` and \`OracleLexiconPattern\` as element sub-patterns, so a scroll pattern **inside** another scroll pattern fell into the generic-expression fallback and raised \`Unsupported operation: OracleScrollPattern { … }\` at runtime instead of recursing:

```aby
forge xss: scroll = [[1, 2], [3, 4]];
oracle (xss) {
    [[a, b], [c, d]] => unveil(a + b + c + d);   // 💥 was: Unsupported operation: OracleScrollPattern { … }
};
```

This broke the docs' "patterns can nest" claim that PR4 documented, and that \`match_artifact_pattern\` / \`match_lexicon_pattern\` already honoured for the symmetric cases (lexicon-of-scroll, artifact-of-scroll, etc.). The fix is one new arm in \`match_scroll_pattern\` that delegates back to itself, mirroring how the other two helpers handle their nested forms.

## What changes

- \`match_scroll_pattern\` gains an explicit \`AST::OracleScrollPattern\` arm in its element sub-pattern dispatch, recursing via \`match_scroll_pattern\` so nested scroll patterns actually destructure rather than fall into the literal-compare path.

## Tests

- Regression test \`test_oracle_nested_scroll_pattern_inside_scroll\` matches \`[[a, b], [c, d]]\` against \`[[1, 2], [3, 4]]\` and asserts \`a + b + c + d == 10\`. Oracle suite is now 42 tests.

## Test plan

- [x] \`cargo test --workspace\` — all suites green.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Manual: \`forge xss: scroll = [[1, 2], [3, 4]]; oracle (xss) { [[a, b], [c, d]] => reveal(a); };\` now binds \`a = 1\` (was a runtime error before this fix).
- [ ] CI green on this PR.

## Release plan

This lands on \`develop\` ahead of the v0.5.0 release PR (#427). Once this is merged, #427 picks the fix up automatically (since #427 is \`develop → main\`).