### PR TITLE
refactor(interpreter): introduce structured EvalError variants

### DIFF
--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -214,10 +214,7 @@ impl RuntimeEnv {
         for scope in self.scopes.iter_mut().rev() {
             if let Some(var_info) = scope.get_mut(name) {
                 if !var_info.is_morph {
-                    return Err(EvalError::InvalidOperation(
-                        format!("Cannot reassign to immutable variable {}", name),
-                        line_info,
-                    ));
+                    return Err(EvalError::ImmutableAssignment(name.to_string(), line_info));
                 }
 
                 if var_info.var_type != var_type
@@ -414,7 +411,9 @@ mod tests {
         let immutable_err = env
             .update_var("sigil", Value::Arcana(2), Type::Arcana, None)
             .unwrap_err();
-        assert!(matches!(immutable_err, EvalError::InvalidOperation(_, _)));
+        assert!(
+            matches!(immutable_err, EvalError::ImmutableAssignment(name, _) if name == "sigil")
+        );
 
         env.set_var("hex".into(), Value::Arcana(0), Type::Arcana, true, None);
         let type_err = env
@@ -525,7 +524,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("Cannot reassign to immutable variable")
+            Err(EvalError::ImmutableAssignment(name, _)) if name == "x"
         ));
     }
 

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -785,6 +785,32 @@ mod tests {
     }
 
     #[test]
+    fn test_index_access_missing_lexicon_key() {
+        let mut env = RuntimeEnv::new();
+        let mut entries = HashMap::new();
+        entries.insert("known".to_string(), Value::Arcana(1));
+        env.set_var(
+            "lex".to_string(),
+            Value::Lexicon(Rc::new(RefCell::new(entries))),
+            Type::Lexicon,
+            false,
+            None,
+        );
+
+        let expr = AST::IndexAccess {
+            target: Box::new(AST::Var("lex".to_string(), dummy_line_info())),
+            index: Box::new(AST::Rune("missing".to_string(), dummy_line_info())),
+            line_info: dummy_line_info(),
+        };
+
+        let result = try_evaluate_expression(&expr, &mut env);
+        assert!(matches!(
+            result,
+            Err(EvalError::MissingLexiconKey(key, _)) if key == "missing"
+        ));
+    }
+
+    #[test]
     fn test_index_access_invalid_target() {
         let mut env = RuntimeEnv::new();
         let target = AST::Arcana(1, dummy_line_info()); // Not a collection

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -197,22 +197,17 @@ pub(crate) fn try_evaluate_expression(
                 EvalResult::Data(Value::Scroll(items)) => {
                     let idx = expect_arcana_index(&idx_value, line_info)?;
                     let borrowed = items.borrow();
-                    let value = borrowed.get(idx).cloned().ok_or_else(|| {
-                        EvalError::InvalidOperation(
-                            format!("Index {} is out of bounds for scroll", idx),
-                            line_info.clone(),
-                        )
-                    })?;
+                    let value = borrowed
+                        .get(idx)
+                        .cloned()
+                        .ok_or_else(|| EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()))?;
                     EvalResult::data(value)
                 }
                 EvalResult::Data(Value::Lexicon(entries)) => {
                     let key = expect_rune_key(&idx_value, line_info)?;
                     let borrowed = entries.borrow();
                     let value = borrowed.get(&key).cloned().ok_or_else(|| {
-                        EvalError::InvalidOperation(
-                            format!("Lexicon key '{}' does not exist", key),
-                            line_info.clone(),
-                        )
+                        EvalError::MissingLexiconKey(key.clone(), line_info.clone())
                     })?;
                     EvalResult::data(value)
                 }
@@ -695,13 +690,11 @@ fn validate_artifact_type(
     if actual == expected {
         Ok(Value::Artifact(handle))
     } else {
-        Err(EvalError::TypeError(
-            format!(
-                "Expected artifact of type {} but received {}",
-                expected, actual
-            ),
-            line_info.clone(),
-        ))
+        Err(EvalError::ArtifactTypeMismatch {
+            expected: expected.to_string(),
+            found: actual,
+            line_info: line_info.clone(),
+        })
     }
 }
 
@@ -787,7 +780,7 @@ mod tests {
         let result = try_evaluate_expression(&expr, &mut env);
         assert!(matches!(
             result,
-            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("out of bounds")
+            Err(EvalError::ScrollIndexOutOfBounds(_, _))
         ));
     }
 

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -1,5 +1,5 @@
 use crate::env::{ArtifactHandle, Value};
-use abyss_core::ast::LineInfo;
+use abyss_core::ast::{LineInfo, Type};
 use ariadne::{Color, Label, Report, ReportKind, Source};
 use std::fmt;
 
@@ -44,6 +44,42 @@ pub enum EvalError {
     InvalidOperation(String, Option<LineInfo>),
     NegativeExponent(Option<LineInfo>),
     TypeError(String, Option<LineInfo>),
+    /// A value of the given type was required but something else was
+    /// produced (variable initialisation, argument conversion, builtin
+    /// extraction). For `Type::Artifact` the message names the artifact
+    /// type; use [`EvalError::ArtifactTypeMismatch`] when the *found*
+    /// artifact type is also known.
+    ExpectedType(Type, Option<LineInfo>),
+    /// An artifact of one type appeared where another artifact type was
+    /// required.
+    ArtifactTypeMismatch {
+        expected: String,
+        found: String,
+        line_info: Option<LineInfo>,
+    },
+    /// Assignment to a variable that was not declared `morph`.
+    ImmutableAssignment(String, Option<LineInfo>),
+    /// Scroll index outside the valid range.
+    ScrollIndexOutOfBounds(usize, Option<LineInfo>),
+    /// Lexicon lookup with a key that has no entry.
+    MissingLexiconKey(String, Option<LineInfo>),
+}
+
+/// Lowercase keyword name for a type, as used in "Expected … value"
+/// messages (`arcana`, `rune`, …).
+fn type_label(ty: &Type) -> &str {
+    match ty {
+        Type::Arcana => "arcana",
+        Type::Aether => "aether",
+        Type::Rune => "rune",
+        Type::Omen => "omen",
+        Type::Abyss => "abyss",
+        Type::Scroll => "scroll",
+        Type::Lexicon => "lexicon",
+        Type::Glyph => "glyph",
+        Type::Materia => "materia",
+        Type::Artifact(name) => name,
+    }
 }
 
 impl EvalError {
@@ -53,6 +89,13 @@ impl EvalError {
             EvalError::UndefinedVariable(_, info)
             | EvalError::InvalidOperation(_, info)
             | EvalError::TypeError(_, info)
+            | EvalError::ExpectedType(_, info)
+            | EvalError::ArtifactTypeMismatch {
+                line_info: info, ..
+            }
+            | EvalError::ImmutableAssignment(_, info)
+            | EvalError::ScrollIndexOutOfBounds(_, info)
+            | EvalError::MissingLexiconKey(_, info)
             | EvalError::NegativeExponent(info) => info.as_ref(),
         }
     }
@@ -62,13 +105,22 @@ impl EvalError {
     fn kind_label(&self) -> &'static str {
         match self {
             EvalError::UndefinedVariable(_, _) => "Undefined variable",
-            EvalError::InvalidOperation(_, _) => "Invalid operation",
+            EvalError::InvalidOperation(_, _)
+            | EvalError::ImmutableAssignment(_, _)
+            | EvalError::ScrollIndexOutOfBounds(_, _)
+            | EvalError::MissingLexiconKey(_, _) => "Invalid operation",
             EvalError::NegativeExponent(_) => "Negative exponent",
-            EvalError::TypeError(_, _) => "Type error",
+            EvalError::TypeError(_, _)
+            | EvalError::ExpectedType(_, _)
+            | EvalError::ArtifactTypeMismatch { .. } => "Type error",
         }
     }
 }
 
+// The structured variants render byte-identically to the strings the
+// legacy `InvalidOperation(String)` / `TypeError(String)` sites produced,
+// so published docs and the VS Code extension keep matching. Wording
+// changes are deliberate decisions, made here and nowhere else.
 impl fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -78,6 +130,32 @@ impl fmt::Display for EvalError {
                 write!(f, "PowArcana operation requires a non-negative exponent!")
             }
             EvalError::TypeError(var_type, _) => write!(f, "Type error: {}", var_type),
+            EvalError::ExpectedType(Type::Artifact(name), _) => {
+                write!(f, "Type error: Expected artifact of type {}", name)
+            }
+            EvalError::ExpectedType(ty, _) => {
+                write!(f, "Type error: Expected {} value", type_label(ty))
+            }
+            EvalError::ArtifactTypeMismatch {
+                expected, found, ..
+            } => write!(
+                f,
+                "Type error: Expected artifact of type {} but received {}",
+                expected, found
+            ),
+            EvalError::ImmutableAssignment(name, _) => write!(
+                f,
+                "Invalid operation: Cannot reassign to immutable variable {}",
+                name
+            ),
+            EvalError::ScrollIndexOutOfBounds(index, _) => write!(
+                f,
+                "Invalid operation: Index {} is out of bounds for scroll",
+                index
+            ),
+            EvalError::MissingLexiconKey(key, _) => {
+                write!(f, "Invalid operation: Lexicon key '{}' does not exist", key)
+            }
         }
     }
 }

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -342,6 +342,98 @@ mod tests {
         }
     }
 
+    /// Pins the Display contract of the structured variants: these strings
+    /// are referenced by published docs and the VS Code extension, and must
+    /// stay byte-identical to the legacy stringly-typed messages.
+    #[test]
+    fn structured_variants_render_legacy_messages() {
+        let info = Some(LineInfo::new(3, 7));
+
+        let cases: Vec<(EvalError, &str, &str)> = vec![
+            (
+                EvalError::ExpectedType(Type::Arcana, info.clone()),
+                "Type error: Expected arcana value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Aether, info.clone()),
+                "Type error: Expected aether value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Rune, info.clone()),
+                "Type error: Expected rune value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Omen, info.clone()),
+                "Type error: Expected omen value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Abyss, info.clone()),
+                "Type error: Expected abyss value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Scroll, info.clone()),
+                "Type error: Expected scroll value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Lexicon, info.clone()),
+                "Type error: Expected lexicon value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Glyph, info.clone()),
+                "Type error: Expected glyph value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Materia, info.clone()),
+                "Type error: Expected materia value",
+                "Type error",
+            ),
+            (
+                EvalError::ExpectedType(Type::Artifact("Player".into()), info.clone()),
+                "Type error: Expected artifact of type Player",
+                "Type error",
+            ),
+            (
+                EvalError::ArtifactTypeMismatch {
+                    expected: "Player".into(),
+                    found: "Enemy".into(),
+                    line_info: info.clone(),
+                },
+                "Type error: Expected artifact of type Player but received Enemy",
+                "Type error",
+            ),
+            (
+                EvalError::ImmutableAssignment("sigil".into(), info.clone()),
+                "Invalid operation: Cannot reassign to immutable variable sigil",
+                "Invalid operation",
+            ),
+            (
+                EvalError::ScrollIndexOutOfBounds(9, info.clone()),
+                "Invalid operation: Index 9 is out of bounds for scroll",
+                "Invalid operation",
+            ),
+            (
+                EvalError::MissingLexiconKey("port".into(), info.clone()),
+                "Invalid operation: Lexicon key 'port' does not exist",
+                "Invalid operation",
+            ),
+        ];
+
+        for (err, expected_display, expected_kind) in cases {
+            assert_eq!(err.to_string(), expected_display);
+            assert_eq!(err.kind_label(), expected_kind);
+            let returned = err.line_info().expect("line info should be attached");
+            assert_eq!((returned.line, returned.column), (3, 7));
+        }
+    }
+
     #[test]
     fn line_info_returns_attached_position() {
         let err = EvalError::TypeError("x".into(), Some(LineInfo::new(3, 4)));

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -652,6 +652,51 @@ mod tests {
     }
 
     #[test]
+    fn index_assignment_rejects_immutable_variables() {
+        let mut env = RuntimeEnv::new();
+        env.set_var(
+            "scroll".into(),
+            scroll(vec![Value::Arcana(0)]),
+            Type::Scroll,
+            false,
+            line(),
+        );
+
+        let index_assignment = AST::IndexAssignment {
+            target: Box::new(AST::Var("scroll".into(), line())),
+            index: Box::new(AST::Arcana(0, line())),
+            value: Box::new(AST::Arcana(99, line())),
+            line_info: line(),
+        };
+
+        let err = evaluate(&index_assignment, &mut env).expect_err("immutable index assignment");
+        assert!(matches!(err, EvalError::ImmutableAssignment(name, _) if name == "scroll"));
+    }
+
+    #[test]
+    fn field_assignment_rejects_immutable_variables() {
+        let mut env = RuntimeEnv::new();
+        register_artifact(&mut env, "Relic", vec![("power", Type::Arcana)]);
+        env.set_var(
+            "relic".into(),
+            Value::Artifact(artifact_handle("Relic", vec![("power", Value::Arcana(1))])),
+            Type::Artifact("Relic".into()),
+            false,
+            line(),
+        );
+
+        let field_assignment = AST::FieldAssignment {
+            target: Box::new(AST::Var("relic".into(), line())),
+            field: "power".into(),
+            value: Box::new(AST::Arcana(2, line())),
+            line_info: line(),
+        };
+
+        let err = evaluate(&field_assignment, &mut env).expect_err("immutable field assignment");
+        assert!(matches!(err, EvalError::ImmutableAssignment(name, _) if name == "relic"));
+    }
+
+    #[test]
     fn index_assignment_updates_scroll_entries() {
         let mut env = RuntimeEnv::new();
         env.set_var(

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -87,8 +87,8 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             let evaluated_value = evaluate(value, env)?;
             if let Some(var_info) = env.get_var_mut(name) {
                 if !var_info.is_morph {
-                    return Err(EvalError::InvalidOperation(
-                        format!("Cannot reassign to immutable variable {}", name),
+                    return Err(EvalError::ImmutableAssignment(
+                        name.clone(),
                         line_info.clone(),
                     ));
                 }
@@ -182,10 +182,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                             ));
                         }
                         if !matches!(evaluated_value, EvalResult::Data(Value::Abyss)) {
-                            return Err(EvalError::TypeError(
-                                "Expected abyss value".to_string(),
-                                line_info.clone(),
-                            ));
+                            return Err(EvalError::ExpectedType(Type::Abyss, line_info.clone()));
                         }
                     }
                     (value_slot, Type::Scroll) => {
@@ -263,8 +260,8 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             };
 
             if !var_info.is_morph {
-                return Err(EvalError::InvalidOperation(
-                    format!("Cannot reassign to immutable variable {}", base_name),
+                return Err(EvalError::ImmutableAssignment(
+                    base_name.clone(),
                     line_info.clone(),
                 ));
             }
@@ -279,10 +276,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                     let idx = expect_arcana_index(&final_index_value, line_info)?;
                     let mut items = handle.borrow_mut();
                     if idx >= items.len() {
-                        return Err(EvalError::InvalidOperation(
-                            format!("Index {} is out of bounds for scroll", idx),
-                            line_info.clone(),
-                        ));
+                        return Err(EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()));
                     }
                     items[idx] = new_value;
                 }
@@ -324,8 +318,8 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             };
 
             if !var_info.is_morph {
-                return Err(EvalError::InvalidOperation(
-                    format!("Cannot reassign to immutable variable {}", base_name),
+                return Err(EvalError::ImmutableAssignment(
+                    base_name.clone(),
                     line_info.clone(),
                 ));
             }
@@ -583,22 +577,18 @@ fn clone_indexed_child(
         Value::Scroll(handle) => {
             let idx = expect_arcana_index(index, line_info)?;
             let borrowed = handle.borrow();
-            borrowed.get(idx).cloned().ok_or_else(|| {
-                EvalError::InvalidOperation(
-                    format!("Index {} is out of bounds for scroll", idx),
-                    line_info.clone(),
-                )
-            })
+            borrowed
+                .get(idx)
+                .cloned()
+                .ok_or_else(|| EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()))
         }
         Value::Lexicon(handle) => {
             let key = expect_rune_key(index, line_info)?;
             let borrowed = handle.borrow();
-            borrowed.get(&key).cloned().ok_or_else(|| {
-                EvalError::InvalidOperation(
-                    format!("Lexicon key '{}' does not exist", key),
-                    line_info.clone(),
-                )
-            })
+            borrowed
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| EvalError::MissingLexiconKey(key.clone(), line_info.clone()))
         }
         _ => Err(EvalError::InvalidOperation(
             "Cannot index into non-collection value".to_string(),
@@ -656,7 +646,7 @@ mod tests {
 
         let err = evaluate(&assignment, &mut env).expect_err("immutable reassign should fail");
         match err {
-            EvalError::InvalidOperation(..) => {}
+            EvalError::ImmutableAssignment(name, _) => assert_eq!(name, "sigil"),
             other => panic!("unexpected error variant {:?}", other),
         }
     }
@@ -833,9 +823,7 @@ mod tests {
         let err = clone_indexed_child(&value, &EvalResult::data(Value::Arcana(5)), &line())
             .expect_err("out of bounds should fail");
         match err {
-            EvalError::InvalidOperation(message, _) => {
-                assert!(message.contains("out of bounds"), "{}", message)
-            }
+            EvalError::ScrollIndexOutOfBounds(index, _) => assert_eq!(index, 5),
             other => panic!("unexpected error variant {:?}", other),
         }
     }
@@ -846,9 +834,7 @@ mod tests {
         let err = clone_indexed_child(&value, &EvalResult::data(rune("missing")), &line())
             .expect_err("missing key should fail");
         match err {
-            EvalError::InvalidOperation(message, _) => {
-                assert!(message.contains("does not exist"), "{}", message)
-            }
+            EvalError::MissingLexiconKey(key, _) => assert_eq!(key, "missing"),
             other => panic!("unexpected error variant {:?}", other),
         }
     }

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -341,6 +341,43 @@ mod tests {
     }
 
     #[test]
+    fn convert_to_typed_value_rejects_each_scalar_mismatch() {
+        let info = line();
+        let cases: Vec<(Type, Value)> = vec![
+            (Type::Arcana, Value::Abyss),
+            (Type::Aether, Value::Arcana(1)),
+            (Type::Rune, Value::Arcana(1)),
+            (Type::Omen, Value::Arcana(1)),
+            (Type::Abyss, Value::Arcana(1)),
+            (Type::Scroll, Value::Arcana(1)),
+            (Type::Lexicon, Value::Arcana(1)),
+            (Type::Glyph, Value::Arcana(1)),
+        ];
+        for (expected, value) in cases {
+            let err = convert_to_typed_value(EvalResult::data(value), &expected, &info)
+                .expect_err("mismatched value should fail");
+            match err {
+                EvalError::ExpectedType(ty, returned) => {
+                    assert_eq!(ty, expected);
+                    assert!(returned.is_some());
+                }
+                other => panic!("expected ExpectedType for {:?}, got {:?}", expected, other),
+            }
+        }
+
+        let err = convert_to_typed_value(
+            EvalResult::data(Value::Arcana(1)),
+            &Type::Artifact("Player".into()),
+            &info,
+        )
+        .expect_err("non-artifact should fail artifact conversion");
+        match err {
+            EvalError::ExpectedType(Type::Artifact(name), _) => assert_eq!(name, "Player"),
+            other => panic!("expected artifact ExpectedType, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn extractors_error_on_wrong_type() {
         let info = line();
         let err = extract_rune(&EvalResult::data(Value::Arcana(1)), &info).unwrap_err();
@@ -348,6 +385,11 @@ mod tests {
             EvalError::ExpectedType(Type::Rune, info) => assert!(info.is_some()),
             other => panic!("expected type error, got {:?}", other),
         }
+
+        let err = extract_arcana(&EvalResult::data(Value::Abyss), &info).unwrap_err();
+        assert!(matches!(err, EvalError::ExpectedType(Type::Arcana, _)));
+        let err = extract_omen(&EvalResult::data(Value::Abyss), &info).unwrap_err();
+        assert!(matches!(err, EvalError::ExpectedType(Type::Omen, _)));
 
         let resume = EvalResult::Resume(None);
         let info = line();

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -55,59 +55,35 @@ pub(crate) fn convert_to_typed_value(
         }),
         Type::Arcana => match value {
             Value::Arcana(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected arcana value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Arcana, line_info.clone())),
         },
         Type::Aether => match value {
             Value::Aether(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected aether value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Aether, line_info.clone())),
         },
         Type::Rune => match value {
             Value::Rune(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected rune value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Rune, line_info.clone())),
         },
         Type::Omen => match value {
             Value::Omen(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected omen value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Omen, line_info.clone())),
         },
         Type::Abyss => match value {
             Value::Abyss => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected abyss value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Abyss, line_info.clone())),
         },
         Type::Scroll => match value {
             Value::Scroll(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected scroll value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Scroll, line_info.clone())),
         },
         Type::Lexicon => match value {
             Value::Lexicon(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected lexicon value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Lexicon, line_info.clone())),
         },
         Type::Glyph => match value {
             Value::Glyph(_) => Ok(value),
-            _ => Err(EvalError::TypeError(
-                "Expected glyph value".to_string(),
-                line_info.clone(),
-            )),
+            _ => Err(EvalError::ExpectedType(Type::Glyph, line_info.clone())),
         },
         Type::Artifact(expected) => match value {
             Value::Artifact(handle) => {
@@ -115,17 +91,15 @@ pub(crate) fn convert_to_typed_value(
                 if &borrowed.type_name == expected {
                     Ok(Value::Artifact(clone_artifact_handle(&handle)))
                 } else {
-                    Err(EvalError::TypeError(
-                        format!(
-                            "Expected artifact of type {} but received {}",
-                            expected, borrowed.type_name
-                        ),
-                        line_info.clone(),
-                    ))
+                    Err(EvalError::ArtifactTypeMismatch {
+                        expected: expected.clone(),
+                        found: borrowed.type_name.clone(),
+                        line_info: line_info.clone(),
+                    })
                 }
             }
-            _ => Err(EvalError::TypeError(
-                format!("Expected artifact of type {}", expected),
+            _ => Err(EvalError::ExpectedType(
+                Type::Artifact(expected.clone()),
                 line_info.clone(),
             )),
         },
@@ -138,10 +112,7 @@ pub(crate) fn extract_arcana(
 ) -> Result<i64, EvalError> {
     match result {
         EvalResult::Data(Value::Arcana(v)) => Ok(*v),
-        _ => Err(EvalError::TypeError(
-            "Expected arcana value".to_string(),
-            line_info.clone(),
-        )),
+        _ => Err(EvalError::ExpectedType(Type::Arcana, line_info.clone())),
     }
 }
 
@@ -151,10 +122,7 @@ pub(crate) fn extract_aether(
 ) -> Result<f64, EvalError> {
     match result {
         EvalResult::Data(Value::Aether(v)) => Ok(*v),
-        _ => Err(EvalError::TypeError(
-            "Expected aether value".to_string(),
-            line_info.clone(),
-        )),
+        _ => Err(EvalError::ExpectedType(Type::Aether, line_info.clone())),
     }
 }
 
@@ -164,10 +132,7 @@ pub(crate) fn extract_rune(
 ) -> Result<String, EvalError> {
     match result {
         EvalResult::Data(Value::Rune(rc)) => Ok(rc.as_ref().clone()),
-        _ => Err(EvalError::TypeError(
-            "Expected rune value".to_string(),
-            line_info.clone(),
-        )),
+        _ => Err(EvalError::ExpectedType(Type::Rune, line_info.clone())),
     }
 }
 
@@ -177,10 +142,7 @@ pub(crate) fn extract_omen(
 ) -> Result<bool, EvalError> {
     match result {
         EvalResult::Data(Value::Omen(v)) => Ok(*v),
-        _ => Err(EvalError::TypeError(
-            "Expected omen value".to_string(),
-            line_info.clone(),
-        )),
+        _ => Err(EvalError::ExpectedType(Type::Omen, line_info.clone())),
     }
 }
 
@@ -301,7 +263,7 @@ mod tests {
         )
         .expect_err("type mismatch should error");
         match rune_err {
-            EvalError::TypeError(_, info) => assert!(info.is_some()),
+            EvalError::ExpectedType(Type::Arcana, info) => assert!(info.is_some()),
             other => panic!("expected type error, got {:?}", other),
         }
 
@@ -334,7 +296,12 @@ mod tests {
         )
         .expect_err("mismatched artifact type should fail");
         match wrong_artifact {
-            EvalError::TypeError(msg, _) => assert!(msg.contains("Glyph")),
+            EvalError::ArtifactTypeMismatch {
+                expected, found, ..
+            } => {
+                assert_eq!(expected, "Glyph");
+                assert_eq!(found, "Sigil");
+            }
             other => panic!("expected type error, got {:?}", other),
         }
 
@@ -378,7 +345,7 @@ mod tests {
         let info = line();
         let err = extract_rune(&EvalResult::data(Value::Arcana(1)), &info).unwrap_err();
         match err {
-            EvalError::TypeError(_, info) => assert!(info.is_some()),
+            EvalError::ExpectedType(Type::Rune, info) => assert!(info.is_some()),
             other => panic!("expected type error, got {:?}", other),
         }
 
@@ -386,7 +353,7 @@ mod tests {
         let info = line();
         let err = extract_aether(&resume, &info).unwrap_err();
         match err {
-            EvalError::TypeError(_, info) => assert!(info.is_some()),
+            EvalError::ExpectedType(Type::Aether, info) => assert!(info.is_some()),
             other => panic!("expected type error from control value, got {:?}", other),
         }
     }

--- a/crates/abyss-interpreter/tests/test_artifacts.rs
+++ b/crates/abyss-interpreter/tests/test_artifacts.rs
@@ -31,14 +31,10 @@ hero.health = 75;
     match test_base(input) {
         Ok(_) => panic!("expected immutability error"),
         Err(err) => match err.downcast_ref::<EvalError>() {
-            Some(EvalError::InvalidOperation(message, _)) => {
-                assert!(
-                    message.contains("immutable"),
-                    "unexpected message: {}",
-                    message
-                );
+            Some(EvalError::ImmutableAssignment(name, _)) => {
+                assert_eq!(name, "hero");
             }
-            other => panic!("expected invalid operation error, found {:?}", other),
+            other => panic!("expected immutable-assignment error, found {:?}", other),
         },
     }
 }
@@ -93,12 +89,11 @@ forge hero: Player = Enemy { name: "Goblin", damage: 7 };
     match test_base(input) {
         Ok(_) => panic!("expected type mismatch error"),
         Err(err) => match err.downcast_ref::<EvalError>() {
-            Some(EvalError::TypeError(message, _)) => {
-                assert!(
-                    message.contains("Expected artifact of type"),
-                    "unexpected message: {}",
-                    message
-                );
+            Some(EvalError::ArtifactTypeMismatch {
+                expected, found, ..
+            }) => {
+                assert_eq!(expected, "Player");
+                assert_eq!(found, "Enemy");
             }
             other => panic!("expected type error, found {:?}", other),
         },
@@ -137,12 +132,11 @@ describe(foe);
     match test_base(input) {
         Ok(_) => panic!("expected parameter type error"),
         Err(err) => match err.downcast_ref::<EvalError>() {
-            Some(EvalError::TypeError(message, _)) => {
-                assert!(
-                    message.contains("Expected artifact of type Player"),
-                    "unexpected message: {}",
-                    message
-                );
+            Some(EvalError::ArtifactTypeMismatch {
+                expected, found, ..
+            }) => {
+                assert_eq!(expected, "Player");
+                assert_eq!(found, "Enemy");
             }
             other => panic!("expected type error, found {:?}", other),
         },

--- a/crates/abyss-interpreter/tests/test_forge.rs
+++ b/crates/abyss-interpreter/tests/test_forge.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use abyss_core::ast::Type;
+
 use abyss_interpreter::env::Value;
 use abyss_interpreter::eval::{EvalError, EvalResult};
 use common::test_base;
@@ -73,7 +75,7 @@ fn test_forge_morph_type_mismatch() {
     ";
     match test_base(input) {
         Err(e) => match e.downcast_ref::<EvalError>() {
-            Some(EvalError::TypeError(_, _)) => {}
+            Some(EvalError::ExpectedType(Type::Arcana, _)) => {}
             _ => panic!("Expected a type error for mismatched assignment"),
         },
         Ok(_) => panic!("Expected an error for type mismatch with morph variable"),
@@ -150,8 +152,8 @@ fn test_forge_reassign_immutable() {
     ";
     match test_base(input) {
         Err(e) => match e.downcast_ref::<EvalError>() {
-            Some(EvalError::InvalidOperation(_, _)) => {}
-            _ => panic!("Expected an invalid operation error for reassigning immutable variable"),
+            Some(EvalError::ImmutableAssignment(name, _)) if name == "x" => {}
+            _ => panic!("Expected an immutable-assignment error"),
         },
         Ok(_) => panic!("Expected an error for reassigning immutable variable"),
     }
@@ -165,8 +167,8 @@ fn test_forge_reassign_different_type() {
     ";
     match test_base(input) {
         Err(e) => match e.downcast_ref::<EvalError>() {
-            Some(EvalError::InvalidOperation(_, _)) => {}
-            _ => panic!("Expected an invalid operation error for type mismatch"),
+            Some(EvalError::ImmutableAssignment(name, _)) if name == "x" => {}
+            _ => panic!("Expected an immutable-assignment error for reassigning x"),
         },
         Ok(_) => panic!("Expected an error for type mismatch"),
     }


### PR DESCRIPTION
## Summary

Resolves #506.

Introduce structured `EvalError` variants for the recurring runtime-error shapes, so raise sites supply data and the final wording lives in exactly one place (the `Display` impl):

- **`ExpectedType(Type, …)`** — "Expected {type} value" (and "Expected artifact of type {name}" for `Type::Artifact`), with a centralised `type_label` keyword mapping. Replaces 13 hand-formatted sites in `eval/values.rs` / `eval/statements.rs`.
- **`ArtifactTypeMismatch { expected, found }`** — "Expected artifact of type X but received Y" (2 sites).
- **`ImmutableAssignment(name)`** — "Cannot reassign to immutable variable {name}" (4 sites across `env.rs`, `statements.rs`).
- **`ScrollIndexOutOfBounds(index)`** and **`MissingLexiconKey(key)`** — the collection access errors (5 sites across `statements.rs`, `expressions.rs`).

Guarantees:

- **Display output is byte-identical** to the previous strings (verified via CLI smoke runs: the ariadne header labels and message bodies match), so published docs and the VS Code extension keep matching. A comment on the `Display` impl pins this contract.
- `EvalError` is already `#[non_exhaustive]`, so the added variants are non-breaking for downstream matchers.
- Tests that previously asserted on message substrings (`msg.contains("out of bounds")`, `contains("immutable")`, …) now match variants structurally with exact payload assertions — the concrete payoff of this change.

The remaining one-off `InvalidOperation(String)` / `TypeError(String)` messages are intentionally left as-is; the legacy variants stay for those until a shape recurs enough to justify a variant.

## Verification

- `cargo test --workspace` — all 23 test binaries pass, zero warnings
- `cargo clippy --workspace --all-targets` — clean
- CLI smoke: immutable-reassign and out-of-bounds scripts render the same "Invalid operation" reports as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
