### PR TITLE
feat(docs): add Playground page with wasm-pack build pipeline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,11 @@ comment:
   behavior: default
   require_changes: false
   hide_project_coverage: false
+
+# `crates/abyss-wasm/src/bindings.rs` holds the `#[wasm_bindgen]` JS
+# entry points. Their bodies touch `JsValue` which is effectively a stub
+# under native `cargo test`, so they are intrinsically unreachable from
+# our coverage runs. The testable surface (`run`, `PlaygroundBridge`,
+# `EvalOutcome`) lives in `lib.rs` and stays under coverage.
+ignore:
+  - "crates/abyss-wasm/src/bindings.rs"

--- a/crates/abyss-wasm/README.md
+++ b/crates/abyss-wasm/README.md
@@ -1,6 +1,6 @@
 # abyss-wasm
 
-Wasm adapter for the [AbySS interpreter](https://abyss-lang.dev). Wraps `abyss-core` and `abyss-interpreter` behind a single `eval(source)` entry point for the docs-site Playground.
+Wasm adapter for the [AbySS interpreter](https://abyss-lang.dev). Wraps `abyss-core` and `abyss-interpreter` behind a single `evaluate(source)` entry point for the docs-site Playground.
 
 This crate is **not published to crates.io** — it is a private workspace member built by the docs-site bundler (PR3+ of the v0.6.0 cycle).
 
@@ -26,7 +26,11 @@ type EvalOutcome = {
 // rare — only on a serde-wasm-bindgen internal failure). Successful
 // runs and ordinary user errors (parser diagnostics, runtime errors)
 // resolve normally with `error` populated.
-function eval(source: string): EvalOutcome;
+//
+// The function is named `evaluate` rather than `eval` because `eval`
+// is reserved in strict-mode ES modules and `wasm-bindgen` would
+// rename it to `_eval` on the JS side.
+function evaluate(source: string): EvalOutcome;
 ```
 
 `stdout` captures everything `unveil` would print on the CLI. `stderr` carries the parser / runtime diagnostic, ANSI-coloured the same way the CLI prints it (so the playground UI can either render the ANSI codes via xterm.js or strip them for a plain inline message). `error` is non-null when evaluation could not complete; `stdout` may still contain partial output up to the failure point.

--- a/crates/abyss-wasm/src/bindings.rs
+++ b/crates/abyss-wasm/src/bindings.rs
@@ -1,0 +1,35 @@
+//! Wasm-bindgen bridge functions exposed to JavaScript.
+//!
+//! Kept in a dedicated module so the [`crate::run`] core (which is what
+//! the unit tests actually exercise) stays separate from the
+//! `JsValue`-touching wrappers that can only execute under a real wasm
+//! runtime. `codecov.yml` ignores this file because the wrapper bodies
+//! are unreachable from native `cargo test`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::run;
+
+/// Initialise panic hooks once per Wasm instance so a Rust panic gets
+/// surfaced to the browser console instead of an opaque
+/// `RuntimeError: unreachable executed`.
+#[wasm_bindgen(start)]
+pub fn start() {
+    #[cfg(target_arch = "wasm32")]
+    console_error_panic_hook::set_once();
+}
+
+/// Evaluate `source` and return the captured stdout, the rendered
+/// diagnostic (if any), and an `error` string when evaluation could not
+/// complete. The function is exposed to JavaScript as a plain function
+/// taking a string and returning an `EvalOutcome` JSON object.
+///
+/// Named `evaluate` rather than `eval` because `eval` is reserved in
+/// strict-mode ES modules and `wasm-bindgen` renames it to `_eval` on
+/// the JS side, which is awkward for hand-written callers. `evaluate`
+/// reaches the browser unmangled.
+#[wasm_bindgen]
+pub fn evaluate(source: String) -> Result<JsValue, JsValue> {
+    let outcome = run(&source);
+    serde_wasm_bindgen::to_value(&outcome).map_err(|err| JsValue::from_str(&err.to_string()))
+}

--- a/crates/abyss-wasm/src/lib.rs
+++ b/crates/abyss-wasm/src/lib.rs
@@ -1,9 +1,9 @@
 //! Wasm adapter for the AbySS interpreter.
 //!
-//! Exposes a single `eval(source)` entry point that the docs-site
-//! Playground (introduced in PR3 of the v0.6.0 cycle) calls from
-//! JavaScript. Output is captured into a [`String`] via the
-//! [`PlaygroundBridge`] implementation of
+//! Exposes a single `evaluate(source)` entry point (defined in
+//! [`bindings`]) that the docs-site Playground (introduced in PR3 of the
+//! v0.6.0 cycle) calls from JavaScript. Output is captured into a
+//! [`String`] via the [`PlaygroundBridge`] implementation of
 //! [`abyss_interpreter::io_bridge::IoBridge`], and diagnostics flow
 //! through the same `render_*` renderers the CLI uses (so the
 //! playground sees the same ariadne formatting the user would see in a
@@ -18,9 +18,10 @@ use abyss_interpreter::eval::{evaluate as evaluate_ast, render_error_with_source
 use abyss_interpreter::io_bridge::IoBridge;
 use abyss_interpreter::stdlib::create_global_environment;
 use serde::Serialize;
-use wasm_bindgen::prelude::*;
 
-/// Result handed back to JavaScript for each `eval(source)` call.
+mod bindings;
+
+/// Result handed back to JavaScript for each `evaluate(source)` call.
 ///
 /// `stdout` captures everything `unveil` would print on the CLI.
 /// `stderr` carries the parser / runtime diagnostic, ANSI-coloured the
@@ -59,33 +60,9 @@ impl IoBridge for PlaygroundBridge {
     }
 }
 
-/// Initialise panic hooks once per Wasm instance so a Rust panic gets
-/// surfaced to the browser console instead of an opaque
-/// `RuntimeError: unreachable executed`.
-#[wasm_bindgen(start)]
-pub fn start() {
-    #[cfg(target_arch = "wasm32")]
-    console_error_panic_hook::set_once();
-}
-
-/// Evaluate `source` and return the captured stdout, the rendered
-/// diagnostic (if any), and an `error` string when evaluation could not
-/// complete. The function is exposed to JavaScript as a plain function
-/// taking a string and returning an `EvalOutcome` JSON object.
-///
-/// Named `evaluate` rather than `eval` because `eval` is reserved in
-/// strict-mode ES modules and `wasm-bindgen` renames it to `_eval` on
-/// the JS side, which is awkward for hand-written callers. `evaluate`
-/// reaches the browser unmangled.
-#[wasm_bindgen]
-pub fn evaluate(source: String) -> Result<JsValue, JsValue> {
-    let outcome = run(&source);
-    serde_wasm_bindgen::to_value(&outcome).map_err(|err| JsValue::from_str(&err.to_string()))
-}
-
 const PLAYGROUND_SOURCE_ID: &str = "<playground>";
 
-fn run(source: &str) -> EvalOutcome {
+pub(crate) fn run(source: &str) -> EvalOutcome {
     let mut outcome = EvalOutcome::default();
 
     let parsed = parse(source);

--- a/crates/abyss-wasm/src/lib.rs
+++ b/crates/abyss-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::rc::Rc;
 
 use abyss_core::parser::{parse, render_diagnostics};
-use abyss_interpreter::eval::{evaluate, render_error_with_source_id};
+use abyss_interpreter::eval::{evaluate as evaluate_ast, render_error_with_source_id};
 use abyss_interpreter::io_bridge::IoBridge;
 use abyss_interpreter::stdlib::create_global_environment;
 use serde::Serialize;
@@ -72,8 +72,13 @@ pub fn start() {
 /// diagnostic (if any), and an `error` string when evaluation could not
 /// complete. The function is exposed to JavaScript as a plain function
 /// taking a string and returning an `EvalOutcome` JSON object.
+///
+/// Named `evaluate` rather than `eval` because `eval` is reserved in
+/// strict-mode ES modules and `wasm-bindgen` renames it to `_eval` on
+/// the JS side, which is awkward for hand-written callers. `evaluate`
+/// reaches the browser unmangled.
 #[wasm_bindgen]
-pub fn eval(source: String) -> Result<JsValue, JsValue> {
+pub fn evaluate(source: String) -> Result<JsValue, JsValue> {
     let outcome = run(&source);
     serde_wasm_bindgen::to_value(&outcome).map_err(|err| JsValue::from_str(&err.to_string()))
 }
@@ -113,7 +118,7 @@ fn run(source: &str) -> EvalOutcome {
     env.set_io_bridge(Box::new(bridge));
 
     for ast in parsed.ast {
-        if let Err(error) = evaluate(&ast, &mut env) {
+        if let Err(error) = evaluate_ast(&ast, &mut env) {
             // Use the same `<playground>` source id the parser
             // diagnostics carry so the labels stay consistent across
             // both rendering paths.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,9 @@ dist/
 # generated types
 .astro/
 
+# wasm-pack output for the Playground (rebuilt by `bun run build:wasm`)
+public/wasm/
+
 # dependencies
 node_modules/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,16 @@ Every fenced code block tagged `abyss` on the site uses the same TextMate gramma
 
 All commands are run from `docs/` in a terminal.
 
-| Command         | Action                                       |
-| :-------------- | :------------------------------------------- |
-| `bun install`   | Install dependencies                         |
-| `bun dev`       | Start the local dev server at `localhost:4321` |
-| `bun build`     | Build the production site to `./dist/`      |
-| `bun preview`   | Preview the production build locally         |
-| `bun astro ...` | Run Astro CLI commands (e.g. `astro check`)  |
+| Command            | Action                                       |
+| :----------------- | :------------------------------------------- |
+| `bun install`      | Install dependencies                         |
+| `bun run build:wasm` | Compile `crates/abyss-wasm` for the Playground (output → `public/wasm/`) |
+| `bun dev`          | Start the local dev server at `localhost:4321` (rebuilds wasm first) |
+| `bun build`        | Build the production site to `./dist/` (rebuilds wasm first) |
+| `bun preview`      | Preview the production build locally         |
+| `bun astro ...`    | Run Astro CLI commands (e.g. `astro check`)  |
+
+The Playground page (`/playground/`) compiles `abyss-core` and `abyss-interpreter` to WebAssembly via `wasm-pack` and ships the artifact under `public/wasm/`. Running `bun dev` or `bun build` rebuilds it automatically; `bun install` does not. The `wasm-pack` binary must be on `$PATH` — install it once with `cargo install wasm-pack`.
 
 ## Contributing
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig({
                     items: [
                         { label: 'Welcome', slug: 'index' },
                         { label: 'Getting Started', slug: 'getting-started' },
+                        { label: 'Playground', slug: 'playground' },
                     ],
                 },
                 {
@@ -62,4 +63,17 @@ export default defineConfig({
     ],
 
     adapter: vercel(),
+
+    vite: {
+        build: {
+            rollupOptions: {
+                // The Playground component dynamically imports the
+                // wasm-pack output via `/wasm/abyss_wasm.js`. That URL is
+                // served as a static asset at runtime (the file lives
+                // under `docs/public/wasm/`), so Vite/Rollup must not try
+                // to resolve it during the docs-site bundle step.
+                external: [/^\/wasm\//],
+            },
+        },
+    },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,10 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro build",
+    "build:wasm": "wasm-pack build ../crates/abyss-wasm --target web --out-dir ../../docs/public/wasm --no-pack",
+    "dev": "bun run build:wasm && astro dev",
+    "start": "bun run build:wasm && astro dev",
+    "build": "bun run build:wasm && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/docs/src/components/Playground.astro
+++ b/docs/src/components/Playground.astro
@@ -1,0 +1,241 @@
+---
+// Playground component for the AbySS docs site.
+//
+// Embeds a code editor (currently a plain textarea — CodeMirror is
+// queued for the v0.6.0 PR4 polish pass) plus a Run button that loads
+// the wasm-pack output produced by `bun run build:wasm` and feeds the
+// editor contents through `eval(source)`. The captured stdout, the
+// rendered diagnostic, and the short error summary are surfaced in
+// dedicated panels so the user can correlate them with each other.
+//
+// The wasm module is loaded on the first Run click rather than at page
+// load — keeps the docs site fast for visitors who land on the
+// Playground page but never run anything.
+---
+<style>
+    .playground {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 1rem;
+    }
+
+    .playground__toolbar {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .playground__select,
+    .playground__run {
+        font: inherit;
+        padding: 0.4rem 0.75rem;
+        border-radius: 0.25rem;
+        border: 1px solid var(--sl-color-gray-5);
+        background: var(--sl-color-bg-sidebar);
+        color: var(--sl-color-text);
+        cursor: pointer;
+    }
+
+    .playground__run:hover:not(:disabled) {
+        background: var(--sl-color-accent-low);
+    }
+
+    .playground__run:disabled {
+        opacity: 0.6;
+        cursor: progress;
+    }
+
+    .playground__editor {
+        width: 100%;
+        min-height: 16rem;
+        font-family: var(--sl-font-mono);
+        font-size: 0.9rem;
+        padding: 0.75rem;
+        border-radius: 0.25rem;
+        border: 1px solid var(--sl-color-gray-5);
+        background: var(--sl-color-bg);
+        color: var(--sl-color-text);
+        resize: vertical;
+        tab-size: 4;
+    }
+
+    .playground__panel {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .playground__panel-label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--sl-color-gray-2);
+    }
+
+    .playground__output,
+    .playground__error,
+    .playground__summary {
+        font-family: var(--sl-font-mono);
+        font-size: 0.85rem;
+        padding: 0.75rem;
+        border-radius: 0.25rem;
+        background: var(--sl-color-bg-sidebar);
+        border: 1px solid var(--sl-color-gray-5);
+        white-space: pre-wrap;
+        word-break: break-word;
+        min-height: 1.5rem;
+        max-height: 24rem;
+        overflow: auto;
+    }
+
+    .playground__error {
+        border-color: var(--sl-color-red);
+    }
+
+    .playground__summary {
+        border-color: var(--sl-color-red);
+        color: var(--sl-color-red);
+    }
+
+    .playground__hidden {
+        display: none;
+    }
+</style>
+
+<div class="playground">
+    <div class="playground__toolbar">
+        <label for="playground-sample" class="sl-sr-only">Sample</label>
+        <select id="playground-sample" class="playground__select">
+            <option value="hello">hello: unveil &quot;Hello, AbySS!&quot;</option>
+            <option value="patterns">patterns: ward + scroll destructuring</option>
+            <option value="empty">empty: start from scratch</option>
+        </select>
+        <button id="playground-run" type="button" class="playground__run">
+            Run
+        </button>
+        <span id="playground-status" aria-live="polite"></span>
+    </div>
+
+    <textarea
+        id="playground-editor"
+        class="playground__editor"
+        spellcheck="false"
+        autocapitalize="off"
+        autocomplete="off"
+        autocorrect="off"
+    ></textarea>
+
+    <div class="playground__panel" id="playground-summary-panel" hidden>
+        <div class="playground__panel-label">Error summary</div>
+        <pre id="playground-summary" class="playground__summary"></pre>
+    </div>
+
+    <div class="playground__panel">
+        <div class="playground__panel-label">Output</div>
+        <pre id="playground-output" class="playground__output"></pre>
+    </div>
+
+    <div class="playground__panel" id="playground-error-panel" hidden>
+        <div class="playground__panel-label">Diagnostic</div>
+        <pre id="playground-error" class="playground__error"></pre>
+    </div>
+</div>
+
+<script>
+    // Minimal shape of the wasm-pack ESM output we depend on. The
+    // module is loaded at runtime from `/wasm/abyss_wasm.js`, so we
+    // annotate the parts we use rather than rely on TypeScript
+    // resolving an absolute-URL module specifier at type-check time.
+    interface AbyssWasmModule {
+        default: () => Promise<unknown>;
+        eval: (source: string) => EvalOutcome;
+    }
+
+    type EvalOutcome = {
+        stdout: string;
+        stderr: string;
+        error: string | null;
+    };
+
+    const SAMPLES: Record<string, string> = {
+        hello: `unveil("Hello, AbySS!");\n`,
+        patterns: `forge xs: scroll = [10, 20, 30, 40];\n\noracle (xs) {\n    [] => unveil("empty");\n    [head, ..rest] ward head > 5 => unveil(\n        "head=" + head.trans(rune) + ", " + rest.tally().trans(rune) + " more"\n    );\n    _ => unveil("other");\n};\n`,
+        empty: '',
+    };
+
+    const editor = document.getElementById('playground-editor') as HTMLTextAreaElement;
+    const sample = document.getElementById('playground-sample') as HTMLSelectElement;
+    const runBtn = document.getElementById('playground-run') as HTMLButtonElement;
+    const status = document.getElementById('playground-status') as HTMLSpanElement;
+    const output = document.getElementById('playground-output') as HTMLPreElement;
+    const errorPanel = document.getElementById('playground-error-panel') as HTMLElement;
+    const errorPre = document.getElementById('playground-error') as HTMLPreElement;
+    const summaryPanel = document.getElementById('playground-summary-panel') as HTMLElement;
+    const summaryPre = document.getElementById('playground-summary') as HTMLPreElement;
+
+    // Strip ANSI colour codes from the rendered diagnostic so the inline
+    // panel stays readable. A future polish pass can swap this for an
+    // ANSI-aware terminal-emulator component (xterm.js etc.).
+    function stripAnsi(input: string): string {
+        // eslint-disable-next-line no-control-regex
+        return input.replace(/\x1b\[[0-9;]*m/g, '');
+    }
+
+    editor.value = SAMPLES[sample.value] ?? '';
+    sample.addEventListener('change', () => {
+        editor.value = SAMPLES[sample.value] ?? '';
+    });
+
+    let wasmReady: Promise<AbyssWasmModule> | null = null;
+    function loadWasm(): Promise<AbyssWasmModule> {
+        if (wasmReady === null) {
+            status.textContent = 'Loading interpreter…';
+            // The wasm-pack output is served from /wasm/ as a static
+            // asset; the .wasm sibling is fetched relative to the
+            // bundle URL by wasm-bindgen's generated initialiser.
+            // The `// @ts-ignore` skips type resolution for this
+            // absolute-URL specifier.
+            // @ts-ignore - dynamic import of wasm-pack ESM bundle
+            wasmReady = import(/* @vite-ignore */ '/wasm/abyss_wasm.js')
+                .then(async (mod: AbyssWasmModule) => {
+                    await mod.default();
+                    status.textContent = '';
+                    return mod;
+                })
+                .catch((err) => {
+                    status.textContent = '';
+                    wasmReady = null;
+                    throw err;
+                });
+        }
+        return wasmReady;
+    }
+
+    runBtn.addEventListener('click', async () => {
+        runBtn.disabled = true;
+        output.textContent = '';
+        errorPanel.hidden = true;
+        summaryPanel.hidden = true;
+
+        try {
+            const mod = await loadWasm();
+            const outcome = mod.eval(editor.value) as EvalOutcome;
+            output.textContent = outcome.stdout;
+            if (outcome.stderr) {
+                errorPre.textContent = stripAnsi(outcome.stderr);
+                errorPanel.hidden = false;
+            }
+            if (outcome.error) {
+                summaryPre.textContent = outcome.error;
+                summaryPanel.hidden = false;
+            }
+        } catch (err) {
+            summaryPre.textContent =
+                'Failed to run: ' + (err instanceof Error ? err.message : String(err));
+            summaryPanel.hidden = false;
+        } finally {
+            runBtn.disabled = false;
+        }
+    });
+</script>

--- a/docs/src/components/Playground.astro
+++ b/docs/src/components/Playground.astro
@@ -138,11 +138,13 @@
     </div>
 </div>
 
-<script lang="ts">
-    // Minimal shape of the wasm-pack ESM output we depend on. The
-    // module is loaded at runtime from `/wasm/abyss_wasm.js`, so we
-    // annotate the parts we use rather than rely on TypeScript
-    // resolving an absolute-URL module specifier at type-check time.
+<script>
+    // Astro's default `<script>` (no `lang` attribute) is processed by
+    // Vite/esbuild, which transparently handles TypeScript syntax and
+    // bundles the output. Adding `lang="ts"` flipped Astro into inline
+    // mode and shipped the raw `interface` keyword to the browser, so
+    // we keep the plain `<script>` form. Type annotations below stay
+    // for editor support during development; the bundler strips them.
     interface AbyssWasmModule {
         default: () => Promise<unknown>;
         evaluate: (source: string) => EvalOutcome;

--- a/docs/src/components/Playground.astro
+++ b/docs/src/components/Playground.astro
@@ -97,10 +97,6 @@
         border-color: var(--sl-color-red);
         color: var(--sl-color-red);
     }
-
-    .playground__hidden {
-        display: none;
-    }
 </style>
 
 <div class="playground">
@@ -142,14 +138,14 @@
     </div>
 </div>
 
-<script>
+<script lang="ts">
     // Minimal shape of the wasm-pack ESM output we depend on. The
     // module is loaded at runtime from `/wasm/abyss_wasm.js`, so we
     // annotate the parts we use rather than rely on TypeScript
     // resolving an absolute-URL module specifier at type-check time.
     interface AbyssWasmModule {
         default: () => Promise<unknown>;
-        eval: (source: string) => EvalOutcome;
+        evaluate: (source: string) => EvalOutcome;
     }
 
     type EvalOutcome = {
@@ -220,7 +216,7 @@
 
         try {
             const mod = await loadWasm();
-            const outcome = mod.eval(editor.value) as EvalOutcome;
+            const outcome = mod.evaluate(editor.value);
             output.textContent = outcome.stdout;
             if (outcome.stderr) {
                 errorPre.textContent = stripAnsi(outcome.stderr);

--- a/docs/src/content/docs/playground.mdx
+++ b/docs/src/content/docs/playground.mdx
@@ -1,0 +1,14 @@
+---
+title: Playground
+description: Run AbySS code directly in your browser. The interpreter is compiled to WebAssembly and shipped with this page.
+---
+
+import Playground from '../../components/Playground.astro';
+
+Try AbySS without installing anything. The interpreter compiles to WebAssembly (the same `abyss-core` and `abyss-interpreter` crates the CLI uses), so what you see here matches what `abyss invoke` would print on your machine.
+
+`unveil` writes appear under **Output**. Parser and runtime diagnostics appear under **Diagnostic** with the same labels the CLI shows; an inline **Error summary** is displayed when execution could not complete. `summon` (interactive input) is intentionally not wired up in the browser — calling it raises a clear runtime error rather than blocking forever.
+
+<Playground />
+
+Pick a sample from the dropdown to seed the editor, or start from scratch and write your own. Hit **Run** to evaluate.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target wasm32-unknown-unknown && . \"$HOME/.cargo/env\" && cargo install --locked wasm-pack && cd docs && bun install --frozen-lockfile",
+  "buildCommand": ". \"$HOME/.cargo/env\" && cd docs && bun run build",
+  "outputDirectory": "docs/dist"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": ". /rust/env && rustup target add wasm32-unknown-unknown && cargo install --locked wasm-pack && cd docs && bun install --frozen-lockfile",
-  "buildCommand": ". /rust/env && cd docs && bun run build",
-  "outputDirectory": "docs/dist"
+  "installCommand": ". /rust/env && rustup target add wasm32-unknown-unknown && cargo install --locked wasm-pack && bun install --frozen-lockfile",
+  "buildCommand": ". /rust/env && bun run build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": ". /rust/env && rustup target add wasm32-unknown-unknown && cargo install --locked wasm-pack && bun install --frozen-lockfile",
+  "installCommand": ". /rust/env && rustup target add wasm32-unknown-unknown && cargo install --locked --version 0.14.0 wasm-pack && bun install --frozen-lockfile",
   "buildCommand": ". /rust/env && bun run build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target wasm32-unknown-unknown && . \"$HOME/.cargo/env\" && cargo install --locked wasm-pack && cd docs && bun install --frozen-lockfile",
-  "buildCommand": ". \"$HOME/.cargo/env\" && cd docs && bun run build",
+  "installCommand": ". /rust/env && rustup target add wasm32-unknown-unknown && cargo install --locked wasm-pack && cd docs && bun install --frozen-lockfile",
+  "buildCommand": ". /rust/env && cd docs && bun run build",
   "outputDirectory": "docs/dist"
 }


### PR DESCRIPTION
## Summary

Third piece of the **v0.6.0 Web Playground & Wasm** cycle. End-to-end in-browser AbySS execution lands here: paste / edit code, hit **Run**, see captured stdout, the rendered diagnostic, and an inline error summary, all from the docs site at `/playground/`.

## What changes

- **`docs/src/components/Playground.astro`** — vanilla TypeScript component (no React/Solid pulled in) that renders a `<textarea>` editor, a sample dropdown (hello / patterns / empty), a Run button, and three output panels (stdout / diagnostic / error summary). Dynamically imports `/wasm/abyss_wasm.js` on first Run, routes editor contents through `eval(source)` from the `abyss-wasm` crate (PR #431), and surfaces the captured fields. ANSI colour codes are stripped client-side so the diagnostic panel stays readable.
- **`docs/src/content/docs/playground.mdx`** — the page that mounts the component and explains the surface.
- **`docs/astro.config.mjs`** — Playground entry under the *Start Here* sidebar group; Vite/Rollup config externalises `/wasm/...` so the bundler does not try to resolve the dynamic import at build time.
- **`docs/package.json`** — new `build:wasm` script that runs `wasm-pack build ../crates/abyss-wasm --target web --out-dir ../../docs/public/wasm --no-pack`. `dev` / `start` / `build` chain it so a contributor cloning the repo gets a working Playground after `bun install` + `bun dev` (with `wasm-pack` installed once via `cargo install wasm-pack`).
- **`vercel.json`** — installs the Rust toolchain and `wasm-pack` in Vercel's install hook, then chains the docs build. Adds ~3 min to a cold deploy but means the Playground works on the production deploy without an external CDN.
- **`docs/README.md`** — documents the `wasm-pack` requirement and the new `build:wasm` script.

## Test plan

- [x] \`bun run build\` from \`docs/\` succeeds end-to-end (16 pages built, including \`/playground/\`).
- [x] Generated HTML for \`/playground/\` contains the editor / sample dropdown / Run button / output / diagnostic / summary markup.
- [x] The bundled component still references \`/wasm/abyss_wasm.js\` (Vite externalisation works as expected).
- [x] \`docs/public/wasm/\` is gitignored — Vercel rebuilds it from source on every deploy.
- [ ] CI green on this PR.
- [ ] Eyeball the Vercel preview to confirm the Playground loads, the wasm initialises on first Run, and the sample programs print as expected.

## Out of scope (deferred to subsequent PRs in the v0.6.0 cycle)

- **PR4 — UX polish**: swap the textarea for CodeMirror with AbySS syntax highlighting, URL-hash code sharing, \`localStorage\` persistence, inline error highlighting, layout tweaks for narrow screens.
- **PR5 — Release v0.6.0**: version bump 0.5.0 → 0.6.0 + develop→main promotion to fire \`release.yml\`.