### PR TITLE
feat(wasm): add abyss-wasm adapter crate with PlaygroundBridge for stdout capture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo check (wasm32-unknown-unknown)
-        run: cargo check --target wasm32-unknown-unknown -p abyss-core -p abyss-interpreter
+        run: cargo check --target wasm32-unknown-unknown -p abyss-core -p abyss-interpreter -p abyss-wasm
 
   version-check:
     name: Version Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "abyss-wasm"
+version = "0.5.0"
+dependencies = [
+ "abyss-core",
+ "abyss-interpreter",
+ "console_error_panic_hook",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +139,12 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
@@ -229,6 +247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +308,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +373,18 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -389,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +478,12 @@ checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -476,6 +552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rustyline"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +624,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -617,6 +716,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["crates/abyss-core", "crates/abyss-interpreter", "crates/abyss-cli"]
+members = [
+    "crates/abyss-core",
+    "crates/abyss-interpreter",
+    "crates/abyss-cli",
+    "crates/abyss-wasm",
+]
 
 [workspace.package]
 version = "0.5.0"

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -62,24 +62,48 @@ pub struct VarInfo {
 }
 
 /// Manages variable and function scopes in the execution environment, including
-/// both the global scope and any nested local scopes.
-#[derive(Debug, Clone)]
+/// both the global scope and any nested local scopes. Carries the
+/// [`IoBridge`](crate::io_bridge::IoBridge) used by `unveil` / `summon`,
+/// so non-CLI hosts (Wasm playground, future LSP) can swap in a custom
+/// implementation that captures output instead of touching `stdout`.
 pub struct RuntimeEnv {
     scopes: Vec<HashMap<String, VarInfo>>, // Variable scopes
     function_scopes: Vec<HashMap<String, Callable>>, // Function scopes
     artifact_scopes: Vec<HashMap<String, ArtifactSchema>>, // Artifact schemas per scope
     builtin_methods: BuiltinMethodRegistry,
+    io_bridge: Box<dyn crate::io_bridge::IoBridge>,
 }
 
 impl RuntimeEnv {
-    /// Creates a new environment with an initial global scope.
+    /// Creates a new environment with an initial global scope and the
+    /// default [`StdIoBridge`](crate::io_bridge::StdIoBridge), so CLI /
+    /// REPL paths get the same `stdout` / `stdin` behaviour they had
+    /// before the bridge abstraction landed. Non-CLI hosts call
+    /// [`set_io_bridge`](Self::set_io_bridge) afterwards to swap in
+    /// their own implementation.
     pub fn new() -> Self {
         RuntimeEnv {
             scopes: vec![HashMap::new()],
             function_scopes: vec![HashMap::new()],
             artifact_scopes: vec![HashMap::new()],
             builtin_methods: HashMap::new(),
+            io_bridge: Box::new(crate::io_bridge::StdIoBridge),
         }
+    }
+
+    /// Replace the I/O bridge used by `unveil` / `summon`. Wasm callers
+    /// install a `String`-backed implementation here so output the
+    /// playground would otherwise drop to `stdout` is captured into a
+    /// buffer the host can hand back to JavaScript.
+    pub fn set_io_bridge(&mut self, bridge: Box<dyn crate::io_bridge::IoBridge>) {
+        self.io_bridge = bridge;
+    }
+
+    /// Mutable access to the installed I/O bridge. Used by
+    /// `stdlib::functions::io` to route `unveil` writes and `summon`
+    /// reads through the bridge the host provided.
+    pub fn io_bridge_mut(&mut self) -> &mut dyn crate::io_bridge::IoBridge {
+        self.io_bridge.as_mut()
     }
 
     /// Pushes a new scope onto the stack, creating a new local environment for variables and functions.

--- a/crates/abyss-interpreter/src/io_bridge.rs
+++ b/crates/abyss-interpreter/src/io_bridge.rs
@@ -1,0 +1,45 @@
+//! I/O bridge abstraction shared by `RuntimeEnv` and the stdlib `unveil` /
+//! `summon` builtins.
+//!
+//! The interpreter delegates writes (`unveil`) and prompts (`summon`)
+//! through this trait instead of touching `std::io::stdout` / `stdin`
+//! directly, so non-CLI hosts (the v0.6.0 Wasm playground, future LSP,
+//! embedded REPL) can capture both streams without intercepting the
+//! actual file descriptors. `RuntimeEnv` carries one
+//! `Box<dyn IoBridge>`; CLI builds default to [`StdIoBridge`], and the
+//! Wasm crate swaps in its own implementation that buffers writes into a
+//! shared `String` and refuses reads.
+
+use std::io;
+
+/// Behaviour the interpreter needs from its embedding environment to
+/// implement `unveil` (write) and `summon` (read-line). Output is
+/// buffered by the consumer; the interpreter does not assume the bytes
+/// are actually flushed to a TTY.
+pub trait IoBridge {
+    fn write_str(&mut self, content: &str) -> io::Result<()>;
+    fn flush(&mut self) -> io::Result<()>;
+    fn read_line(&mut self, buffer: &mut String) -> io::Result<()>;
+}
+
+/// Default bridge for CLI builds: writes go to `std::io::stdout()` and
+/// reads come from `std::io::stdin()`. `RuntimeEnv::new()` installs this
+/// automatically, so the existing CLI / REPL paths get the same
+/// behaviour they had before the abstraction landed.
+pub struct StdIoBridge;
+
+impl IoBridge for StdIoBridge {
+    fn write_str(&mut self, content: &str) -> io::Result<()> {
+        use std::io::Write;
+        io::stdout().write_all(content.as_bytes())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        use std::io::Write;
+        io::stdout().flush()
+    }
+
+    fn read_line(&mut self, buffer: &mut String) -> io::Result<()> {
+        io::stdin().read_line(buffer).map(|_| ())
+    }
+}

--- a/crates/abyss-interpreter/src/lib.rs
+++ b/crates/abyss-interpreter/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod diagnostics;
 pub mod env;
 pub mod eval;
+pub mod io_bridge;
 pub mod stdlib;

--- a/crates/abyss-interpreter/src/stdlib/functions/io.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/io.rs
@@ -79,8 +79,12 @@ pub(crate) fn native_summon_with_io(
         .map_err(|_| map_io_error("Failed to flush stdout", &line))?;
 
     let mut input = String::new();
+    // Preserve the underlying `io::Error` message so a bridge that
+    // refuses reads (e.g. the Wasm Playground bridge, which has no
+    // interactive stdin) can surface its specific reason to the user
+    // instead of being collapsed into a generic "Failed to read input".
     io.read_line(&mut input)
-        .map_err(|_| map_io_error("Failed to read input", &line))?;
+        .map_err(|err| map_io_error(&format!("Failed to read input: {}", err), &line))?;
 
     Ok(EvalResult::data(Value::Rune(Rc::new(
         input.trim().to_string(),

--- a/crates/abyss-interpreter/src/stdlib/functions/io.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/io.rs
@@ -1,38 +1,18 @@
 use crate::env::{CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
+use crate::io_bridge::IoBridge;
 use abyss_core::ast::{LineInfo, Type};
-use std::io::{self, Write};
 use std::rc::Rc;
-
-pub trait IoBridge {
-    fn write_str(&mut self, content: &str) -> io::Result<()>;
-    fn flush(&mut self) -> io::Result<()>;
-    fn read_line(&mut self, buffer: &mut String) -> io::Result<()>;
-}
-
-struct StdIoBridge;
-
-impl IoBridge for StdIoBridge {
-    fn write_str(&mut self, content: &str) -> io::Result<()> {
-        io::stdout().write_all(content.as_bytes())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        io::stdout().flush()
-    }
-
-    fn read_line(&mut self, buffer: &mut String) -> io::Result<()> {
-        io::stdin().read_line(buffer).map(|_| ())
-    }
-}
 
 pub fn native_unveil(
     env: &mut RuntimeEnv,
     args: Vec<CallArg>,
     line: Option<LineInfo>,
 ) -> Result<EvalResult, EvalError> {
-    let mut io = StdIoBridge;
-    native_unveil_with_io(env, args, line, &mut io)
+    // Route writes through the bridge `RuntimeEnv` carries, so non-CLI
+    // hosts (Wasm playground, future LSP) can capture output without
+    // touching `stdout`. CLI builds default to `StdIoBridge`.
+    native_unveil_with_io(args, line, env.io_bridge_mut())
 }
 
 fn map_io_error(message: &str, line: &Option<LineInfo>) -> EvalError {
@@ -40,7 +20,6 @@ fn map_io_error(message: &str, line: &Option<LineInfo>) -> EvalError {
 }
 
 pub(crate) fn native_unveil_with_io(
-    _env: &mut RuntimeEnv,
     args: Vec<CallArg>,
     line: Option<LineInfo>,
     io: &mut dyn IoBridge,
@@ -70,12 +49,10 @@ pub fn native_summon(
     args: Vec<CallArg>,
     line: Option<LineInfo>,
 ) -> Result<EvalResult, EvalError> {
-    let mut io = StdIoBridge;
-    native_summon_with_io(env, args, line, &mut io)
+    native_summon_with_io(args, line, env.io_bridge_mut())
 }
 
 pub(crate) fn native_summon_with_io(
-    _env: &mut RuntimeEnv,
     args: Vec<CallArg>,
     line: Option<LineInfo>,
     io: &mut dyn IoBridge,
@@ -200,6 +177,7 @@ mod tests {
     use crate::env::{ArtifactHandle, ArtifactValue};
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
+    use std::io;
     use std::rc::Rc;
 
     #[derive(Default)]
@@ -290,24 +268,21 @@ mod tests {
 
     #[test]
     fn native_unveil_with_io_writes_all_arguments() {
-        let mut env = RuntimeEnv::new();
         let args = vec![
             arg(EvalResult::data(Value::Omen(true))),
             arg(EvalResult::data(Value::Rune(Rc::new("hex".to_string())))),
         ];
         let mut io = MockIo::default();
-        let result =
-            native_unveil_with_io(&mut env, args, None, &mut io).expect("unveil should succeed");
+        let result = native_unveil_with_io(args, None, &mut io).expect("unveil should succeed");
         assert!(matches!(result, EvalResult::Data(Value::Abyss)));
         assert_eq!(io.writes.join(""), "boonhex\n");
     }
 
     #[test]
     fn native_unveil_with_io_rejects_control_flow() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::Revealed(Box::new(EvalResult::abyss())))];
         let mut io = MockIo::default();
-        let err = native_unveil_with_io(&mut env, args, None, &mut io)
+        let err = native_unveil_with_io(args, None, &mut io)
             .expect_err("control flow values should error");
         if let EvalError::InvalidOperation(msg, _) = err {
             assert!(msg.contains("Revealed"));
@@ -318,19 +293,16 @@ mod tests {
 
     #[test]
     fn native_unveil_with_io_propagates_write_errors() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::data(Value::Arcana(1)))];
         let mut io = MockIo::with_write_failure();
-        assert!(native_unveil_with_io(&mut env, args, None, &mut io).is_err());
+        assert!(native_unveil_with_io(args, None, &mut io).is_err());
     }
 
     #[test]
     fn native_summon_with_io_returns_trimmed_input() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::data(Value::Rune(Rc::new("?".to_string()))))];
         let mut io = MockIo::with_reads(&["mage answer\n"]);
-        let result =
-            native_summon_with_io(&mut env, args, None, &mut io).expect("summon should succeed");
+        let result = native_summon_with_io(args, None, &mut io).expect("summon should succeed");
         match result {
             EvalResult::Data(Value::Rune(text)) => assert_eq!(text.as_ref(), "mage answer"),
             other => panic!("expected rune result, got {:?}", other),
@@ -340,19 +312,17 @@ mod tests {
 
     #[test]
     fn native_summon_with_io_errors_on_read_failure() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::data(Value::Rune(Rc::new("?".to_string()))))];
         let mut io = MockIo::with_reads(&[]);
         io.push_error("read failure");
-        assert!(native_summon_with_io(&mut env, args, None, &mut io).is_err());
+        assert!(native_summon_with_io(args, None, &mut io).is_err());
     }
 
     #[test]
     fn native_summon_with_io_errors_on_flush_failure() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::data(Value::Rune(Rc::new("?".to_string()))))];
         let mut io = MockIo::with_flush_failure();
-        assert!(native_summon_with_io(&mut env, args, None, &mut io).is_err());
+        assert!(native_summon_with_io(args, None, &mut io).is_err());
     }
 
     #[test]
@@ -381,10 +351,9 @@ mod tests {
 
     #[test]
     fn native_unveil_requires_arguments() {
-        let mut env = RuntimeEnv::new();
         let args = vec![];
         let mut io = MockIo::default();
-        let result = native_unveil_with_io(&mut env, args, None, &mut io);
+        let result = native_unveil_with_io(args, None, &mut io);
         assert!(matches!(
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("requires at least 1 argument")
@@ -393,10 +362,9 @@ mod tests {
 
     #[test]
     fn native_summon_requires_exactly_one_argument() {
-        let mut env = RuntimeEnv::new();
         let args = vec![];
         let mut io = MockIo::default();
-        let result = native_summon_with_io(&mut env, args, None, &mut io);
+        let result = native_summon_with_io(args, None, &mut io);
         assert!(matches!(
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("requires exactly 1 argument")
@@ -405,10 +373,9 @@ mod tests {
 
     #[test]
     fn native_summon_requires_rune_argument() {
-        let mut env = RuntimeEnv::new();
         let args = vec![arg(EvalResult::data(Value::Arcana(1)))];
         let mut io = MockIo::default();
-        let result = native_summon_with_io(&mut env, args, None, &mut io);
+        let result = native_summon_with_io(args, None, &mut io);
         assert!(matches!(
             result,
             Err(EvalError::TypeError(msg, _)) if msg.contains("must be a Rune")

--- a/crates/abyss-wasm/Cargo.toml
+++ b/crates/abyss-wasm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "abyss-wasm"
+description = "Wasm adapter for the AbySS interpreter, exposing a single `eval(source)` entry point for the docs-site Playground."
+readme = "README.md"
+keywords = ["abyss", "wasm", "playground", "interpreter"]
+categories = ["wasm", "development-tools"]
+publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+abyss-core.workspace = true
+abyss-interpreter.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+wasm-bindgen = "0.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"

--- a/crates/abyss-wasm/README.md
+++ b/crates/abyss-wasm/README.md
@@ -1,0 +1,30 @@
+# abyss-wasm
+
+Wasm adapter for the [AbySS interpreter](https://abyss-lang.dev). Wraps `abyss-core` and `abyss-interpreter` behind a single `eval(source)` entry point for the docs-site Playground.
+
+This crate is **not published to crates.io** — it is a private workspace member built by the docs-site bundler (PR3+ of the v0.6.0 cycle).
+
+## Building
+
+```bash
+cargo install wasm-pack   # one-time
+wasm-pack build crates/abyss-wasm --target web
+```
+
+The output lands in `crates/abyss-wasm/pkg/` and is consumed by the Starlight site under `docs/`.
+
+## Public surface
+
+```ts
+type EvalOutcome = {
+  stdout: string;
+  stderr: string;
+  error: string | null;
+};
+
+function eval(source: string): EvalOutcome;
+```
+
+`stdout` captures everything `unveil` would print on the CLI. `stderr` carries the parser / runtime diagnostic, ANSI-coloured the same way the CLI prints it (so the playground UI can either render the ANSI codes via xterm.js or strip them for a plain inline message). `error` is non-null when evaluation could not complete; `stdout` may still contain partial output up to the failure point.
+
+`summon` (interactive input) is **not supported** in the playground build — calling it raises a runtime error with a clear message.

--- a/crates/abyss-wasm/README.md
+++ b/crates/abyss-wasm/README.md
@@ -22,9 +22,13 @@ type EvalOutcome = {
   error: string | null;
 };
 
+// Throws if the EvalOutcome cannot be serialised to a JS value (very
+// rare — only on a serde-wasm-bindgen internal failure). Successful
+// runs and ordinary user errors (parser diagnostics, runtime errors)
+// resolve normally with `error` populated.
 function eval(source: string): EvalOutcome;
 ```
 
 `stdout` captures everything `unveil` would print on the CLI. `stderr` carries the parser / runtime diagnostic, ANSI-coloured the same way the CLI prints it (so the playground UI can either render the ANSI codes via xterm.js or strip them for a plain inline message). `error` is non-null when evaluation could not complete; `stdout` may still contain partial output up to the failure point.
 
-`summon` (interactive input) is **not supported** in the playground build — calling it raises a runtime error with a clear message.
+`summon` (interactive input) is **not supported** in the playground build — calling it raises a runtime error with a clear message ("summon (interactive input) is not available in the Playground").

--- a/crates/abyss-wasm/src/lib.rs
+++ b/crates/abyss-wasm/src/lib.rs
@@ -1,0 +1,191 @@
+//! Wasm adapter for the AbySS interpreter.
+//!
+//! Exposes a single `eval(source)` entry point that the docs-site
+//! Playground (introduced in PR3 of the v0.6.0 cycle) calls from
+//! JavaScript. Output is captured into a [`String`] via the
+//! [`PlaygroundBridge`] implementation of
+//! [`abyss_interpreter::io_bridge::IoBridge`], and diagnostics flow
+//! through the same `render_*` renderers the CLI uses (so the
+//! playground sees the same ariadne formatting the user would see in a
+//! terminal — ANSI colour codes included).
+
+use std::cell::RefCell;
+use std::io;
+use std::rc::Rc;
+
+use abyss_core::parser::{parse, render_diagnostics};
+use abyss_interpreter::eval::{evaluate, render_error_with_source};
+use abyss_interpreter::io_bridge::IoBridge;
+use abyss_interpreter::stdlib::create_global_environment;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+/// Result handed back to JavaScript for each `eval(source)` call.
+///
+/// `stdout` captures everything `unveil` would print on the CLI.
+/// `stderr` carries the parser / runtime diagnostic, ANSI-coloured the
+/// same way the CLI prints it. `error` is `Some(_)` when evaluation
+/// could not complete; `stdout` may still contain partial output up to
+/// the failure point.
+#[derive(Debug, Default, Serialize)]
+struct EvalOutcome {
+    stdout: String,
+    stderr: String,
+    error: Option<String>,
+}
+
+/// Captures `unveil` writes into a shared `String`. `read_line` is
+/// rejected so a `summon` call surfaces a clear "input is not available
+/// in the Playground" error rather than blocking forever or panicking.
+struct PlaygroundBridge {
+    stdout: Rc<RefCell<String>>,
+}
+
+impl IoBridge for PlaygroundBridge {
+    fn write_str(&mut self, content: &str) -> io::Result<()> {
+        self.stdout.borrow_mut().push_str(content);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn read_line(&mut self, _buffer: &mut String) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "summon (interactive input) is not available in the Playground",
+        ))
+    }
+}
+
+/// Initialise panic hooks once per Wasm instance so a Rust panic gets
+/// surfaced to the browser console instead of an opaque
+/// `RuntimeError: unreachable executed`.
+#[wasm_bindgen(start)]
+pub fn start() {
+    #[cfg(target_arch = "wasm32")]
+    console_error_panic_hook::set_once();
+}
+
+/// Evaluate `source` and return the captured stdout, the rendered
+/// diagnostic (if any), and an `error` string when evaluation could not
+/// complete. The function is exposed to JavaScript as a plain function
+/// taking a string and returning an `EvalOutcome` JSON object.
+#[wasm_bindgen]
+pub fn eval(source: String) -> Result<JsValue, JsValue> {
+    let outcome = run(&source);
+    serde_wasm_bindgen::to_value(&outcome).map_err(|err| JsValue::from_str(&err.to_string()))
+}
+
+const PLAYGROUND_SOURCE_ID: &str = "<playground>";
+
+fn run(source: &str) -> EvalOutcome {
+    let mut outcome = EvalOutcome::default();
+
+    let parsed = parse(source);
+    if !parsed.diagnostics.is_empty() {
+        // Parser-level diagnostics are an error: nothing was evaluated,
+        // so stdout stays empty. We surface the rendered report under
+        // `stderr` and a short summary under `error` for the host to
+        // display inline.
+        match render_diagnostics(PLAYGROUND_SOURCE_ID, source, &parsed.diagnostics) {
+            Ok(rendered) => outcome.stderr = rendered,
+            Err(err) => outcome.stderr = format!("Failed to render diagnostics: {err}"),
+        }
+        outcome.error = Some(format!(
+            "{} parser diagnostic(s) — see stderr for details",
+            parsed.diagnostics.len()
+        ));
+        return outcome;
+    }
+
+    // Run with a custom bridge so `unveil` output flows into a String
+    // rather than the native stdout (which is a no-op on
+    // wasm32-unknown-unknown anyway). The handle stays live until after
+    // `evaluate` returns, so partial output is preserved when a
+    // mid-script runtime error truncates execution.
+    let stdout_buf: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
+    let bridge = PlaygroundBridge {
+        stdout: stdout_buf.clone(),
+    };
+    let mut env = create_global_environment();
+    env.set_io_bridge(Box::new(bridge));
+
+    for ast in parsed.ast {
+        if let Err(error) = evaluate(&ast, &mut env) {
+            outcome.stderr = render_error_with_source(source, &error);
+            outcome.error = Some(format!("{}", error));
+            // Drop borrow before assigning into the outcome.
+            outcome.stdout = std::mem::take(&mut *stdout_buf.borrow_mut());
+            return outcome;
+        }
+    }
+
+    outcome.stdout = std::mem::take(&mut *stdout_buf.borrow_mut());
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_captures_unveil_output_via_bridge() {
+        // The capture mechanism the Playground depends on: `unveil`
+        // writes flow through `PlaygroundBridge` into a shared `String`,
+        // not to `stdout`. The newline is the trailing one `unveil`
+        // appends after each call.
+        let outcome = run("unveil(\"hello\");");
+        assert_eq!(outcome.stdout, "hello\n");
+        assert!(outcome.stderr.is_empty(), "got stderr: {}", outcome.stderr);
+        assert!(outcome.error.is_none(), "got error: {:?}", outcome.error);
+    }
+
+    #[test]
+    fn run_surfaces_parser_diagnostics_with_no_eval() {
+        // `forge x = 1` is missing a type annotation. Parsing fails;
+        // `stdout` stays empty (nothing was evaluated), `stderr`
+        // carries the rendered diagnostic, `error` summarises.
+        let outcome = run("forge x = 1;");
+        assert!(outcome.stdout.is_empty());
+        assert!(!outcome.stderr.is_empty());
+        assert!(outcome.error.is_some());
+        let summary = outcome.error.unwrap();
+        assert!(
+            summary.contains("parser diagnostic"),
+            "unexpected error summary: {summary}"
+        );
+    }
+
+    #[test]
+    fn run_preserves_partial_stdout_on_runtime_error() {
+        // First `unveil` succeeds and ends up in the captured stdout;
+        // the second statement hits a runtime error which truncates
+        // execution. The Playground UI shows the captured "first" line
+        // alongside the diagnostic, matching the CLI experience.
+        let source = "unveil(\"first\");\nreveal y;";
+        let outcome = run(source);
+        assert_eq!(outcome.stdout, "first\n");
+        assert!(!outcome.stderr.is_empty());
+        assert!(outcome.error.is_some());
+        let summary = outcome.error.unwrap();
+        assert!(summary.contains("Variable y"), "got: {summary}");
+    }
+
+    #[test]
+    fn run_rejects_summon_with_unsupported_message() {
+        // Interactive input is intentionally unsupported in the
+        // Playground bridge — `summon` raises a runtime error rather
+        // than blocking forever or panicking.
+        let source = r#"forge name: rune = summon("name?");"#;
+        let outcome = run(source);
+        assert!(outcome.error.is_some());
+        let combined = format!("{}\n{}", outcome.stderr, outcome.error.unwrap());
+        assert!(
+            combined.contains("not available in the Playground")
+                || combined.contains("Failed to read input"),
+            "expected summon-not-supported error; got: {combined}"
+        );
+    }
+}

--- a/crates/abyss-wasm/src/lib.rs
+++ b/crates/abyss-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::rc::Rc;
 
 use abyss_core::parser::{parse, render_diagnostics};
-use abyss_interpreter::eval::{evaluate, render_error_with_source};
+use abyss_interpreter::eval::{evaluate, render_error_with_source_id};
 use abyss_interpreter::io_bridge::IoBridge;
 use abyss_interpreter::stdlib::create_global_environment;
 use serde::Serialize;
@@ -114,7 +114,10 @@ fn run(source: &str) -> EvalOutcome {
 
     for ast in parsed.ast {
         if let Err(error) = evaluate(&ast, &mut env) {
-            outcome.stderr = render_error_with_source(source, &error);
+            // Use the same `<playground>` source id the parser
+            // diagnostics carry so the labels stay consistent across
+            // both rendering paths.
+            outcome.stderr = render_error_with_source_id(PLAYGROUND_SOURCE_ID, source, &error);
             outcome.error = Some(format!("{}", error));
             // Drop borrow before assigning into the outcome.
             outcome.stdout = std::mem::take(&mut *stdout_buf.borrow_mut());
@@ -177,15 +180,17 @@ mod tests {
     fn run_rejects_summon_with_unsupported_message() {
         // Interactive input is intentionally unsupported in the
         // Playground bridge — `summon` raises a runtime error rather
-        // than blocking forever or panicking.
+        // than blocking forever or panicking. The interpreter side
+        // preserves the bridge's `io::Error` message
+        // (`stdlib::functions::io::native_summon`), so the
+        // playground-specific text reaches the user.
         let source = r#"forge name: rune = summon("name?");"#;
         let outcome = run(source);
         assert!(outcome.error.is_some());
         let combined = format!("{}\n{}", outcome.stderr, outcome.error.unwrap());
         assert!(
-            combined.contains("not available in the Playground")
-                || combined.contains("Failed to read input"),
-            "expected summon-not-supported error; got: {combined}"
+            combined.contains("not available in the Playground"),
+            "expected playground-specific summon error to reach the user; got: {combined}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Second piece of the **v0.6.0 Web Playground & Wasm** cycle. Lifts the existing `IoBridge` trait out of `stdlib::functions::io` into a top-level module, makes `RuntimeEnv` carry a `Box<dyn IoBridge>`, and introduces a new `crates/abyss-wasm` workspace member that exposes the AbySS interpreter to JavaScript via `wasm-bindgen`.

## What changes

### IoBridge restructure (internal)

- **`IoBridge` and `StdIoBridge` move to `abyss_interpreter::io_bridge`** so `RuntimeEnv` (in `crate::env`) can hold one without creating a circular dependency.
- **`RuntimeEnv` gains `io_bridge: Box<dyn IoBridge>`**, a `set_io_bridge(...)` setter, and an `io_bridge_mut(...)` accessor. `RuntimeEnv::new()` installs `StdIoBridge`, so CLI / REPL behaviour is unchanged.
- **`native_unveil` / `native_summon` route through `env.io_bridge_mut()`** instead of constructing their own `StdIoBridge`.
- **`RuntimeEnv` drops the unused `Debug, Clone` derives** — no in-tree caller used either, and `Box<dyn IoBridge>` does not implement `Clone`.

### New `crates/abyss-wasm` workspace member

- **`PlaygroundBridge`** buffers `unveil` writes into a `Rc<RefCell<String>>`, ignores flush, and rejects `read_line` with a clear "summon (interactive input) is not available in the Playground" error.
- **`#[wasm_bindgen] pub fn eval(source: String) -> Result<JsValue, JsValue>`** — single entry point returning an `EvalOutcome { stdout, stderr, error }` JSON object via `serde-wasm-bindgen`. Parser diagnostics route through `render_diagnostics`, runtime errors through `render_error_with_source`. Partial `unveil` output up to a mid-script runtime error is preserved.
- **`#[wasm_bindgen(start)]`** wires `console_error_panic_hook` (gated to `wasm32`) so panics surface in the browser console rather than as `RuntimeError: unreachable executed`.
- Crate is **`publish = false`** — it is built from source by the docs-site bundler in PR3, not via crates.io.

### CI

- The Wasm Check job (added in PR1) now also builds `-p abyss-wasm`, so the playground crate stays wasm-buildable on every push.

## Tests

- **Four unit tests in `abyss-wasm`**, all running on the native target so the capture invariants are exercised by `cargo test` without a wasm runtime:
  - **`run_captures_unveil_output_via_bridge`** — the basic capture mechanism (writes flow into a shared `String`).
  - **`run_surfaces_parser_diagnostics_with_no_eval`** — `forge x = 1;` (missing type annotation) → parser fails, stdout empty, stderr non-empty, error summary.
  - **`run_preserves_partial_stdout_on_runtime_error`** — `unveil("first"); reveal y;` → first call captured, runtime error truncates execution, captured "first\\n" preserved alongside the diagnostic.
  - **`run_rejects_summon_with_unsupported_message`** — `summon("name?")` raises a runtime error with the unsupported-input message.

## Test plan

- [x] \`cargo test --workspace\` passes — every existing suite still green; abyss-wasm adds 4 tests.
- [x] \`cargo fmt --check\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo check --target wasm32-unknown-unknown -p abyss-core -p abyss-interpreter -p abyss-wasm\` passes locally.
- [x] \`python3 scripts/check_version_sync.py\` — no version drift.
- [ ] CI green on this PR (the Wasm Check job will run abyss-wasm too).

## Out of scope (deferred to subsequent PRs in the v0.6.0 cycle)

- **PR3** — Starlight playground component (CodeMirror or Monaco editor + `wasm-pack build` integration in the docs-site bundler + initial examples menu).
- **PR4** — UX polish: inline error highlighting, URL-hash code sharing, localStorage state, layout polish.
- **PR5** — Release v0.6.0.