### PR TITLE
test: move shared integration-test helper to tests/common/

### DIFF
--- a/crates/abyss-interpreter/src/eval/mod.rs
+++ b/crates/abyss-interpreter/src/eval/mod.rs
@@ -3,6 +3,8 @@ mod collections;
 mod expressions;
 mod result;
 mod statements;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod values;
 
 pub use result::{

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1348,60 +1348,10 @@ fn clone_indexed_child(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::env::{ArtifactFieldSchema, ArtifactSchema, ArtifactValue};
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-    use std::rc::Rc;
+    use crate::eval::test_support::{artifact_handle, lexicon, register_artifact, rune, scroll};
 
     fn line() -> Option<LineInfo> {
         Some(LineInfo::new(1, 1))
-    }
-
-    fn scroll(values: Vec<Value>) -> Value {
-        Value::Scroll(Rc::new(RefCell::new(values)))
-    }
-
-    fn lexicon(entries: Vec<(&str, Value)>) -> Value {
-        let mut map = HashMap::new();
-        for (key, value) in entries {
-            map.insert(key.to_string(), value);
-        }
-        Value::Lexicon(Rc::new(RefCell::new(map)))
-    }
-
-    fn rune(text: &str) -> Value {
-        Value::Rune(Rc::new(text.to_string()))
-    }
-
-    fn artifact_handle(name: &str, fields: Vec<(&str, Value)>) -> Rc<RefCell<ArtifactValue>> {
-        let mut map = HashMap::new();
-        let mut order = Vec::new();
-        for (field, value) in fields {
-            let key = field.to_string();
-            order.push(key.clone());
-            map.insert(key, value);
-        }
-        Rc::new(RefCell::new(ArtifactValue {
-            type_name: name.to_string(),
-            fields: map,
-            field_order: order,
-        }))
-    }
-
-    fn register_artifact(env: &mut RuntimeEnv, name: &str, fields: Vec<(&str, Type)>) {
-        let schema = ArtifactSchema {
-            name: name.to_string(),
-            fields: fields
-                .into_iter()
-                .map(|(field, field_type)| ArtifactFieldSchema {
-                    name: field.to_string(),
-                    field_type,
-                })
-                .collect(),
-            methods: HashMap::new(),
-            line_info: None,
-        };
-        env.define_artifact(schema).expect("schema registration");
     }
 
     #[test]

--- a/crates/abyss-interpreter/src/eval/test_support.rs
+++ b/crates/abyss-interpreter/src/eval/test_support.rs
@@ -1,0 +1,61 @@
+//! Shared constructors for the `eval` unit tests.
+//!
+//! Only compiled for `cfg(test)`; keeps the per-module `#[cfg(test)]`
+//! blocks free of copy-pasted `Value` / artifact scaffolding.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use abyss_core::ast::Type;
+
+use crate::env::{
+    ArtifactFieldSchema, ArtifactHandle, ArtifactSchema, ArtifactValue, RuntimeEnv, Value,
+};
+
+pub(crate) fn rune(text: &str) -> Value {
+    Value::Rune(Rc::new(text.to_string()))
+}
+
+pub(crate) fn scroll(values: Vec<Value>) -> Value {
+    Value::Scroll(Rc::new(RefCell::new(values)))
+}
+
+pub(crate) fn lexicon(entries: Vec<(&str, Value)>) -> Value {
+    let mut map = HashMap::new();
+    for (key, value) in entries {
+        map.insert(key.to_string(), value);
+    }
+    Value::Lexicon(Rc::new(RefCell::new(map)))
+}
+
+pub(crate) fn artifact_handle(name: &str, fields: Vec<(&str, Value)>) -> ArtifactHandle {
+    let mut map = HashMap::new();
+    let mut order = Vec::new();
+    for (field, value) in fields {
+        let key = field.to_string();
+        order.push(key.clone());
+        map.insert(key, value);
+    }
+    Rc::new(RefCell::new(ArtifactValue {
+        type_name: name.to_string(),
+        fields: map,
+        field_order: order,
+    }))
+}
+
+pub(crate) fn register_artifact(env: &mut RuntimeEnv, name: &str, fields: Vec<(&str, Type)>) {
+    let schema = ArtifactSchema {
+        name: name.to_string(),
+        fields: fields
+            .into_iter()
+            .map(|(field, field_type)| ArtifactFieldSchema {
+                name: field.to_string(),
+                field_type,
+            })
+            .collect(),
+        methods: HashMap::new(),
+        line_info: None,
+    };
+    env.define_artifact(schema).expect("schema registration");
+}

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -253,22 +253,8 @@ fn clone_lexicon(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{cell::RefCell, collections::HashMap, rc::Rc};
-
-    fn artifact_handle(name: &str, fields: Vec<(&str, Value)>) -> ArtifactHandle {
-        let mut map = HashMap::new();
-        let mut order = Vec::new();
-        for (key, value) in fields {
-            let key_string = key.to_string();
-            order.push(key_string.clone());
-            map.insert(key_string, value);
-        }
-        Rc::new(RefCell::new(ArtifactValue {
-            type_name: name.to_string(),
-            fields: map,
-            field_order: order,
-        }))
-    }
+    use crate::eval::test_support::artifact_handle;
+    use std::{cell::RefCell, rc::Rc};
 
     fn line() -> Option<LineInfo> {
         Some(LineInfo::new(2, 3))

--- a/crates/abyss-interpreter/tests/common/mod.rs
+++ b/crates/abyss-interpreter/tests/common/mod.rs
@@ -1,11 +1,13 @@
+//! Shared driver for the integration suites: parses a source string and
+//! evaluates every statement against a fresh global environment. Lives in
+//! `tests/common/` (a directory, not a top-level file) so Cargo does not
+//! compile it as a test target of its own.
+
 use abyss_core::parser::{emit_diagnostics, parse};
 use abyss_interpreter::{
     eval::{EvalResult, display_error_with_source_id, evaluate},
     stdlib,
 };
-
-#[allow(unused_imports)]
-pub use abyss_interpreter::env::Value;
 
 const TEST_SOURCE_ID: &str = "<test>";
 

--- a/crates/abyss-interpreter/tests/test_artifacts.rs
+++ b/crates/abyss-interpreter/tests/test_artifacts.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn artifact_instantiation_and_access() {

--- a/crates/abyss-interpreter/tests/test_calc.rs
+++ b/crates/abyss-interpreter/tests/test_calc.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_parse_arcana_simple() {

--- a/crates/abyss-interpreter/tests/test_collections.rs
+++ b/crates/abyss-interpreter/tests/test_collections.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn tally_handles_scroll_and_lexicon() {

--- a/crates/abyss-interpreter/tests/test_comp.rs
+++ b/crates/abyss-interpreter/tests/test_comp.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_arcana_comparison_equal() {

--- a/crates/abyss-interpreter/tests/test_engrave.rs
+++ b/crates/abyss-interpreter/tests/test_engrave.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::EvalResult;
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_simple_function() {

--- a/crates/abyss-interpreter/tests/test_examples.rs
+++ b/crates/abyss-interpreter/tests/test_examples.rs
@@ -1,8 +1,8 @@
-mod test_base;
+mod common;
 
+use common::test_base;
 use std::fs;
 use std::path::PathBuf;
-use test_base::test_base;
 
 fn load_example(name: &str) -> String {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/abyss-interpreter/tests/test_forge.rs
+++ b/crates/abyss-interpreter/tests/test_forge.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_forge_and_usage() {

--- a/crates/abyss-interpreter/tests/test_logical.rs
+++ b/crates/abyss-interpreter/tests/test_logical.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::EvalResult;
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_logical_not() {

--- a/crates/abyss-interpreter/tests/test_oracle.rs
+++ b/crates/abyss-interpreter/tests/test_oracle.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::EvalResult;
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_oracle_simple_positive() {

--- a/crates/abyss-interpreter/tests/test_orbit.rs
+++ b/crates/abyss-interpreter/tests/test_orbit.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::EvalResult;
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_simple_orbit() {

--- a/crates/abyss-interpreter/tests/test_rune.rs
+++ b/crates/abyss-interpreter/tests/test_rune.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_parse_rune() {

--- a/crates/abyss-interpreter/tests/test_type.rs
+++ b/crates/abyss-interpreter/tests/test_type.rs
@@ -1,7 +1,8 @@
-mod test_base;
+mod common;
 
+use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
-use test_base::{Value, test_base};
+use common::test_base;
 
 #[test]
 fn test_cast_arcana_to_aether() {


### PR DESCRIPTION
## Summary

Resolves #502.

- Move `tests/test_base.rs` to the conventional `tests/common/mod.rs`. Directories under `tests/` are not treated as test targets, so Cargo no longer compiles the shared helper as its own empty test binary (previously visible as extra `running 0 tests` entries).
- Drop the `#[allow(unused_imports)]` workaround: the `Value` re-export is gone and the suites that need `Value` import it directly from `abyss_interpreter::env`.
- Dedupe the unit-test constructors (`rune`, `scroll`, `lexicon`, `artifact_handle`, `register_artifact`) previously copy-pasted between the `#[cfg(test)]` modules of `eval/statements.rs` and `eval/values.rs` into a new `cfg(test)`-only `eval::test_support` module. The `line()` helpers stay local because the two suites intentionally use different positions.

## Verification

- `cargo test -p abyss-interpreter` — all 14 test binaries pass, zero warnings
- Pre-commit (`cargo fmt`, `clippy -D warnings`, `check`, `test`) — passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
