### PR TITLE
chore(deps): centralise shared dependencies in workspace.dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ AbySS is a magic-themed scripting language with its own interpreter, formatter, 
 ## Tech Stack
 
 - Rust stable toolchain, edition 2024.
-- `chumsky` 0.12 for parser combinators and `ariadne` 0.6 for themed diagnostics (both in `abyss-core`).
-- `ordered-float` 5 for deterministic floating-point comparisons.
+- `chumsky` 0.13 for parser combinators and `ariadne` 0.6 for themed diagnostics (both in `abyss-core`).
+- `ordered-float` 5 for deterministic floating-point comparisons (in `abyss-core`; shared third-party versions are pinned once in the root `[workspace.dependencies]`).
 - `clap` 4, `rustyline` 18, `colored` 3, and `dirs` 6 in `abyss-cli` for the CLI, REPL, terminal styling, and OS config paths.
 
 ## Conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,6 @@ version = "0.5.0"
 dependencies = [
  "abyss-core",
  "ariadne",
- "ordered-float",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ homepage = "https://abyss-lang.dev"
 [workspace.dependencies]
 abyss-core = { path = "crates/abyss-core", version = "0.5.0" }
 abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.5.0" }
+ariadne = "0.6"
+chumsky = "0.13"
+ordered-float = "5"
 
 [workspace.metadata.release]
 shared-version = true

--- a/crates/abyss-core/Cargo.toml
+++ b/crates/abyss-core/Cargo.toml
@@ -12,6 +12,6 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-ariadne = "0.6"
-chumsky = "0.13"
-ordered-float = "5"
+ariadne.workspace = true
+chumsky.workspace = true
+ordered-float.workspace = true

--- a/crates/abyss-interpreter/Cargo.toml
+++ b/crates/abyss-interpreter/Cargo.toml
@@ -13,5 +13,4 @@ homepage.workspace = true
 
 [dependencies]
 abyss-core.workspace = true
-ariadne = "0.6"
-ordered-float = "5"
+ariadne.workspace = true


### PR DESCRIPTION
## Summary

Resolves #501.

- Move `ariadne`, `chumsky`, and `ordered-float` version pins to the root `[workspace.dependencies]`; crate manifests now use `<dep>.workspace = true`, so each shared third-party version is declared exactly once.
- Remove the unused `ordered-float` dependency from `abyss-interpreter` (zero references in `src/` and `tests/`; it is only used by `abyss-core` for `Token::Aether`).
- Fix the stale chumsky version in `AGENTS.md` (0.12 → 0.13) and note the workspace-level pinning policy.

## Not included

The optional `cargo machete` pre-commit/CI hook from #501 is left out to keep this PR manifest-only; it can land separately if desired.

## Verification

- `cargo check --workspace`
- `cargo test --workspace` — all 24 test binaries pass
- `python3 scripts/check_version_sync.py` (via pre-commit) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
