### PR TITLE
feat(diag): string-returning renderer API for parser and runtime errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,32 @@ jobs:
       - name: Run cargo check
         run: cargo check
 
+  wasm-check:
+    # Locks down wasm-readiness for the v0.6.0 Web Playground cycle:
+    # `abyss-core` and `abyss-interpreter` must keep building for
+    # `wasm32-unknown-unknown` (the future `crates/abyss-wasm` adapter
+    # depends on this, and the playground feature would silently break
+    # if a new dependency or `cfg` choice broke wasm support). The CLI
+    # crate (`abyss-lang`) is excluded — it pulls in `rustyline` /
+    # `dirs` / `colored` which are CLI-only and intentionally not
+    # wasm-compatible.
+    name: Wasm Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-04
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run cargo check (wasm32-unknown-unknown)
+        run: cargo check --target wasm32-unknown-unknown -p abyss-core -p abyss-interpreter
+
   version-check:
     name: Version Check
     runs-on: ubuntu-latest

--- a/crates/abyss-core/src/parser/diagnostics.rs
+++ b/crates/abyss-core/src/parser/diagnostics.rs
@@ -63,10 +63,14 @@ pub fn emit_diagnostics(
     source: &str,
     diagnostics: &[ParserDiagnostic],
 ) -> Result<(), std::io::Error> {
-    let rendered = render_diagnostics(source_id, source, diagnostics)?;
+    // Stream the report directly to a locked stdout handle — no
+    // intermediate `String` allocation. `write_diagnostics` is the shared
+    // core that `render_diagnostics` also uses with a `Vec<u8>` writer.
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    write_diagnostics(source_id, source, diagnostics, &mut handle)?;
     use std::io::Write;
-    std::io::stdout().write_all(rendered.as_bytes())?;
-    std::io::stdout().flush()
+    handle.flush()
 }
 
 /// Render parser diagnostics as a single string instead of writing to
@@ -74,14 +78,32 @@ pub fn emit_diagnostics(
 /// codes and all) that [`emit_diagnostics`] would print, so consumers
 /// running on a non-CLI surface — Wasm playground, future LSP, embedded
 /// REPL — can capture and post-process the bytes themselves (strip ANSI,
-/// translate to HTML, etc.). The CLI renders via [`emit_diagnostics`],
-/// which is now a thin wrapper around this function.
+/// translate to HTML, etc.).
 pub fn render_diagnostics(
     source_id: &str,
     source: &str,
     diagnostics: &[ParserDiagnostic],
 ) -> Result<String, std::io::Error> {
     let mut buffer: Vec<u8> = Vec::new();
+    write_diagnostics(source_id, source, diagnostics, &mut buffer)?;
+    // ariadne writes valid UTF-8 (it formats `&str` content), so the
+    // conversion is infallible in practice; surface the (impossible)
+    // error as a `std::io::Error` to match the stdout path's signature.
+    String::from_utf8(buffer)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+}
+
+/// Shared implementation for both [`emit_diagnostics`] (stdout) and
+/// [`render_diagnostics`] (`Vec<u8>`). Writes each diagnostic as an
+/// `ariadne` report directly into the supplied writer — the CLI path
+/// streams to a locked stdout handle without buffering, while the
+/// string-returning path streams into a `Vec<u8>` and converts.
+fn write_diagnostics<W: std::io::Write>(
+    source_id: &str,
+    source: &str,
+    diagnostics: &[ParserDiagnostic],
+    writer: &mut W,
+) -> Result<(), std::io::Error> {
     for diagnostic in diagnostics {
         let span_range = diagnostic.span.into_range();
         let mut report = Report::build(ReportKind::Error, (source_id, span_range.clone()))
@@ -98,11 +120,53 @@ pub fn render_diagnostics(
 
         report
             .finish()
-            .write((source_id, Source::from(source)), &mut buffer)?;
+            .write((source_id, Source::from(source)), &mut *writer)?;
     }
-    // ariadne writes valid UTF-8 (it formats `&str` content), so the
-    // conversion is infallible in practice; surface the (impossible)
-    // error as a `std::io::Error` to match the stdout path's signature.
-    String::from_utf8(buffer)
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_diagnostics_returns_ariadne_report_for_each_entry() {
+        // Locks down the public renderer's contract for the future Wasm
+        // playground / LSP consumers: it produces non-empty output that
+        // mentions the title, label, and help text from each diagnostic.
+        let source = "forge x = 1;";
+        let diagnostics = vec![ParserDiagnostic {
+            title: "Spell error: Incantation failed".into(),
+            label: "Unexpected token `=`".into(),
+            span: SimpleSpan::new(8, 9),
+            help: Some("Perhaps you meant one of: ':'".into()),
+        }];
+
+        let rendered = render_diagnostics("<test>", source, &diagnostics)
+            .expect("rendering an in-memory diagnostic should not fail");
+
+        assert!(
+            !rendered.is_empty(),
+            "render_diagnostics returned empty output"
+        );
+        assert!(
+            rendered.contains("Spell error: Incantation failed"),
+            "rendered output should include the diagnostic title; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("Unexpected token `=`"),
+            "rendered output should include the diagnostic label; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("Perhaps you meant one of: ':'"),
+            "rendered output should include the help text; got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_diagnostics_returns_empty_string_when_no_diagnostics() {
+        let rendered = render_diagnostics("<test>", "", &[])
+            .expect("empty diagnostic list should render successfully");
+        assert!(rendered.is_empty());
+    }
 }

--- a/crates/abyss-core/src/parser/diagnostics.rs
+++ b/crates/abyss-core/src/parser/diagnostics.rs
@@ -63,6 +63,25 @@ pub fn emit_diagnostics(
     source: &str,
     diagnostics: &[ParserDiagnostic],
 ) -> Result<(), std::io::Error> {
+    let rendered = render_diagnostics(source_id, source, diagnostics)?;
+    use std::io::Write;
+    std::io::stdout().write_all(rendered.as_bytes())?;
+    std::io::stdout().flush()
+}
+
+/// Render parser diagnostics as a single string instead of writing to
+/// stdout. Output includes the same `ariadne` formatting (ANSI colour
+/// codes and all) that [`emit_diagnostics`] would print, so consumers
+/// running on a non-CLI surface — Wasm playground, future LSP, embedded
+/// REPL — can capture and post-process the bytes themselves (strip ANSI,
+/// translate to HTML, etc.). The CLI renders via [`emit_diagnostics`],
+/// which is now a thin wrapper around this function.
+pub fn render_diagnostics(
+    source_id: &str,
+    source: &str,
+    diagnostics: &[ParserDiagnostic],
+) -> Result<String, std::io::Error> {
+    let mut buffer: Vec<u8> = Vec::new();
     for diagnostic in diagnostics {
         let span_range = diagnostic.span.into_range();
         let mut report = Report::build(ReportKind::Error, (source_id, span_range.clone()))
@@ -77,7 +96,13 @@ pub fn emit_diagnostics(
             report = report.with_help(help.clone());
         }
 
-        report.finish().print((source_id, Source::from(source)))?;
+        report
+            .finish()
+            .write((source_id, Source::from(source)), &mut buffer)?;
     }
-    Ok(())
+    // ariadne writes valid UTF-8 (it formats `&str` content), so the
+    // conversion is infallible in practice; surface the (impossible)
+    // error as a `std::io::Error` to match the stdout path's signature.
+    String::from_utf8(buffer)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
 }

--- a/crates/abyss-core/src/parser/mod.rs
+++ b/crates/abyss-core/src/parser/mod.rs
@@ -7,7 +7,7 @@ mod helpers;
 mod span;
 mod tokens;
 
-pub use diagnostics::{ParserDiagnostic, emit_diagnostics};
+pub use diagnostics::{ParserDiagnostic, emit_diagnostics, render_diagnostics};
 
 use std::sync::Arc;
 

--- a/crates/abyss-interpreter/src/eval/mod.rs
+++ b/crates/abyss-interpreter/src/eval/mod.rs
@@ -7,6 +7,6 @@ pub(crate) mod values;
 
 pub use result::{
     EvalError, EvalResult, RUNTIME_SOURCE_ID, display_error_with_source,
-    display_error_with_source_id,
+    display_error_with_source_id, render_error_with_source, render_error_with_source_id,
 };
 pub use statements::evaluate;

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -106,13 +106,19 @@ pub fn display_error_with_source(script: &str, error: &EvalError) {
 /// `"<script>"`, `"<repl>"`, `"<test>"`, or a file path) so runtime reports
 /// stay consistent with the parser diagnostics produced for the same input.
 ///
-/// Output goes to stderr. Any I/O failure from ariadne is swallowed (matching
-/// the pre-migration `eprintln!`-based behaviour). Use
-/// [`render_error_with_source_id`] when you want the rendered output as a
-/// string instead — for example, in a Wasm playground or a future LSP.
+/// Output is streamed directly to a locked stderr handle — no intermediate
+/// `String` allocation, and any I/O failure (broken pipe, etc.) is silently
+/// dropped to preserve the non-panicking behaviour the pre-migration
+/// `eprintln!`-based path had. Use [`render_error_with_source_id`] when
+/// you want the rendered output as a string instead — for example, in a
+/// Wasm playground or a future LSP.
 pub fn display_error_with_source_id(source_id: &str, script: &str, error: &EvalError) {
-    let rendered = render_error_with_source_id(source_id, script, error);
-    eprint!("{}", rendered);
+    let stderr = std::io::stderr();
+    let mut handle = stderr.lock();
+    // The CLI path explicitly drops I/O errors so a closed pipe doesn't
+    // panic the interpreter — matching the original `report.eprint(...)`
+    // semantics that this refactor replaced.
+    let _ = write_error_with_source_id(source_id, script, error, &mut handle);
 }
 
 /// Same default-source-id rendering as [`display_error_with_source`], but
@@ -130,6 +136,33 @@ pub fn render_error_with_source(script: &str, error: &EvalError) -> String {
 /// surface — Wasm playground, future LSP, embedded REPL — can capture the
 /// bytes and post-process them (strip ANSI, translate to HTML, etc.).
 pub fn render_error_with_source_id(source_id: &str, script: &str, error: &EvalError) -> String {
+    let mut buffer: Vec<u8> = Vec::new();
+    // Writing into a `Vec<u8>` is infallible in practice; on the (impossible)
+    // I/O failure path we still want a string back rather than a `Result`,
+    // so fall back to the bare `Error: …` form so the caller has something
+    // useful to display.
+    if write_error_with_source_id(source_id, script, error, &mut buffer).is_err() {
+        return format!("Error: {}\n", error);
+    }
+    String::from_utf8(buffer).unwrap_or_else(|err| {
+        format!(
+            "Error: {} (rendering produced invalid UTF-8: {})",
+            error, err
+        )
+    })
+}
+
+/// Shared implementation for both [`display_error_with_source_id`] (stderr)
+/// and [`render_error_with_source_id`] (`Vec<u8>`). Streams an `ariadne`
+/// report directly into the supplied writer — the CLI path streams to a
+/// locked stderr handle without buffering, while the string-returning
+/// path streams into a `Vec<u8>` and converts.
+fn write_error_with_source_id<W: std::io::Write>(
+    source_id: &str,
+    script: &str,
+    error: &EvalError,
+    writer: &mut W,
+) -> std::io::Result<()> {
     let message = error.to_string();
     if let Some(info) = error.line_info()
         && let Some(start) = line_col_to_byte_offset(script, info.line, info.column)
@@ -148,17 +181,9 @@ pub fn render_error_with_source_id(source_id: &str, script: &str, error: &EvalEr
                     .with_color(Color::Red),
             )
             .finish();
-        let mut buffer: Vec<u8> = Vec::new();
-        // ariadne writes valid UTF-8. Any I/O failure from a `Vec<u8>`
-        // writer is unreachable in practice; treat the (impossible) error
-        // the same way the previous `eprint`-based path did — drop it —
-        // so callers do not have to thread a `Result` through every
-        // diagnostic-rendering path.
-        let _ = report.write((source_id, Source::from(script)), &mut buffer);
-        String::from_utf8(buffer)
-            .unwrap_or_else(|err| format!("Error: {} (rendering failed: {})", message, err))
+        report.write((source_id, Source::from(script)), writer)
     } else {
-        format!("Error: {}\n", message)
+        writeln!(writer, "Error: {}", message)
     }
 }
 

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -107,8 +107,29 @@ pub fn display_error_with_source(script: &str, error: &EvalError) {
 /// stay consistent with the parser diagnostics produced for the same input.
 ///
 /// Output goes to stderr. Any I/O failure from ariadne is swallowed (matching
-/// the pre-migration `eprintln!`-based behaviour).
+/// the pre-migration `eprintln!`-based behaviour). Use
+/// [`render_error_with_source_id`] when you want the rendered output as a
+/// string instead — for example, in a Wasm playground or a future LSP.
 pub fn display_error_with_source_id(source_id: &str, script: &str, error: &EvalError) {
+    let rendered = render_error_with_source_id(source_id, script, error);
+    eprint!("{}", rendered);
+}
+
+/// Same default-source-id rendering as [`display_error_with_source`], but
+/// returns the formatted output as a string instead of writing to stderr.
+/// Useful for non-CLI consumers (Wasm playground, LSP, embedded REPL).
+pub fn render_error_with_source(script: &str, error: &EvalError) -> String {
+    render_error_with_source_id(RUNTIME_SOURCE_ID, script, error)
+}
+
+/// Render a runtime error to a `String` using the same `ariadne` formatting
+/// (ANSI colour codes and all) that [`display_error_with_source_id`] would
+/// print to stderr. The trailing newline is included where ariadne emits
+/// one; the positionless fallback path appends `"Error: …\n"` to stay
+/// byte-identical with the stderr behaviour. Consumers running on a non-CLI
+/// surface — Wasm playground, future LSP, embedded REPL — can capture the
+/// bytes and post-process them (strip ANSI, translate to HTML, etc.).
+pub fn render_error_with_source_id(source_id: &str, script: &str, error: &EvalError) -> String {
     let message = error.to_string();
     if let Some(info) = error.line_info()
         && let Some(start) = line_col_to_byte_offset(script, info.line, info.column)
@@ -127,9 +148,17 @@ pub fn display_error_with_source_id(source_id: &str, script: &str, error: &EvalE
                     .with_color(Color::Red),
             )
             .finish();
-        let _ = report.eprint((source_id, Source::from(script)));
+        let mut buffer: Vec<u8> = Vec::new();
+        // ariadne writes valid UTF-8. Any I/O failure from a `Vec<u8>`
+        // writer is unreachable in practice; treat the (impossible) error
+        // the same way the previous `eprint`-based path did — drop it —
+        // so callers do not have to thread a `Result` through every
+        // diagnostic-rendering path.
+        let _ = report.write((source_id, Source::from(script)), &mut buffer);
+        String::from_utf8(buffer)
+            .unwrap_or_else(|err| format!("Error: {} (rendering failed: {})", message, err))
     } else {
-        eprintln!("Error: {}", message);
+        format!("Error: {}\n", message)
     }
 }
 
@@ -271,6 +300,33 @@ mod tests {
     fn display_error_without_line_info_still_prints_message() {
         let err = EvalError::NegativeExponent(None);
         display_error_with_source("sigil = 1", &err);
+    }
+
+    #[test]
+    fn render_error_with_resolvable_position_returns_ariadne_report() {
+        // The string-returning renderer is the surface the future Wasm
+        // playground / LSP capture, so this locks down two things: it
+        // returns a non-empty `String`, and the rendered output mentions
+        // the underlying message rather than swallowing it.
+        let script = "sigil: arcana = 1\nhex = sigil + 2";
+        let err = EvalError::InvalidOperation("invalid op".into(), Some(LineInfo::new(2, 5)));
+        let rendered = render_error_with_source(script, &err);
+        assert!(!rendered.is_empty(), "ariadne rendering produced no output");
+        assert!(
+            rendered.contains("invalid op"),
+            "rendered output should mention the message; got {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_error_without_position_falls_back_to_plain_line() {
+        // With no `LineInfo` the renderer drops down to the
+        // `Error: …\n` fallback (matching what `display_error_with_source`
+        // would print).
+        let err = EvalError::NegativeExponent(None);
+        let rendered = render_error_with_source("sigil = 1", &err);
+        assert!(rendered.starts_with("Error: "), "got: {rendered}");
+        assert!(rendered.ends_with('\n'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First piece of the **v0.6.0 Web Playground & Wasm** cycle. Both diagnostic rendering paths (parser + runtime) now have string-returning siblings alongside the existing stdout/stderr versions. A non-CLI consumer (Wasm playground, future LSP, embedded REPL) can capture the same \`ariadne\`-formatted output the CLI prints without having to redirect actual file descriptors.

## What changes

- **\`abyss_core::parser::render_diagnostics\`** (new) — same shape as \`emit_diagnostics\` but returns \`Result<String, std::io::Error>\` instead of writing to \`stdout\`. \`emit_diagnostics\` is now a thin wrapper.
- **\`abyss_interpreter::eval::render_error_with_source\` / \`render_error_with_source_id\`** (new) — string-returning siblings of the existing \`display_error_with_source\` / \`display_error_with_source_id\`. The display variants are now thin wrappers that \`eprint!\` the rendered bytes.
- **Positionless fallback** stays byte-identical: \`Error: …\\n\` rather than an ariadne report (matching the previous \`eprintln!\` shape).
- **Output keeps ariadne's ANSI colour codes**; the future Wasm crate (PR2) decides whether to strip ANSI before handing the string to the browser, so the renderer stays format-neutral.

## Verification

- [x] \`cargo test --workspace\` — all suites green; two new unit tests (\`render_error_with_resolvable_position_returns_ariadne_report\`, \`render_error_without_position_falls_back_to_plain_line\`) lock down the rendering paths the playground will capture.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] **\`cargo check --target wasm32-unknown-unknown -p abyss-core -p abyss-interpreter\`** — both library crates compile cleanly to wasm32. This PR validates that the existing dependency tree (\`chumsky\` 0.12, \`ariadne\` 0.6, \`ordered-float\` 5) is wasm-ready, so subsequent PRs can build on this without surprises.

## Test plan

- [ ] CI green on this PR.

## Out of scope (deferred to subsequent PRs in the v0.6.0 cycle)

- **PR2** — new \`crates/abyss-wasm\` adapter wrapping \`parse\` / \`evaluate\` and the new renderers behind a \`wasm-bindgen\` \`eval(source) -> { stdout, stderr, error }\` entry point.
- **PR3** — Starlight playground component (CodeMirror or Monaco editor + Wasm load + examples seeded from the \`examples/\` programs).
- **PR4** — UX polish: inline error highlighting, URL-hash code sharing, localStorage state, layout polish.
- **PR5** — Release v0.6.0 (version bump + develop→main promotion).