### PR TITLE
refactor(interpreter): split env.rs into env / value / artifact modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guidance for AI coding assistants (and humans) working in this repository.
 AbySS is a magic-themed scripting language with its own interpreter, formatter, and CLI tooling. The repo is a single Cargo workspace that also hosts the Starlight documentation site and the VS Code extension.
 
 - **`crates/abyss-core`** — AST (`ast.rs`), `chumsky`-based parser (`parser/`), and formatter (`format.rs`). Designed to stay lightweight so a future LSP or Wasm playground can depend on it without pulling in runtime code.
-- **`crates/abyss-interpreter`** — `RuntimeEnv` (`env.rs`), the `Value` enum, the evaluator (`eval/`), and the standard library (`stdlib/`, including the per-type method tables).
+- **`crates/abyss-interpreter`** — `RuntimeEnv` (`env.rs`), the `Value` enum (`value.rs`), artifact schemas/instances (`artifact.rs`), the evaluator (`eval/`), and the standard library (`stdlib/`, including the per-type method tables).
 - **`crates/abyss-cli`** — the user-facing binary `abyss` (crate name `abyss-lang`, published to crates.io). Hosts `main.rs` with `start_interpreter` (the REPL driver) and the `clap` subcommands `cast`, `invoke`, and `align`.
 - **`docs/`** — Starlight (Astro + bun) source for <https://abyss-lang.dev>.
 - **`editors/code/`** — the `abyss-codex-familiar` VS Code extension. Version is kept in lockstep with the `abyss-lang` crate (see `scripts/check_version_sync.py`).

--- a/crates/abyss-interpreter/src/artifact.rs
+++ b/crates/abyss-interpreter/src/artifact.rs
@@ -1,0 +1,63 @@
+//! Artifact (user-defined struct) metadata and instances.
+//!
+//! An artifact definition registers an [`ArtifactSchema`] (field names,
+//! types, and methods) in the [`RuntimeEnv`](crate::env::RuntimeEnv);
+//! instantiation produces an [`ArtifactValue`] shared behind an
+//! [`ArtifactHandle`] so multiple bindings alias the same instance.
+//! Re-exported from [`crate::env`] for backwards compatibility with the
+//! pre-split module layout.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use abyss_core::ast::{LineInfo, Type};
+
+use crate::env::EngravedFunction;
+use crate::value::Value;
+
+/// A method engraved on an artifact schema. `requires_mutable_receiver`
+/// records whether the receiver was declared `morph self`, so calls on
+/// immutable bindings can be rejected.
+#[derive(Debug, Clone)]
+pub struct ArtifactMethod {
+    pub function: EngravedFunction,
+    pub requires_mutable_receiver: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactSchema {
+    pub name: String,
+    pub fields: Vec<ArtifactFieldSchema>,
+    pub methods: HashMap<String, ArtifactMethod>,
+    pub line_info: Option<LineInfo>,
+}
+
+impl ArtifactSchema {
+    pub fn field(&self, name: &str) -> Option<&ArtifactFieldSchema> {
+        self.fields.iter().find(|field| field.name == name)
+    }
+
+    pub fn field_names(&self) -> Vec<String> {
+        self.fields.iter().map(|field| field.name.clone()).collect()
+    }
+
+    pub fn method(&self, name: &str) -> Option<&ArtifactMethod> {
+        self.methods.get(name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactFieldSchema {
+    pub name: String,
+    pub field_type: Type,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactValue {
+    pub type_name: String,
+    pub fields: HashMap<String, Value>,
+    pub field_order: Vec<String>,
+}
+
+pub type ArtifactHandle = Rc<RefCell<ArtifactValue>>;

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -1,9 +1,15 @@
 use crate::diagnostics::{did_you_mean, label_with_suggestions};
 use crate::eval::{EvalError, EvalResult};
 use abyss_core::ast::{AST, LineInfo, Type};
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
+
+// Value and artifact types moved to dedicated modules; re-exported here so
+// pre-split paths (`crate::env::Value`, `abyss_interpreter::env::Value`, …)
+// keep working.
+pub use crate::artifact::{
+    ArtifactFieldSchema, ArtifactHandle, ArtifactMethod, ArtifactSchema, ArtifactValue,
+};
+pub use crate::value::Value;
 
 pub type BuiltinFunc =
     fn(&mut RuntimeEnv, Vec<CallArg>, Option<LineInfo>) -> Result<EvalResult, EvalError>;
@@ -44,12 +50,6 @@ pub struct EngravedFunction {
 pub struct BuiltinFunction {
     pub name: String,
     pub func: BuiltinFunc,
-}
-
-#[derive(Debug, Clone)]
-pub struct ArtifactMethod {
-    pub function: EngravedFunction,
-    pub requires_mutable_receiver: bool,
 }
 
 /// Stores information about a variable, including its value, type, and mutability.
@@ -355,65 +355,10 @@ impl Default for RuntimeEnv {
     }
 }
 
-/// Represents the value stored in a variable, including primitive scalars, collections,
-/// glyphs (type handles), and artifact instances.
-#[derive(Debug, Clone)]
-pub enum Value {
-    Omen(bool),
-    Arcana(i64),
-    Aether(f64),
-    Rune(Rc<String>),
-    Abyss,
-    Scroll(Rc<RefCell<Vec<Value>>>),
-    Lexicon(Rc<RefCell<HashMap<String, Value>>>),
-    Glyph(Type),
-    Artifact(ArtifactHandle),
-}
-
-#[derive(Debug, Clone)]
-pub struct ArtifactSchema {
-    pub name: String,
-    pub fields: Vec<ArtifactFieldSchema>,
-    pub methods: HashMap<String, ArtifactMethod>,
-    pub line_info: Option<LineInfo>,
-}
-
-impl ArtifactSchema {
-    pub fn field(&self, name: &str) -> Option<&ArtifactFieldSchema> {
-        self.fields.iter().find(|field| field.name == name)
-    }
-
-    pub fn field_names(&self) -> Vec<String> {
-        self.fields.iter().map(|field| field.name.clone()).collect()
-    }
-
-    pub fn method(&self, name: &str) -> Option<&ArtifactMethod> {
-        self.methods.get(name)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ArtifactFieldSchema {
-    pub name: String,
-    pub field_type: Type,
-}
-
-#[derive(Debug, Clone)]
-pub struct ArtifactValue {
-    pub type_name: String,
-    pub fields: HashMap<String, Value>,
-    pub field_order: Vec<String>,
-}
-
-pub type ArtifactHandle = Rc<RefCell<ArtifactValue>>;
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn rune(text: &str) -> Value {
-        Value::Rune(Rc::new(text.to_string()))
-    }
+    use crate::eval::test_support::rune;
 
     fn artifact_schema(name: &str) -> ArtifactSchema {
         ArtifactSchema {

--- a/crates/abyss-interpreter/src/lib.rs
+++ b/crates/abyss-interpreter/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod artifact;
 pub(crate) mod diagnostics;
 pub mod env;
 pub mod eval;
 pub mod io_bridge;
 pub mod stdlib;
+pub mod value;

--- a/crates/abyss-interpreter/src/value.rs
+++ b/crates/abyss-interpreter/src/value.rs
@@ -1,0 +1,31 @@
+//! The interpreter's core value representation.
+//!
+//! [`Value`] is what variables hold at runtime. Collections (`Scroll`,
+//! `Lexicon`) and artifact instances are reference-counted with interior
+//! mutability so assignment aliases rather than deep-copies; deep copies
+//! are made explicitly where the language semantics require them (see
+//! `eval::values`). Re-exported from [`crate::env`] for backwards
+//! compatibility with the pre-split module layout.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use abyss_core::ast::Type;
+
+use crate::artifact::ArtifactHandle;
+
+/// Represents the value stored in a variable, including primitive scalars, collections,
+/// glyphs (type handles), and artifact instances.
+#[derive(Debug, Clone)]
+pub enum Value {
+    Omen(bool),
+    Arcana(i64),
+    Aether(f64),
+    Rune(Rc<String>),
+    Abyss,
+    Scroll(Rc<RefCell<Vec<Value>>>),
+    Lexicon(Rc<RefCell<HashMap<String, Value>>>),
+    Glyph(Type),
+    Artifact(ArtifactHandle),
+}


### PR DESCRIPTION
## Summary

Resolves #504.

`env.rs` (692 lines) mixed three concerns: scope management, the core value representation, and artifact metadata. This splits it along those lines:

- **`src/value.rs`** — the `Value` enum, with a module doc covering the aliasing semantics of the `Rc<RefCell<…>>` collection variants.
- **`src/artifact.rs`** — `ArtifactMethod`, `ArtifactSchema`, `ArtifactFieldSchema`, `ArtifactValue`, `ArtifactHandle`.
- **`src/env.rs`** — now only `RuntimeEnv`, the callable machinery (`Callable`, `EngravedFunction`, `BuiltinFunction`, `CallArg`, builtin registries), and `VarInfo`.

Compatibility: `env.rs` re-exports the moved types, so every existing path (`crate::env::Value`, `abyss_interpreter::env::Value`, …) keeps working — zero changes needed at call sites, and no public-API breakage. The new canonical modules are also exported at the crate root.

The `rune()` unit-test helper in `env.rs` now reuses `eval::test_support` instead of a local copy (follow-up to #502). `AGENTS.md`'s crate overview is updated to the new layout.

## Verification

- `cargo test -p abyss-interpreter` — all 14 test binaries pass, zero warnings
- `cargo clippy --workspace --all-targets` — clean
- Pure code move; no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
