### PR TITLE
refactor(interpreter): unify artifact representation in EvalResult

### DIFF
--- a/crates/abyss-interpreter/src/eval/artifacts.rs
+++ b/crates/abyss-interpreter/src/eval/artifacts.rs
@@ -99,7 +99,6 @@ pub(crate) fn expect_artifact_from_eval(
     line_info: &Option<LineInfo>,
 ) -> Result<ArtifactHandle, EvalError> {
     match result {
-        EvalResult::Artifact(handle) => Ok(handle),
         EvalResult::Data(Value::Artifact(handle)) => Ok(handle),
         EvalResult::Data(other) => Err(EvalError::InvalidOperation(
             format!("Expected artifact value, found {}", describe_value(&other)),
@@ -413,7 +412,7 @@ mod tests {
     fn expect_artifact_from_eval_accepts_multiple_sources() {
         let handle = artifact_handle("Sigil", vec![]);
         let eval_handle =
-            expect_artifact_from_eval(EvalResult::Artifact(handle.clone()), &None).unwrap();
+            expect_artifact_from_eval(EvalResult::artifact(handle.clone()), &None).unwrap();
         assert!(Rc::ptr_eq(&handle, &eval_handle));
 
         let data_handle =

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -68,10 +68,7 @@ pub(crate) fn try_evaluate_expression(
             let value = statements::evaluate(target, env)?;
             let handle = expect_artifact_from_eval(value, line_info)?;
             let field_value = read_artifact_field(env, &handle, field, line_info)?;
-            match field_value {
-                Value::Artifact(inner) => EvalResult::Artifact(inner),
-                other => EvalResult::data(other),
-            }
+            EvalResult::data(field_value)
         }
         AST::Add(left, right, line_info) => binary_numeric_op(
             env,
@@ -325,7 +322,7 @@ fn instantiate_artifact_literal(
         ));
     }
 
-    Ok(EvalResult::Artifact(instantiate_artifact_handle(
+    Ok(EvalResult::artifact(instantiate_artifact_handle(
         type_name,
         field_order,
         values,
@@ -348,10 +345,7 @@ fn compare_values(
             (l - r).abs() < f64::EPSILON
         }
         (EvalResult::Data(Value::Rune(l)), EvalResult::Data(Value::Rune(r))) => l == r,
-        (EvalResult::Artifact(left), EvalResult::Artifact(right))
-        | (EvalResult::Artifact(left), EvalResult::Data(Value::Artifact(right)))
-        | (EvalResult::Data(Value::Artifact(left)), EvalResult::Artifact(right))
-        | (EvalResult::Data(Value::Artifact(left)), EvalResult::Data(Value::Artifact(right))) => {
+        (EvalResult::Data(Value::Artifact(left)), EvalResult::Data(Value::Artifact(right))) => {
             compare_artifacts(env, &left, &right, line_info)?
         }
         _ => {
@@ -446,15 +440,6 @@ fn evaluate_method_call(
     }
 
     match receiver_result {
-        EvalResult::Artifact(handle) => evaluate_artifact_method_call(
-            env,
-            receiver,
-            receiver_var_name,
-            handle,
-            method_name,
-            evaluated_args,
-            line_info,
-        ),
         EvalResult::Data(Value::Artifact(handle)) => evaluate_artifact_method_call(
             env,
             receiver,
@@ -556,7 +541,7 @@ fn evaluate_artifact_method_call(
 
     let mut evaluated_args = Vec::with_capacity(arg_values.len() + 1);
     evaluated_args.push(CallArg {
-        value: EvalResult::Artifact(receiver_handle),
+        value: EvalResult::artifact(receiver_handle),
         var_name: receiver_var_name,
     });
     evaluated_args.extend(arg_values);
@@ -678,7 +663,7 @@ fn evaluate_engraved_function(
         (Type::Artifact(expected), Value::Artifact(handle)) => {
             let type_name = handle.borrow().type_name.clone();
             if type_name == expected {
-                Ok(EvalResult::Artifact(handle))
+                Ok(EvalResult::artifact(handle))
             } else {
                 Err(EvalError::TypeError(
                     format!(
@@ -727,7 +712,7 @@ fn convert_morph_param_value(
 ) -> Result<Value, EvalError> {
     match param_type {
         Type::Artifact(expected) => match evaluated_arg {
-            EvalResult::Artifact(handle) | EvalResult::Data(Value::Artifact(handle)) => {
+            EvalResult::Data(Value::Artifact(handle)) => {
                 validate_artifact_type(handle, expected, line_info)
             }
             other => convert_to_typed_value(other, param_type, line_info),

--- a/crates/abyss-interpreter/src/eval/patterns.rs
+++ b/crates/abyss-interpreter/src/eval/patterns.rs
@@ -49,11 +49,8 @@ pub(super) fn evaluate_oracle(
             EvalResult::Data(Value::Scroll(handle)) => Value::Scroll(handle.clone()),
             // Artifacts (typed records) flow through similarly so an
             // artifact pattern arm sees the same handle the user passed
-            // in. The `EvalResult::Artifact` variant is also accepted so
-            // the helper can be invoked equally from places that hand
-            // through the dedicated artifact result.
+            // in.
             EvalResult::Data(Value::Artifact(handle)) => Value::Artifact(handle.clone()),
-            EvalResult::Artifact(handle) => Value::Artifact(handle.clone()),
             // Lexicons flow through as their shared handle so a lexicon
             // pattern arm sees the same entries the user passed in. Mutating
             // the lexicon inside the arm body therefore visibly mutates the
@@ -597,7 +594,6 @@ fn match_artifact_pattern(
                 let pattern_result = evaluate(other, env)?;
                 let pattern_value = match pattern_result {
                     EvalResult::Data(value) => value,
-                    EvalResult::Artifact(handle) => Value::Artifact(handle),
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
                         return Err(EvalError::InvalidOperation(
                             "Artifact field pattern compare must yield a value".to_string(),
@@ -711,7 +707,6 @@ fn match_lexicon_pattern(
                 let pattern_result = evaluate(other, env)?;
                 let pattern_value = match pattern_result {
                     EvalResult::Data(value) => value,
-                    EvalResult::Artifact(handle) => Value::Artifact(handle),
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
                         return Err(EvalError::InvalidOperation(
                             "Lexicon entry pattern compare must yield a value".to_string(),

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -4,10 +4,14 @@ use ariadne::{Color, Label, Report, ReportKind, Source};
 use std::fmt;
 
 /// Represents the result of an evaluation in the interpreter.
+///
+/// Artifacts have no dedicated variant: they travel as
+/// `Data(Value::Artifact(_))` like every other value, so consumers only
+/// need to distinguish data from the control-flow variants
+/// (`Revealed` / `Resume` / `Eject`).
 #[derive(Debug, Clone)]
 pub enum EvalResult {
     Data(Value),
-    Artifact(ArtifactHandle),
     Revealed(Box<EvalResult>),
     Resume(Option<String>),
     Eject(Option<String>),
@@ -23,7 +27,7 @@ impl EvalResult {
     }
 
     pub fn artifact(handle: ArtifactHandle) -> Self {
-        EvalResult::Artifact(handle)
+        EvalResult::Data(Value::Artifact(handle))
     }
 }
 
@@ -253,7 +257,7 @@ mod tests {
     fn artifact_constructor_preserves_handle() {
         let handle = sample_handle("Sigil");
         match EvalResult::artifact(handle.clone()) {
-            EvalResult::Artifact(result_handle) => {
+            EvalResult::Data(Value::Artifact(result_handle)) => {
                 assert!(Rc::ptr_eq(&result_handle, &handle))
             }
             other => panic!("expected artifact handle, got {:?}", other),

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -7,16 +7,12 @@ use std::rc::Rc;
 use super::result::{EvalError, EvalResult};
 
 pub(crate) fn value_to_eval_result(value: &Value) -> EvalResult {
-    match value {
-        Value::Artifact(handle) => EvalResult::Artifact(handle.clone()),
-        _ => EvalResult::data(value.clone()),
-    }
+    EvalResult::data(value.clone())
 }
 
 pub(crate) fn eval_result_to_value_any(result: EvalResult) -> Result<Value, EvalError> {
     match result {
         EvalResult::Data(value) => Ok(value),
-        EvalResult::Artifact(handle) => Ok(Value::Artifact(handle)),
         EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
             Err(EvalError::InvalidOperation(
                 "Control-flow result cannot be treated as data".to_string(),
@@ -44,7 +40,6 @@ pub(crate) fn convert_to_typed_value(
 ) -> Result<Value, EvalError> {
     let value = match result {
         EvalResult::Data(value) => value,
-        EvalResult::Artifact(handle) => Value::Artifact(handle),
         control => {
             return Err(EvalError::InvalidOperation(
                 format!("Expected data value but received {:?}", control),
@@ -270,7 +265,9 @@ mod tests {
 
         let handle = artifact_handle("Glyph", vec![("power", Value::Arcana(3))]);
         match value_to_eval_result(&Value::Artifact(handle.clone())) {
-            EvalResult::Artifact(result_handle) => assert!(Rc::ptr_eq(&handle, &result_handle)),
+            EvalResult::Data(Value::Artifact(result_handle)) => {
+                assert!(Rc::ptr_eq(&handle, &result_handle))
+            }
             other => panic!("expected artifact handle, got {:?}", other),
         }
     }

--- a/crates/abyss-interpreter/src/stdlib/functions/io.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/io.rs
@@ -96,8 +96,8 @@ pub(crate) fn format_eval_result(
     line: &Option<LineInfo>,
 ) -> Result<String, EvalError> {
     match value {
+        EvalResult::Data(Value::Artifact(handle)) => format_artifact(handle, line),
         EvalResult::Data(inner) => format_value(inner, line),
-        EvalResult::Artifact(handle) => format_artifact(handle, line),
         EvalResult::Revealed(_) => Err(EvalError::InvalidOperation(
             "Cannot unveil a Revealed value (control flow construct)".to_string(),
             line.clone(),

--- a/crates/abyss-interpreter/src/stdlib/methods/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/mod.rs
@@ -146,7 +146,6 @@ pub(super) fn call_arg_to_value(
 ) -> Result<Value, EvalError> {
     match arg.value {
         EvalResult::Data(value) => Ok(value),
-        EvalResult::Artifact(handle) => Ok(Value::Artifact(handle)),
         EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
             Err(EvalError::InvalidOperation(
                 format!("{} cannot accept control-flow results", context),

--- a/crates/abyss-interpreter/tests/test_artifacts.rs
+++ b/crates/abyss-interpreter/tests/test_artifacts.rs
@@ -162,7 +162,7 @@ create_player("Nova");
     let results = test_base(input).expect("artifact return failed");
     assert_eq!(results.len(), 3);
     match &results[2] {
-        EvalResult::Artifact(handle) => {
+        EvalResult::Data(Value::Artifact(handle)) => {
             let borrowed = handle.borrow();
             assert_eq!(borrowed.type_name, "Player");
             match borrowed.fields.get("name") {


### PR DESCRIPTION
## Summary

Resolves #505 (first checkbox; see note below on the second).

Remove the duplicate artifact representation: `EvalResult::Artifact(ArtifactHandle)` is gone, and artifacts now travel as `EvalResult::Data(Value::Artifact(_))` like every other value.

- The `EvalResult::artifact(handle)` convenience constructor is kept but now builds the `Data` form, so most construction sites are untouched.
- All ~23 match sites are simplified: duplicated `Artifact` / `Data(Value::Artifact)` arm pairs collapse to one (method receiver dispatch, artifact comparison, scrutinee capture, pattern compares, `unveil` formatting, `expect_artifact_from_eval`, stdlib arg extraction).
- `eval/values.rs` conversion helpers shrink: `value_to_eval_result` is now a trivial clone-to-`Data`, and the artifact arms disappear from `eval_result_to_value_any` / `convert_to_typed_value`.
- One public-API consumer adjusted: `tests/test_artifacts.rs` matched the removed variant; updated to the `Data` form. Technically semver-breaking for `abyss-interpreter` (enum variant removal), which is fine within the current 0.6.0 cycle.

## Control-flow separation (second checkbox of #505)

Evaluated and deliberately deferred: splitting `Revealed` / `Resume` / `Eject` out of `EvalResult` changes the signature of `evaluate()` and every helper around it — the same surface #510's AST split reworks. Doing it inside #510 avoids churning those signatures twice. Left a note on the issue.

## Verification

- `cargo test --workspace` — all 23 test binaries pass, zero warnings (includes the artifact integration suite and the REPL/wasm consumers)
- `cargo clippy --workspace --all-targets` — clean
- `grep -rn "EvalResult::Artifact"` — zero remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
