### PR TITLE
refactor(core)!: carry byte spans through the AST and EvalError (#510 sub-task 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Changed
+
+- **AST nodes and `EvalError` now carry byte spans instead of point `LineInfo`** ([#510](https://github.com/liebe-magi/abyss-lang/issues/510)) — the parser stores each node's `start..end` byte span (`abyss_core::span::Span`) and diagnostics derive positions at render time, so runtime errors now underline the full offending range instead of a single caret. Pulled forward from the roadmap's v0.8 "Span-tracking Refactor" slot. Breaking for `abyss-core` / `abyss-interpreter` consumers: `LineInfo`, `LineMap`, and `attach_line_info` are gone, and `build_parser` no longer takes a line map. Error message texts are unchanged.
+
 ### Removed
 
 - **`abyss_core::semantic` module (`SymbolTable` / `SymbolInfo`)** ([#503](https://github.com/liebe-magi/abyss-lang/issues/503)) — the static-analysis scaffold had zero consumers anywhere in the workspace since its introduction. The roadmap's LSP milestone (v0.8.1) is preceded by the v0.8 span-tracking refactor, and a symbol table without span data would have been rewritten there anyway; git history preserves the removed code. Breaking for `abyss-core` per Cargo 0.x semver, so this ships with the next `0.x.0` bump.

--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -1,84 +1,72 @@
-/// Represents line and column information for debugging purposes.
-#[derive(Debug, Clone)]
-pub struct LineInfo {
-    pub line: usize,
-    pub column: usize,
-}
-
-impl LineInfo {
-    /// Creates a `LineInfo` from explicit 1-based line and column values.
-    pub fn new(line: usize, column: usize) -> Self {
-        LineInfo { line, column }
-    }
-}
+pub use crate::span::Span;
 
 /// Represents the abstract syntax tree (AST) for the language.
 #[derive(Debug, Clone)]
 pub enum AST {
-    Statement(Box<AST>, Option<LineInfo>),
-    Omen(bool, Option<LineInfo>),
-    Arcana(i64, Option<LineInfo>),
-    Aether(f64, Option<LineInfo>),
-    Rune(String, Option<LineInfo>),
-    Abyss(Option<LineInfo>),
-    Add(Box<AST>, Box<AST>, Option<LineInfo>),
-    Sub(Box<AST>, Box<AST>, Option<LineInfo>),
-    Mul(Box<AST>, Box<AST>, Option<LineInfo>),
-    Div(Box<AST>, Box<AST>, Option<LineInfo>),
-    Mod(Box<AST>, Box<AST>, Option<LineInfo>),
-    PowArcana(Box<AST>, Box<AST>, Option<LineInfo>),
-    PowAether(Box<AST>, Box<AST>, Option<LineInfo>),
-    Equal(Box<AST>, Box<AST>, Option<LineInfo>),
-    NotEqual(Box<AST>, Box<AST>, Option<LineInfo>),
-    LessThan(Box<AST>, Box<AST>, Option<LineInfo>),
-    LessThanOrEqual(Box<AST>, Box<AST>, Option<LineInfo>),
-    GreaterThan(Box<AST>, Box<AST>, Option<LineInfo>),
-    GreaterThanOrEqual(Box<AST>, Box<AST>, Option<LineInfo>),
-    LogicalAnd(Box<AST>, Box<AST>, Option<LineInfo>),
-    LogicalOr(Box<AST>, Box<AST>, Option<LineInfo>),
-    LogicalNot(Box<AST>, Option<LineInfo>),
+    Statement(Box<AST>, Option<Span>),
+    Omen(bool, Option<Span>),
+    Arcana(i64, Option<Span>),
+    Aether(f64, Option<Span>),
+    Rune(String, Option<Span>),
+    Abyss(Option<Span>),
+    Add(Box<AST>, Box<AST>, Option<Span>),
+    Sub(Box<AST>, Box<AST>, Option<Span>),
+    Mul(Box<AST>, Box<AST>, Option<Span>),
+    Div(Box<AST>, Box<AST>, Option<Span>),
+    Mod(Box<AST>, Box<AST>, Option<Span>),
+    PowArcana(Box<AST>, Box<AST>, Option<Span>),
+    PowAether(Box<AST>, Box<AST>, Option<Span>),
+    Equal(Box<AST>, Box<AST>, Option<Span>),
+    NotEqual(Box<AST>, Box<AST>, Option<Span>),
+    LessThan(Box<AST>, Box<AST>, Option<Span>),
+    LessThanOrEqual(Box<AST>, Box<AST>, Option<Span>),
+    GreaterThan(Box<AST>, Box<AST>, Option<Span>),
+    GreaterThanOrEqual(Box<AST>, Box<AST>, Option<Span>),
+    LogicalAnd(Box<AST>, Box<AST>, Option<Span>),
+    LogicalOr(Box<AST>, Box<AST>, Option<Span>),
+    LogicalNot(Box<AST>, Option<Span>),
     VarAssign {
         name: String,
         value: Box<AST>,
         var_type: Type,
         is_morph: bool,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     Assignment {
         name: String,
         value: Box<AST>,
         op: AssignmentOp,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
-    Var(String, Option<LineInfo>),
-    Reveal(Box<AST>, Option<LineInfo>),
+    Var(String, Option<Span>),
+    Reveal(Box<AST>, Option<Span>),
     Oracle {
         is_match: bool,
         conditionals: Vec<ConditionalAssignment>,
         branches: Vec<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     OracleBranch {
         pattern: Vec<AST>,
         guard: Option<Box<AST>>,
         body: Box<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
-    OracleDontCareItem(Option<LineInfo>),
+    OracleDontCareItem(Option<Span>),
     /// Scroll-shape pattern that destructures a `scroll` scrutinee into
     /// its elements. Each element is one of: `OracleDontCareItem`,
     /// `OracleScrollRest`, `Var(name)` (binding), or any other AST node
     /// (treated as a literal expression to compare against).
     OracleScrollPattern {
         elements: Vec<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     /// Rest segment inside an `OracleScrollPattern`. `name = Some("rest")`
     /// for `..rest` (binds the unmatched tail to a fresh sub-scroll);
     /// `name = None` for `..` (anonymous, drops the tail).
     OracleScrollRest {
         name: Option<String>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     /// Artifact-shape pattern that matches a `TypeName { field, … }`
     /// scrutinee. Each `(field_name, sub_pattern)` entry pulls the named
@@ -90,7 +78,7 @@ pub enum AST {
     OracleArtifactPattern {
         type_name: String,
         fields: Vec<(String, AST)>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     /// Lexicon-shape pattern that matches a `{ "key": value, … }`
     /// scrutinee. Each `(key, sub_pattern)` entry pulls the named entry
@@ -100,88 +88,88 @@ pub enum AST {
     /// "pick what you need" ergonomics.
     OracleLexiconPattern {
         entries: Vec<(String, AST)>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
-    Block(Vec<AST>, Option<LineInfo>),
-    Comment(String, Option<LineInfo>),
+    Block(Vec<AST>, Option<Span>),
+    Comment(String, Option<Span>),
     Orbit {
         params: Vec<AST>,
         body: Box<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     OrbitParam {
         name: String,
         start: Box<AST>,
         end: Box<AST>,
         op: String,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
-    Resume(Option<String>, Option<LineInfo>),
-    Eject(Option<String>, Option<LineInfo>),
+    Resume(Option<String>, Option<Span>),
+    Eject(Option<String>, Option<Span>),
     Engrave {
         name: String,
         params: Vec<AST>,
         return_type: Type,
         body: Box<AST>,
         method_target: Option<ArtifactMethodTarget>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     EngraveParam {
         name: String,
         param_type: Type,
         is_morph: bool,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     FuncCall {
         name: String,
         args: Vec<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     ListLiteral {
         elements: Vec<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     MapLiteral {
         entries: Vec<(String, AST)>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     IndexAccess {
         target: Box<AST>,
         index: Box<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     IndexAssignment {
         target: Box<AST>,
         index: Box<AST>,
         value: Box<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     ArtifactDef {
         name: String,
         fields: Vec<ArtifactField>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     ArtifactLiteral {
         type_name: String,
         fields: Vec<(String, AST)>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     FieldAccess {
         target: Box<AST>,
         field: String,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     FieldAssignment {
         target: Box<AST>,
         field: String,
         value: Box<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     MethodCall {
         receiver: Box<AST>,
         method: String,
         args: Vec<AST>,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
 }
 
@@ -189,7 +177,7 @@ pub enum AST {
 pub struct ArtifactField {
     pub name: String,
     pub field_type: Type,
-    pub line_info: Option<LineInfo>,
+    pub line_info: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -203,7 +191,7 @@ pub struct ArtifactMethodTarget {
 pub struct ConditionalAssignment {
     pub variable: String,
     pub expression: Box<AST>,
-    pub line_info: Option<LineInfo>,
+    pub line_info: Option<Span>,
 }
 
 /// Represents the type of a variable or expression.

--- a/crates/abyss-core/src/lib.rs
+++ b/crates/abyss-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod ast;
 pub mod format;
 pub mod parser;
+pub mod span;

--- a/crates/abyss-core/src/parser/diagnostics.rs
+++ b/crates/abyss-core/src/parser/diagnostics.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ariadne::{Color, Label, Report, ReportKind, Source};
 use chumsky::{
     error::{Rich, RichReason},
@@ -7,7 +5,6 @@ use chumsky::{
 };
 
 use super::SimpleSpan;
-use super::helpers::LineMap;
 
 #[derive(Debug, Clone)]
 pub struct ParserDiagnostic {
@@ -17,11 +14,7 @@ pub struct ParserDiagnostic {
     pub help: Option<String>,
 }
 
-pub fn convert_rich_error<'a, T, S>(
-    error: Rich<'a, T, S>,
-    _map: &Arc<LineMap>,
-    title: &str,
-) -> ParserDiagnostic
+pub fn convert_rich_error<'a, T, S>(error: Rich<'a, T, S>, title: &str) -> ParserDiagnostic
 where
     T: std::fmt::Display + Clone,
     S: ChumskySpan<Context = (), Offset = usize> + Clone,

--- a/crates/abyss-core/src/parser/grammar/expressions.rs
+++ b/crates/abyss-core/src/parser/grammar/expressions.rs
@@ -51,7 +51,7 @@ pub(super) fn or_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 (
-                    AST::LogicalOr(Box::new(left.0), Box::new(right.0), info.clone()),
+                    AST::LogicalOr(Box::new(left.0), Box::new(right.0), info),
                     span,
                 )
             })
@@ -79,7 +79,7 @@ pub(super) fn and_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 (
-                    AST::LogicalAnd(Box::new(left.0), Box::new(right.0), info.clone()),
+                    AST::LogicalAnd(Box::new(left.0), Box::new(right.0), info),
                     span,
                 )
             })
@@ -101,10 +101,7 @@ pub(super) fn not_expr_parser<'src>(
             for span in nots.into_iter().rev() {
                 let total_span = SimpleSpan::new(span.start(), current.1.end());
                 let info = ctx_for_map.info(total_span);
-                current = (
-                    AST::LogicalNot(Box::new(current.0), info.clone()),
-                    total_span,
-                );
+                current = (AST::LogicalNot(Box::new(current.0), info), total_span);
             }
             current
         })
@@ -135,21 +132,17 @@ pub(super) fn comp_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Equal => AST::Equal(Box::new(left.0), Box::new(right.0), info.clone()),
-                    Token::NotEqual => {
-                        AST::NotEqual(Box::new(left.0), Box::new(right.0), info.clone())
-                    }
-                    Token::LessThan => {
-                        AST::LessThan(Box::new(left.0), Box::new(right.0), info.clone())
-                    }
+                    Token::Equal => AST::Equal(Box::new(left.0), Box::new(right.0), info),
+                    Token::NotEqual => AST::NotEqual(Box::new(left.0), Box::new(right.0), info),
+                    Token::LessThan => AST::LessThan(Box::new(left.0), Box::new(right.0), info),
                     Token::LessThanOrEqual => {
-                        AST::LessThanOrEqual(Box::new(left.0), Box::new(right.0), info.clone())
+                        AST::LessThanOrEqual(Box::new(left.0), Box::new(right.0), info)
                     }
                     Token::GreaterThan => {
-                        AST::GreaterThan(Box::new(left.0), Box::new(right.0), info.clone())
+                        AST::GreaterThan(Box::new(left.0), Box::new(right.0), info)
                     }
                     Token::GreaterThanOrEqual => {
-                        AST::GreaterThanOrEqual(Box::new(left.0), Box::new(right.0), info.clone())
+                        AST::GreaterThanOrEqual(Box::new(left.0), Box::new(right.0), info)
                     }
                     _ => unreachable!(),
                 };
@@ -181,8 +174,8 @@ pub(super) fn add_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Plus => AST::Add(Box::new(left.0), Box::new(right.0), info.clone()),
-                    Token::Minus => AST::Sub(Box::new(left.0), Box::new(right.0), info.clone()),
+                    Token::Plus => AST::Add(Box::new(left.0), Box::new(right.0), info),
+                    Token::Minus => AST::Sub(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -211,9 +204,9 @@ pub(super) fn mul_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Star => AST::Mul(Box::new(left.0), Box::new(right.0), info.clone()),
-                    Token::Slash => AST::Div(Box::new(left.0), Box::new(right.0), info.clone()),
-                    Token::Percent => AST::Mod(Box::new(left.0), Box::new(right.0), info.clone()),
+                    Token::Star => AST::Mul(Box::new(left.0), Box::new(right.0), info),
+                    Token::Slash => AST::Div(Box::new(left.0), Box::new(right.0), info),
+                    Token::Percent => AST::Mod(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -242,12 +235,8 @@ pub(super) fn pow_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::DoubleStar => {
-                        AST::PowAether(Box::new(left.0), Box::new(right.0), info.clone())
-                    }
-                    Token::Caret => {
-                        AST::PowArcana(Box::new(left.0), Box::new(right.0), info.clone())
-                    }
+                    Token::DoubleStar => AST::PowAether(Box::new(left.0), Box::new(right.0), info),
+                    Token::Caret => AST::PowArcana(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -465,7 +454,7 @@ pub(super) fn func_call_parser<'src>(
                     AST::FuncCall {
                         name,
                         args,
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )
@@ -500,7 +489,7 @@ pub(super) fn list_literal_parser<'src>(
             (
                 AST::ListLiteral {
                     elements,
-                    line_info: info.clone(),
+                    line_info: info,
                 },
                 span,
             )
@@ -538,7 +527,7 @@ pub(super) fn map_literal_parser<'src>(
             (
                 AST::MapLiteral {
                     entries,
-                    line_info: info.clone(),
+                    line_info: info,
                 },
                 span,
             )
@@ -579,7 +568,7 @@ pub(super) fn artifact_literal_parser<'src>(
                     AST::ArtifactLiteral {
                         type_name,
                         fields,
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )

--- a/crates/abyss-core/src/parser/grammar/mod.rs
+++ b/crates/abyss-core/src/parser/grammar/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use chumsky::{
     error::Rich,
     extra,
@@ -8,10 +6,9 @@ use chumsky::{
     recursive::{self, Direct},
 };
 
-use crate::ast::{AST, LineInfo};
+use crate::ast::{AST, Span};
 
 use super::SimpleSpan;
-use super::helpers::LineMap;
 use super::tokens::{SpannedToken, Token};
 
 pub(super) type ParserInput<'src> = IterInput<std::vec::IntoIter<SpannedToken>, SimpleSpan<usize>>;
@@ -24,14 +21,16 @@ pub(super) type RecursiveParser<'src, T> =
 pub(super) type SpannedAst = (AST, SimpleSpan<usize>);
 pub(super) type IndexedTarget = (SpannedAst, SpannedAst);
 
+/// Shared per-parser context. Since the span refactor it carries no
+/// state — nodes store byte spans directly — but it is kept as the
+/// construction point for node positions so a future context (e.g.
+/// interning, config) has an obvious home.
 #[derive(Clone)]
-pub(super) struct ParserContext {
-    map: Arc<LineMap>,
-}
+pub(super) struct ParserContext {}
 
 impl ParserContext {
-    fn info(&self, span: SimpleSpan<usize>) -> Option<LineInfo> {
-        self.map.line_info(span)
+    fn info(&self, span: SimpleSpan<usize>) -> Option<Span> {
+        Some(span)
     }
 
     fn wrap_statement(&self, ast: AST, span: SimpleSpan<usize>) -> AST {
@@ -43,8 +42,8 @@ pub(super) fn merge_span(a: SimpleSpan<usize>, b: SimpleSpan<usize>) -> SimpleSp
     SimpleSpan::new(a.start().min(b.start()), a.end().max(b.end()))
 }
 
-pub fn build_parser<'src>(map: Arc<LineMap>) -> BoxedParser<'src, Vec<AST>> {
-    let ctx = ParserContext { map };
+pub fn build_parser<'src>() -> BoxedParser<'src, Vec<AST>> {
+    let ctx = ParserContext {};
 
     let ctx_for_recursive = ctx.clone();
 

--- a/crates/abyss-core/src/parser/grammar/patterns.rs
+++ b/crates/abyss-core/src/parser/grammar/patterns.rs
@@ -58,7 +58,7 @@ pub(super) fn oracle_expr_parser<'src>(
                     (false, Vec::new())
                 };
                 for cond in &mut conditionals {
-                    cond.line_info = info.clone();
+                    cond.line_info = info;
                 }
 
                 let mut branch_asts = Vec::with_capacity(branches.len());
@@ -71,7 +71,7 @@ pub(super) fn oracle_expr_parser<'src>(
                         is_match,
                         conditionals,
                         branches: branch_asts,
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )
@@ -125,7 +125,7 @@ pub(super) fn oracle_branch_parser<'src>(
                         pattern,
                         guard: guard_ast,
                         body: Box::new(body_ast),
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )

--- a/crates/abyss-core/src/parser/grammar/statements.rs
+++ b/crates/abyss-core/src/parser/grammar/statements.rs
@@ -28,7 +28,7 @@ pub(super) fn artifact_def_parser<'src>(ctx: ParserContext) -> BoxedParser<'src,
                 AST::ArtifactDef {
                     name,
                     fields,
-                    line_info: info.clone(),
+                    line_info: info,
                 },
                 span,
             )
@@ -108,7 +108,7 @@ pub(super) fn forge_parser<'src>(
                         value: Box::new(value_ast),
                         var_type: ty,
                         is_morph,
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )
@@ -333,8 +333,8 @@ pub(super) fn reveal_parser<'src>(
             let info = ctx_for_map.info(span);
             let value = maybe_expr
                 .map(|(ast, _)| Box::new(ast))
-                .unwrap_or_else(|| Box::new(AST::Abyss(info.clone())));
-            (AST::Reveal(value, info.clone()), span)
+                .unwrap_or_else(|| Box::new(AST::Abyss(info)));
+            (AST::Reveal(value, info), span)
         })
         .boxed()
 }
@@ -363,7 +363,7 @@ pub(super) fn orbit_parser<'src>(
                 AST::Orbit {
                     params: params_opt.unwrap_or_default(),
                     body: Box::new(body_ast),
-                    line_info: info.clone(),
+                    line_info: info,
                 },
                 span,
             )
@@ -392,10 +392,7 @@ pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, S
                     .map(|(_, id_span)| SimpleSpan::new(resume_span.start(), id_span.end()))
                     .unwrap_or(resume_span);
                 let info = ctx_resume.info(span);
-                (
-                    AST::Resume(maybe_ident.map(|(name, _)| name), info.clone()),
-                    span,
-                )
+                (AST::Resume(maybe_ident.map(|(name, _)| name), info), span)
             },
         );
 
@@ -413,10 +410,7 @@ pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, S
                     .map(|(_, id_span)| SimpleSpan::new(eject_span.start(), id_span.end()))
                     .unwrap_or(eject_span);
                 let info = ctx_eject.info(span);
-                (
-                    AST::Eject(maybe_ident.map(|(name, _)| name), info.clone()),
-                    span,
-                )
+                (AST::Eject(maybe_ident.map(|(name, _)| name), info), span)
             },
         );
 
@@ -455,7 +449,7 @@ pub(super) fn assignment_parser<'src>(
                         name,
                         value: Box::new(value_ast),
                         op: assignment_op_from_token(token),
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )
@@ -483,7 +477,7 @@ pub(super) fn field_assignment_parser<'src>(
                             target,
                             field,
                             value: Box::new(value_ast),
-                            line_info: info.clone(),
+                            line_info: info,
                         },
                         span,
                     ))
@@ -533,7 +527,7 @@ pub(super) fn index_assignment_parser<'src>(
                         target: Box::new(target_ast),
                         index: Box::new(index_ast),
                         value: Box::new(value_ast),
-                        line_info: info.clone(),
+                        line_info: info,
                     },
                     span,
                 )

--- a/crates/abyss-core/src/parser/helpers.rs
+++ b/crates/abyss-core/src/parser/helpers.rs
@@ -1,56 +1,10 @@
-use std::sync::Arc;
-
 use chumsky::{error::Rich, extra, prelude::*, span::SimpleSpan as ChumskySpan, text};
-
-use crate::ast::LineInfo;
-
-use super::SimpleSpan;
-
-/// Represents a mapping between byte offsets and (line, column) positions.
-#[derive(Debug, Clone)]
-pub struct LineMap {
-    line_starts: Arc<Vec<usize>>,
-}
-
-impl LineMap {
-    pub fn new(source: &str) -> Self {
-        let mut starts = Vec::with_capacity(source.lines().count() + 1);
-        starts.push(0);
-        for (idx, ch) in source.char_indices() {
-            if ch == '\n' {
-                starts.push(idx + ch.len_utf8());
-            }
-        }
-        LineMap {
-            line_starts: Arc::new(starts),
-        }
-    }
-
-    pub fn line_col(&self, offset: usize) -> (usize, usize) {
-        let line_idx = match self.line_starts.binary_search(&offset) {
-            Ok(idx) => idx,
-            Err(idx) => idx.saturating_sub(1),
-        };
-        let line_start = self.line_starts[line_idx];
-        (line_idx + 1, offset - line_start + 1)
-    }
-
-    pub fn line_info(&self, span: SimpleSpan<usize>) -> Option<LineInfo> {
-        let (line, column) = self.line_col(span.start());
-        Some(LineInfo::new(line, column))
-    }
-}
 
 type LexerExtra<'src> = extra::Err<Rich<'src, char, ChumskySpan<usize>>>;
 
 /// Produces a parser that skips AbySS whitespace.
 pub fn abyss_whitespace<'src>() -> impl Parser<'src, &'src str, (), LexerExtra<'src>> + Clone {
     text::whitespace::<_, LexerExtra<'src>>().to(())
-}
-
-/// Helper to attach line info to AST nodes.
-pub fn attach_line_info(map: &LineMap, span: SimpleSpan<usize>) -> Option<LineInfo> {
-    map.line_info(span)
 }
 
 /// Replace comments with whitespace of equal length so token spans align with the original source.

--- a/crates/abyss-core/src/parser/mod.rs
+++ b/crates/abyss-core/src/parser/mod.rs
@@ -1,15 +1,12 @@
-pub use helpers::{LineMap, abyss_whitespace, attach_line_info, scrub_comments_preserve_layout};
-pub use span::SimpleSpan;
+pub use crate::span::SimpleSpan;
+pub use helpers::{abyss_whitespace, scrub_comments_preserve_layout};
 pub use tokens::{SpannedToken, Token, lexer};
 mod diagnostics;
 mod grammar;
 mod helpers;
-mod span;
 mod tokens;
 
 pub use diagnostics::{ParserDiagnostic, emit_diagnostics, render_diagnostics};
-
-use std::sync::Arc;
 
 use chumsky::{Parser, input::IterInput};
 use ordered_float::OrderedFloat;
@@ -24,15 +21,13 @@ pub struct ParseOutcome {
 }
 
 pub fn parse(source: &str) -> ParseOutcome {
-    let map = Arc::new(LineMap::new(source));
-
     let scrubbed_source = scrub_comments_preserve_layout(source);
 
     let (maybe_tokens, lex_errors) = lexer().parse(scrubbed_source.as_str()).into_output_errors();
 
     let mut diagnostics: Vec<ParserDiagnostic> = lex_errors
         .into_iter()
-        .map(|err| convert_rich_error(err, &map, "Incantation unravelled at lexing stage"))
+        .map(|err| convert_rich_error(err, "Incantation unravelled at lexing stage"))
         .collect();
 
     let tokens = match maybe_tokens {
@@ -48,13 +43,13 @@ pub fn parse(source: &str) -> ParseOutcome {
     let len = source.len();
     let token_input = IterInput::new(tokens.into_iter(), SimpleSpan::new(len, len));
 
-    let parser = build_parser(map.clone());
+    let parser = build_parser();
     let (maybe_ast, parse_errors) = parser.parse(token_input).into_output_errors();
 
     diagnostics.extend(
         parse_errors
             .into_iter()
-            .map(|err| convert_rich_error(err, &map, "Spell error: Incantation failed")),
+            .map(|err| convert_rich_error(err, "Spell error: Incantation failed")),
     );
 
     let ast = maybe_ast.unwrap_or_default();

--- a/crates/abyss-core/src/span.rs
+++ b/crates/abyss-core/src/span.rs
@@ -63,3 +63,8 @@ impl<T: Copy + Ord> ChumskySpan for SimpleSpan<T> {
         self.end
     }
 }
+
+/// Byte-offset span into the original source, attached to AST nodes and
+/// runtime errors. Rendering derives line/column (and range underlines)
+/// from this at display time.
+pub type Span = SimpleSpan<usize>;

--- a/crates/abyss-interpreter/src/artifact.rs
+++ b/crates/abyss-interpreter/src/artifact.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use abyss_core::ast::{LineInfo, Type};
+use abyss_core::ast::{Span, Type};
 
 use crate::env::EngravedFunction;
 use crate::value::Value;
@@ -30,7 +30,7 @@ pub struct ArtifactSchema {
     pub name: String,
     pub fields: Vec<ArtifactFieldSchema>,
     pub methods: HashMap<String, ArtifactMethod>,
-    pub line_info: Option<LineInfo>,
+    pub line_info: Option<Span>,
 }
 
 impl ArtifactSchema {

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{did_you_mean, label_with_suggestions};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 use std::collections::HashMap;
 
 // Value and artifact types moved to dedicated modules; re-exported here so
@@ -12,7 +12,7 @@ pub use crate::artifact::{
 pub use crate::value::Value;
 
 pub type BuiltinFunc =
-    fn(&mut RuntimeEnv, Vec<CallArg>, Option<LineInfo>) -> Result<EvalResult, EvalError>;
+    fn(&mut RuntimeEnv, Vec<CallArg>, Option<Span>) -> Result<EvalResult, EvalError>;
 
 pub type BuiltinMethodHandler = fn(
     &mut RuntimeEnv,
@@ -20,7 +20,7 @@ pub type BuiltinMethodHandler = fn(
     Option<&str>,
     Value,
     Vec<CallArg>,
-    &Option<LineInfo>,
+    &Option<Span>,
 ) -> Result<EvalResult, EvalError>;
 
 pub type BuiltinMethodRegistry = HashMap<Type, HashMap<String, BuiltinMethodHandler>>;
@@ -43,7 +43,7 @@ pub struct EngravedFunction {
     pub params: Vec<AST>,
     pub return_type: Type,
     pub body: Box<AST>,
-    pub line_info: Option<LineInfo>,
+    pub line_info: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -58,7 +58,7 @@ pub struct VarInfo {
     pub value: Value,
     pub var_type: Type,
     pub is_morph: bool,
-    pub line_info: Option<LineInfo>,
+    pub line_info: Option<Span>,
 }
 
 /// Manages variable and function scopes in the execution environment, including
@@ -138,7 +138,7 @@ impl RuntimeEnv {
         value: Value,
         var_type: Type,
         is_morph: bool,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     ) {
         if let Some(current_scope) = self.scopes.last_mut() {
             current_scope.insert(
@@ -177,7 +177,7 @@ impl RuntimeEnv {
     /// Falls back to the bare name when no plausible suggestion is available,
     /// so the message shape remains identical to the pre-suggestion era for
     /// truly unknown identifiers.
-    pub fn undefined_variable_error(&self, name: &str, line_info: Option<LineInfo>) -> EvalError {
+    pub fn undefined_variable_error(&self, name: &str, line_info: Option<Span>) -> EvalError {
         let candidates: Vec<&str> = self
             .scopes
             .iter()
@@ -191,7 +191,7 @@ impl RuntimeEnv {
     /// Same shape as [`undefined_variable_error`] but suggestions are drawn
     /// from the function scopes — used when an identifier appearing in a call
     /// position cannot be resolved to a `Callable`.
-    pub fn undefined_function_error(&self, name: &str, line_info: Option<LineInfo>) -> EvalError {
+    pub fn undefined_function_error(&self, name: &str, line_info: Option<Span>) -> EvalError {
         let candidates: Vec<&str> = self
             .function_scopes
             .iter()
@@ -209,7 +209,7 @@ impl RuntimeEnv {
         name: &str,
         value: Value,
         var_type: Type,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     ) -> Result<(), EvalError> {
         for scope in self.scopes.iter_mut().rev() {
             if let Some(var_info) = scope.get_mut(name) {
@@ -274,7 +274,7 @@ impl RuntimeEnv {
             if scope.contains_key(&schema.name) {
                 return Err(EvalError::InvalidOperation(
                     format!("Artifact {} is already defined in this scope", schema.name),
-                    schema.line_info.clone(),
+                    schema.line_info,
                 ));
             }
             scope.insert(schema.name.clone(), schema);
@@ -312,13 +312,13 @@ impl RuntimeEnv {
         artifact: &str,
         method_name: &str,
         method: ArtifactMethod,
-        line_info: &Option<LineInfo>,
+        line_info: &Option<Span>,
     ) -> Result<(), EvalError> {
         if let Some(schema) = self.get_artifact_mut(artifact) {
             if schema.methods.contains_key(method_name) {
                 return Err(EvalError::InvalidOperation(
                     format!("Method {}::{} is already defined", artifact, method_name),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
             schema.methods.insert(method_name.to_string(), method);
@@ -326,7 +326,7 @@ impl RuntimeEnv {
         } else {
             Err(EvalError::InvalidOperation(
                 format!("Artifact {} is not defined", artifact),
-                line_info.clone(),
+                *line_info,
             ))
         }
     }
@@ -379,7 +379,7 @@ mod tests {
     fn builtin(
         _: &mut RuntimeEnv,
         _: Vec<CallArg>,
-        _: Option<LineInfo>,
+        _: Option<Span>,
     ) -> Result<EvalResult, EvalError> {
         Ok(EvalResult::abyss())
     }

--- a/crates/abyss-interpreter/src/eval/artifacts.rs
+++ b/crates/abyss-interpreter/src/eval/artifacts.rs
@@ -1,7 +1,7 @@
 use crate::env::{
     ArtifactFieldSchema, ArtifactHandle, ArtifactSchema, ArtifactValue, RuntimeEnv, Value,
 };
-use abyss_core::ast::{AST, ArtifactField, LineInfo, Type};
+use abyss_core::ast::{AST, ArtifactField, Span, Type};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -13,14 +13,14 @@ use crate::diagnostics::did_you_mean_hint;
 pub(crate) fn ensure_type_known(
     ty: &Type,
     env: &RuntimeEnv,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<(), EvalError> {
     if let Type::Artifact(name) = ty
         && env.get_artifact(name).is_none()
     {
         return Err(EvalError::TypeError(
             format!("Artifact type {} is not defined", name),
-            line_info.clone(),
+            *line_info,
         ));
     }
     Ok(())
@@ -42,7 +42,7 @@ pub(crate) fn ensure_field_type_known(
                         "Artifact field {} references undefined type {}",
                         field.name, name
                     ),
-                    field.line_info.clone(),
+                    field.line_info,
                 ))
             }
         }
@@ -54,7 +54,7 @@ pub(crate) fn build_artifact_schema(
     name: &str,
     fields: &[ArtifactField],
     env: &RuntimeEnv,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<ArtifactSchema, EvalError> {
     let mut seen = HashSet::new();
     let mut compiled_fields = Vec::with_capacity(fields.len());
@@ -63,7 +63,7 @@ pub(crate) fn build_artifact_schema(
         if !seen.insert(field.name.clone()) {
             return Err(EvalError::InvalidOperation(
                 format!("Field '{}' is defined multiple times", field.name),
-                field.line_info.clone().or_else(|| line_info.clone()),
+                field.line_info.or(*line_info),
             ));
         }
         ensure_field_type_known(field, env, name)?;
@@ -77,39 +77,39 @@ pub(crate) fn build_artifact_schema(
         name: name.to_string(),
         fields: compiled_fields,
         methods: HashMap::new(),
-        line_info: line_info.clone(),
+        line_info: *line_info,
     })
 }
 
 pub(crate) fn expect_artifact_handle(
     value: &Value,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<ArtifactHandle, EvalError> {
     match value {
         Value::Artifact(handle) => Ok(handle.clone()),
         other => Err(EvalError::InvalidOperation(
             format!("Expected artifact value, found {}", describe_value(other)),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
 
 pub(crate) fn expect_artifact_from_eval(
     result: EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<ArtifactHandle, EvalError> {
     match result {
         EvalResult::Data(Value::Artifact(handle)) => Ok(handle),
         EvalResult::Data(other) => Err(EvalError::InvalidOperation(
             format!("Expected artifact value, found {}", describe_value(&other)),
-            line_info.clone(),
+            *line_info,
         )),
         control => Err(EvalError::InvalidOperation(
             format!(
                 "Expected artifact value but received control-flow result {:?}",
                 control
             ),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -117,12 +117,12 @@ pub(crate) fn expect_artifact_from_eval(
 pub(crate) fn lookup_schema_by_name<'a>(
     env: &'a RuntimeEnv,
     type_name: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<&'a ArtifactSchema, EvalError> {
     env.get_artifact(type_name).ok_or_else(|| {
         EvalError::InvalidOperation(
             format!("Artifact type {} is not defined", type_name),
-            line_info.clone(),
+            *line_info,
         )
     })
 }
@@ -130,7 +130,7 @@ pub(crate) fn lookup_schema_by_name<'a>(
 pub(crate) fn lookup_schema_from_handle<'a>(
     env: &'a RuntimeEnv,
     handle: &ArtifactHandle,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<&'a ArtifactSchema, EvalError> {
     let type_name = handle.borrow().type_name.clone();
     lookup_schema_by_name(env, &type_name, line_info)
@@ -139,7 +139,7 @@ pub(crate) fn lookup_schema_from_handle<'a>(
 pub(crate) fn ensure_field_exists<'a>(
     schema: &'a ArtifactSchema,
     field: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<&'a ArtifactFieldSchema, EvalError> {
     schema
         .field(field)
@@ -149,7 +149,7 @@ pub(crate) fn ensure_field_exists<'a>(
 pub(crate) fn missing_field_error(
     schema: &ArtifactSchema,
     field: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> EvalError {
     let available_names = schema.field_names();
     let hint = did_you_mean_hint(field, available_names.iter().map(String::as_str), 3)
@@ -161,7 +161,7 @@ pub(crate) fn missing_field_error(
             "Field '{}'{} does not exist on artifact {} (available: [{}])",
             field, hint, schema.name, available
         ),
-        line_info.clone(),
+        *line_info,
     )
 }
 
@@ -169,7 +169,7 @@ pub(crate) fn read_artifact_field(
     env: &RuntimeEnv,
     handle: &ArtifactHandle,
     field: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     let schema = lookup_schema_from_handle(env, handle, line_info)?;
     ensure_field_exists(schema, field, line_info)?;
@@ -197,7 +197,7 @@ pub(crate) fn compare_artifacts(
     env: &RuntimeEnv,
     left: &ArtifactHandle,
     right: &ArtifactHandle,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<bool, EvalError> {
     let left_borrow = left.borrow();
     let right_borrow = right.borrow();
@@ -255,7 +255,7 @@ pub(crate) fn values_equal(
     env: &RuntimeEnv,
     left: &Value,
     right: &Value,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<bool, EvalError> {
     match (left, right) {
         (Value::Omen(l), Value::Omen(r)) => Ok(l == r),

--- a/crates/abyss-interpreter/src/eval/collections.rs
+++ b/crates/abyss-interpreter/src/eval/collections.rs
@@ -1,39 +1,39 @@
 use crate::env::Value;
 use abyss_core::ast::AST;
-use abyss_core::ast::LineInfo;
+use abyss_core::ast::Span;
 
 use super::result::{EvalError, EvalResult};
 
 pub(crate) fn expect_arcana_index(
     index: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<usize, EvalError> {
     if let EvalResult::Data(Value::Arcana(value)) = index {
         if *value < 0 {
             return Err(EvalError::InvalidOperation(
                 "Scroll index cannot be negative".to_string(),
-                line_info.clone(),
+                *line_info,
             ));
         }
         Ok(*value as usize)
     } else {
         Err(EvalError::TypeError(
             "Scroll index must be arcana".to_string(),
-            line_info.clone(),
+            *line_info,
         ))
     }
 }
 
 pub(crate) fn expect_rune_key(
     index: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<String, EvalError> {
     if let EvalResult::Data(Value::Rune(value)) = index {
         Ok(value.as_ref().clone())
     } else {
         Err(EvalError::TypeError(
             "Lexicon key must be rune".to_string(),
-            line_info.clone(),
+            *line_info,
         ))
     }
 }
@@ -62,8 +62,8 @@ mod tests {
     use super::*;
     use std::rc::Rc;
 
-    fn line() -> Option<LineInfo> {
-        Some(LineInfo::new(1, 1))
+    fn line() -> Option<Span> {
+        Some(Span::new(1, 1))
     }
 
     #[test]

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::diagnostics::did_you_mean_hint;
 use crate::env::{CallArg, Callable, EngravedFunction, RuntimeEnv, Value};
 use crate::stdlib::methods;
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 
 use super::artifacts::{
     collect_field_chain, compare_artifacts, ensure_field_exists, expect_artifact_from_eval,
@@ -39,7 +39,7 @@ pub(crate) fn try_evaluate_expression(
             for element in elements {
                 evaluated.push(eval_result_to_value_checked(
                     statements::evaluate(element, env)?,
-                    line_info.clone(),
+                    *line_info,
                 )?);
             }
             EvalResult::data(Value::Scroll(Rc::new(RefCell::new(evaluated))))
@@ -47,10 +47,8 @@ pub(crate) fn try_evaluate_expression(
         AST::MapLiteral { entries, line_info } => {
             let mut map = HashMap::new();
             for (key, expr) in entries {
-                let value = eval_result_to_value_checked(
-                    statements::evaluate(expr, env)?,
-                    line_info.clone(),
-                )?;
+                let value =
+                    eval_result_to_value_checked(statements::evaluate(expr, env)?, *line_info)?;
                 map.insert(key.clone(), value);
             }
             EvalResult::data(Value::Lexicon(Rc::new(RefCell::new(map))))
@@ -121,14 +119,14 @@ pub(crate) fn try_evaluate_expression(
         ) {
             (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => {
                 if r < 0 {
-                    return Err(EvalError::NegativeExponent(line_info.clone()));
+                    return Err(EvalError::NegativeExponent(*line_info));
                 }
                 EvalResult::data(Value::Arcana(l.pow(r as u32)))
             }
             _ => {
                 return Err(EvalError::InvalidOperation(
                     "PowArcana operation requires two Arcana!".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
         },
@@ -142,7 +140,7 @@ pub(crate) fn try_evaluate_expression(
             _ => {
                 return Err(EvalError::InvalidOperation(
                     "PowAether operation requires two Aether!".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
         },
@@ -175,7 +173,7 @@ pub(crate) fn try_evaluate_expression(
                 _ => {
                     return Err(EvalError::InvalidOperation(
                         "LogicalNot operation requires Omen!".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             }
@@ -183,7 +181,7 @@ pub(crate) fn try_evaluate_expression(
         AST::Var(name, line_info) => match env.get_var(name) {
             Some(var_info) => value_to_eval_result(&var_info.value),
             None => {
-                return Err(env.undefined_variable_error(name, line_info.clone()));
+                return Err(env.undefined_variable_error(name, *line_info));
             }
         },
         AST::IndexAccess {
@@ -200,21 +198,22 @@ pub(crate) fn try_evaluate_expression(
                     let value = borrowed
                         .get(idx)
                         .cloned()
-                        .ok_or_else(|| EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()))?;
+                        .ok_or(EvalError::ScrollIndexOutOfBounds(idx, *line_info))?;
                     EvalResult::data(value)
                 }
                 EvalResult::Data(Value::Lexicon(entries)) => {
                     let key = expect_rune_key(&idx_value, line_info)?;
                     let borrowed = entries.borrow();
-                    let value = borrowed.get(&key).cloned().ok_or_else(|| {
-                        EvalError::MissingLexiconKey(key.clone(), line_info.clone())
-                    })?;
+                    let value = borrowed
+                        .get(&key)
+                        .cloned()
+                        .ok_or_else(|| EvalError::MissingLexiconKey(key.clone(), *line_info))?;
                     EvalResult::data(value)
                 }
                 _ => {
                     return Err(EvalError::InvalidOperation(
                         "Indexing is only supported for scroll or lexicon".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             }
@@ -241,7 +240,7 @@ fn binary_numeric_op<TArc, TAether>(
     env: &mut RuntimeEnv,
     left: &AST,
     right: &AST,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     arcana_op: TArc,
     aether_op: TAether,
     rune_op: Option<fn(String, String) -> String>,
@@ -271,7 +270,7 @@ where
         }
         _ => Err(EvalError::InvalidOperation(
             "Operation requires compatible types".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -280,7 +279,7 @@ fn instantiate_artifact_literal(
     env: &mut RuntimeEnv,
     type_name: &str,
     fields: &[(String, AST)],
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let schema = lookup_schema_by_name(env, type_name, line_info)?.clone();
     let mut provided = HashSet::new();
@@ -290,7 +289,7 @@ fn instantiate_artifact_literal(
         if !provided.insert(field_name.clone()) {
             return Err(EvalError::InvalidOperation(
                 format!("Field '{}' is provided multiple times", field_name),
-                line_info.clone(),
+                *line_info,
             ));
         }
 
@@ -313,7 +312,7 @@ fn instantiate_artifact_literal(
                 type_name,
                 missing.join(", ")
             ),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -328,7 +327,7 @@ fn compare_values(
     env: &mut RuntimeEnv,
     left: &AST,
     right: &AST,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     equality: bool,
 ) -> Result<EvalResult, EvalError> {
     let left_result = statements::evaluate(left, env)?;
@@ -346,7 +345,7 @@ fn compare_values(
         _ => {
             return Err(EvalError::InvalidOperation(
                 "Comparison requires compatible types!".to_string(),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -359,7 +358,7 @@ fn order_values<F>(
     env: &mut RuntimeEnv,
     left: &AST,
     right: &AST,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     comparator: F,
 ) -> Result<EvalResult, EvalError>
 where
@@ -377,7 +376,7 @@ where
         }
         _ => Err(EvalError::InvalidOperation(
             "Comparison requires numeric types!".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -386,7 +385,7 @@ fn logical_op<F>(
     env: &mut RuntimeEnv,
     left: &AST,
     right: &AST,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     op: F,
 ) -> Result<EvalResult, EvalError>
 where
@@ -401,7 +400,7 @@ where
         }
         _ => Err(EvalError::InvalidOperation(
             "Logical operation requires two Omen!".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -411,7 +410,7 @@ fn evaluate_method_call(
     receiver: &AST,
     method_name: &str,
     args: &[AST],
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let receiver_result = statements::evaluate(receiver, env)?;
     let receiver_var_name = if let AST::Var(var_name, _) = receiver {
@@ -458,7 +457,7 @@ fn evaluate_method_call(
                 "Cannot invoke method {} on control-flow result {:?}",
                 method_name, control
             ),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -468,7 +467,7 @@ fn ensure_method_receiver_mutability(
     receiver: &AST,
     artifact_name: &str,
     method_name: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<(), EvalError> {
     if let Some((base_name, _)) = collect_field_chain(receiver) {
         if let Some(var_info) = env.get_var(&base_name) {
@@ -480,10 +479,10 @@ fn ensure_method_receiver_mutability(
                     "Cannot call {}::{} with immutable receiver '{}'",
                     artifact_name, method_name, base_name
                 ),
-                line_info.clone(),
+                *line_info,
             ));
         } else {
-            return Err(env.undefined_variable_error(&base_name, line_info.clone()));
+            return Err(env.undefined_variable_error(&base_name, *line_info));
         }
     }
 
@@ -492,7 +491,7 @@ fn ensure_method_receiver_mutability(
             "Method {}::{} requires a morph receiver, but the expression is not tied to a mutable variable",
             artifact_name, method_name
         ),
-        line_info.clone(),
+        *line_info,
     ))
 }
 
@@ -503,7 +502,7 @@ fn evaluate_artifact_method_call(
     receiver_handle: crate::env::ArtifactHandle,
     method_name: &str,
     arg_values: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let schema = lookup_schema_from_handle(env, &receiver_handle, line_info)?;
     let artifact_name = schema.name.clone();
@@ -520,7 +519,7 @@ fn evaluate_artifact_method_call(
                     "Method {}::{} is not defined{}",
                     artifact_name, method_name, hint
                 ),
-                line_info.clone(),
+                *line_info,
             )
         })?;
 
@@ -553,12 +552,12 @@ fn evaluate_function_call(
     env: &mut RuntimeEnv,
     name: &str,
     args: &[AST],
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let callable = match env.get_function(name) {
         Some(func) => func.clone(),
         None => {
-            return Err(env.undefined_function_error(name, line_info.clone()));
+            return Err(env.undefined_function_error(name, *line_info));
         }
     };
 
@@ -580,7 +579,7 @@ fn evaluate_function_call(
         Callable::Engraved(function) => {
             evaluate_engraved_function(env, evaluated_args, function, line_info)
         }
-        Callable::Builtin(function) => (function.func)(env, evaluated_args, line_info.clone()),
+        Callable::Builtin(function) => (function.func)(env, evaluated_args, *line_info),
     }
 }
 
@@ -588,7 +587,7 @@ fn evaluate_engraved_function(
     env: &mut RuntimeEnv,
     evaluated_args: Vec<CallArg>,
     function: EngravedFunction,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let eval_args: Vec<EvalResult> = evaluated_args.into_iter().map(|arg| arg.value).collect();
     let params = function.params.clone();
@@ -602,7 +601,7 @@ fn evaluate_engraved_function(
                 params.len(),
                 eval_args.len()
             ),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -620,7 +619,7 @@ fn evaluate_engraved_function(
                         "Expected EngraveParam in function definition: {}",
                         function.name
                     ),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
         };
@@ -634,7 +633,7 @@ fn evaluate_engraved_function(
             value,
             param_type.clone(),
             is_morph_param,
-            line_info.clone(),
+            *line_info,
         );
     }
 
@@ -644,7 +643,7 @@ fn evaluate_engraved_function(
         evaluated?
     };
 
-    let value = eval_result_to_value_checked(result, function.line_info.clone())?;
+    let value = eval_result_to_value_checked(result, function.line_info)?;
 
     match (function.return_type.clone(), value) {
         (Type::Arcana, Value::Arcana(v)) => Ok(EvalResult::data(Value::Arcana(v))),
@@ -665,7 +664,7 @@ fn evaluate_engraved_function(
                         "Type mismatch for return value of function {} (expected artifact {}, got {})",
                         function.name, expected, type_name
                     ),
-                    function.line_info.clone(),
+                    function.line_info,
                 ))
             }
         }
@@ -676,7 +675,7 @@ fn evaluate_engraved_function(
                 expected,
                 describe_value(&actual)
             ),
-            function.line_info.clone(),
+            function.line_info,
         )),
     }
 }
@@ -684,7 +683,7 @@ fn evaluate_engraved_function(
 fn validate_artifact_type(
     handle: Rc<RefCell<crate::env::ArtifactValue>>,
     expected: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     let actual = handle.borrow().type_name.clone();
     if actual == expected {
@@ -693,7 +692,7 @@ fn validate_artifact_type(
         Err(EvalError::ArtifactTypeMismatch {
             expected: expected.to_string(),
             found: actual,
-            line_info: line_info.clone(),
+            line_info: *line_info,
         })
     }
 }
@@ -701,7 +700,7 @@ fn validate_artifact_type(
 fn convert_morph_param_value(
     evaluated_arg: EvalResult,
     param_type: &Type,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     match param_type {
         Type::Artifact(expected) => match evaluated_arg {
@@ -712,7 +711,7 @@ fn convert_morph_param_value(
         },
         _ => Err(EvalError::InvalidOperation(
             "`morph` parameters are only supported for artifact receivers".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -721,7 +720,7 @@ fn convert_morph_param_value(
 mod tests {
     use super::*;
 
-    fn dummy_line_info() -> Option<LineInfo> {
+    fn dummy_line_info() -> Option<Span> {
         None
     }
 

--- a/crates/abyss-interpreter/src/eval/patterns.rs
+++ b/crates/abyss-interpreter/src/eval/patterns.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::env::{RuntimeEnv, Value};
-use abyss_core::ast::{AST, ConditionalAssignment, LineInfo, Type};
+use abyss_core::ast::{AST, ConditionalAssignment, Span, Type};
 
 use super::artifacts::{lookup_schema_from_handle, read_artifact_field, values_equal};
 use super::result::{EvalError, EvalResult};
@@ -30,7 +30,7 @@ pub(super) fn evaluate_oracle(
     is_match: bool,
     conditionals: &[ConditionalAssignment],
     branches: &[AST],
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     env: &mut RuntimeEnv,
 ) -> Result<EvalResult, EvalError> {
     let mut scrutinee_values = Vec::with_capacity(conditionals.len());
@@ -59,7 +59,7 @@ pub(super) fn evaluate_oracle(
             other => {
                 return Err(EvalError::InvalidOperation(
                     format!("Unsupported type in oracle scrutinee: {:?}", other),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
         };
@@ -119,7 +119,7 @@ fn evaluate_oracle_branch(
     pattern: &[AST],
     guard: Option<&AST>,
     body: &AST,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     scrutinee_values: &[Value],
     env: &mut RuntimeEnv,
 ) -> Result<Option<EvalResult>, EvalError> {
@@ -133,7 +133,7 @@ fn evaluate_oracle_branch(
                     pattern.len(),
                     scrutinee_values.len()
                 ),
-                line_info.clone(),
+                *line_info,
             ));
         }
 
@@ -146,7 +146,7 @@ fn evaluate_oracle_branch(
             let Some(scrutinee_value) = scrutinee_values.get(idx) else {
                 return Err(EvalError::InvalidOperation(
                     "Oracle branch references missing scrutinee".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             };
 
@@ -161,7 +161,7 @@ fn evaluate_oracle_branch(
                     scrutinee_value.clone(),
                     type_of_scrutinee(scrutinee_value),
                     false,
-                    var_line.clone(),
+                    *var_line,
                 );
                 continue;
             }
@@ -244,7 +244,7 @@ fn evaluate_oracle_branch(
                 _ => {
                     return Err(EvalError::InvalidOperation(
                         "Oracle branch pattern type must match scrutinee type".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             }
@@ -265,7 +265,7 @@ fn evaluate_oracle_branch(
                             "Oracle if-else pattern must evaluate to an omen, found {:?}",
                             other
                         ),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             }
@@ -281,7 +281,7 @@ fn evaluate_oracle_branch(
                 other => {
                     return Err(EvalError::InvalidOperation(
                         format!("Oracle ward must evaluate to an omen, found {:?}", other),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             },
@@ -341,7 +341,7 @@ fn type_of_scrutinee(value: &Value) -> Type {
 fn match_scroll_pattern(
     elements: &[AST],
     scrutinee_value: &Value,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     env: &mut RuntimeEnv,
 ) -> Result<bool, EvalError> {
     let scroll_handle = match scrutinee_value {
@@ -352,7 +352,7 @@ fn match_scroll_pattern(
                     "Scroll pattern requires a scroll scrutinee, found {:?}",
                     scrutinee_value
                 ),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -365,7 +365,7 @@ fn match_scroll_pattern(
             if rest_index.is_some() {
                 return Err(EvalError::InvalidOperation(
                     "Scroll pattern may contain at most one rest segment".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
             rest_index = Some(idx);
@@ -377,7 +377,7 @@ fn match_scroll_pattern(
     {
         return Err(EvalError::InvalidOperation(
             "Scroll rest segment must appear at the end of the pattern".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -404,7 +404,7 @@ fn match_scroll_pattern(
                     elem_value.clone(),
                     type_of_scrutinee(elem_value),
                     false,
-                    var_line.clone(),
+                    *var_line,
                 );
             }
             AST::OracleScrollPattern {
@@ -454,7 +454,7 @@ fn match_scroll_pattern(
             Value::Scroll(tail_handle),
             Type::Scroll,
             false,
-            rest_line.clone(),
+            *rest_line,
         );
     }
 
@@ -490,7 +490,7 @@ fn match_artifact_pattern(
     type_name: &str,
     fields: &[(String, AST)],
     scrutinee_value: &Value,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     env: &mut RuntimeEnv,
 ) -> Result<bool, EvalError> {
     let handle = match scrutinee_value {
@@ -501,7 +501,7 @@ fn match_artifact_pattern(
                     "Artifact pattern requires an artifact scrutinee, found {:?}",
                     scrutinee_value
                 ),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -509,7 +509,7 @@ fn match_artifact_pattern(
     if env.get_artifact(type_name).is_none() {
         return Err(EvalError::InvalidOperation(
             format!("Artifact pattern references undefined type {}", type_name),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -544,13 +544,7 @@ fn match_artifact_pattern(
             AST::OracleDontCareItem(_) => continue,
             AST::Var(name, var_line) => {
                 let bound_type = type_of_scrutinee(&field_value);
-                env.set_var(
-                    name.clone(),
-                    field_value,
-                    bound_type,
-                    false,
-                    var_line.clone(),
-                );
+                env.set_var(name.clone(), field_value, bound_type, false, *var_line);
             }
             AST::OracleScrollPattern {
                 elements,
@@ -597,7 +591,7 @@ fn match_artifact_pattern(
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
                         return Err(EvalError::InvalidOperation(
                             "Artifact field pattern compare must yield a value".to_string(),
-                            line_info.clone(),
+                            *line_info,
                         ));
                     }
                 };
@@ -632,7 +626,7 @@ fn match_artifact_pattern(
 fn match_lexicon_pattern(
     entries: &[(String, AST)],
     scrutinee_value: &Value,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
     env: &mut RuntimeEnv,
 ) -> Result<bool, EvalError> {
     let lexicon_handle = match scrutinee_value {
@@ -643,7 +637,7 @@ fn match_lexicon_pattern(
                     "Lexicon pattern requires a lexicon scrutinee, found {:?}",
                     scrutinee_value
                 ),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -661,13 +655,7 @@ fn match_lexicon_pattern(
             AST::OracleDontCareItem(_) => continue,
             AST::Var(name, var_line) => {
                 let bound_type = type_of_scrutinee(&entry_value);
-                env.set_var(
-                    name.clone(),
-                    entry_value,
-                    bound_type,
-                    false,
-                    var_line.clone(),
-                );
+                env.set_var(name.clone(), entry_value, bound_type, false, *var_line);
             }
             AST::OracleScrollPattern {
                 elements,
@@ -710,7 +698,7 @@ fn match_lexicon_pattern(
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
                         return Err(EvalError::InvalidOperation(
                             "Lexicon entry pattern compare must yield a value".to_string(),
-                            line_info.clone(),
+                            *line_info,
                         ));
                     }
                 };
@@ -735,7 +723,7 @@ fn match_lexicon_pattern(
 fn values_match_for_pattern(
     actual: &Value,
     expected: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<bool, EvalError> {
     match (actual, expected) {
         (Value::Arcana(a), EvalResult::Data(Value::Arcana(b))) => Ok(a == b),
@@ -744,7 +732,7 @@ fn values_match_for_pattern(
         (Value::Omen(a), EvalResult::Data(Value::Omen(b))) => Ok(a == b),
         _ => Err(EvalError::InvalidOperation(
             "Scroll pattern element type must match scrutinee element type".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -753,8 +741,8 @@ fn values_match_for_pattern(
 mod tests {
     use super::*;
 
-    fn line() -> Option<LineInfo> {
-        Some(LineInfo::new(1, 1))
+    fn line() -> Option<Span> {
+        Some(Span::new(1, 1))
     }
     #[test]
     fn oracle_match_branch_returns_revealed_value() {

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -1,5 +1,5 @@
 use crate::env::{ArtifactHandle, Value};
-use abyss_core::ast::{LineInfo, Type};
+use abyss_core::ast::{Span, Type};
 use ariadne::{Color, Label, Report, ReportKind, Source};
 use std::fmt;
 
@@ -40,29 +40,29 @@ impl EvalResult {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum EvalError {
-    UndefinedVariable(String, Option<LineInfo>),
-    InvalidOperation(String, Option<LineInfo>),
-    NegativeExponent(Option<LineInfo>),
-    TypeError(String, Option<LineInfo>),
+    UndefinedVariable(String, Option<Span>),
+    InvalidOperation(String, Option<Span>),
+    NegativeExponent(Option<Span>),
+    TypeError(String, Option<Span>),
     /// A value of the given type was required but something else was
     /// produced (variable initialisation, argument conversion, builtin
     /// extraction). For `Type::Artifact` the message names the artifact
     /// type; use [`EvalError::ArtifactTypeMismatch`] when the *found*
     /// artifact type is also known.
-    ExpectedType(Type, Option<LineInfo>),
+    ExpectedType(Type, Option<Span>),
     /// An artifact of one type appeared where another artifact type was
     /// required.
     ArtifactTypeMismatch {
         expected: String,
         found: String,
-        line_info: Option<LineInfo>,
+        line_info: Option<Span>,
     },
     /// Assignment to a variable that was not declared `morph`.
-    ImmutableAssignment(String, Option<LineInfo>),
+    ImmutableAssignment(String, Option<Span>),
     /// Scroll index outside the valid range.
-    ScrollIndexOutOfBounds(usize, Option<LineInfo>),
+    ScrollIndexOutOfBounds(usize, Option<Span>),
     /// Lexicon lookup with a key that has no entry.
-    MissingLexiconKey(String, Option<LineInfo>),
+    MissingLexiconKey(String, Option<Span>),
 }
 
 /// Lowercase keyword name for a type, as used in "Expected … value"
@@ -84,7 +84,7 @@ fn type_label(ty: &Type) -> &str {
 
 impl EvalError {
     /// Returns the source-position metadata attached to this error, if any.
-    pub fn line_info(&self) -> Option<&LineInfo> {
+    pub fn line_info(&self) -> Option<&Span> {
         match self {
             EvalError::UndefinedVariable(_, info)
             | EvalError::InvalidOperation(_, info)
@@ -180,9 +180,9 @@ pub fn display_error_with_source(script: &str, error: &EvalError) {
 
 /// Render a runtime error against the source script using
 /// [`ariadne`]'s annotated report style — matching the parser's diagnostic
-/// look. When the error carries a [`LineInfo`] that resolves into the source,
-/// the offending column is underlined; otherwise a plain "Error: …" line is
-/// printed to stderr as a fallback.
+/// look. When the error carries a [`Span`] that resolves into the source,
+/// the full offending range is underlined; otherwise a plain "Error: …" line
+/// is printed to stderr as a fallback.
 ///
 /// `source_id` controls the label shown by the diagnostic renderer (e.g.
 /// `"<script>"`, `"<repl>"`, `"<test>"`, or a file path) so runtime reports
@@ -247,13 +247,13 @@ fn write_error_with_source_id<W: std::io::Write>(
 ) -> std::io::Result<()> {
     let message = error.to_string();
     if let Some(info) = error.line_info()
-        && let Some(start) = line_col_to_byte_offset(script, info.line, info.column)
+        && info.start() <= script.len()
     {
-        // Single-byte highlight at the reported column, clamped so the span
-        // never extends past the source. `LineInfo` carries no end position
-        // today, so finer-grained highlighting requires the larger Span
-        // refactor planned for a later release.
-        let end = (start + 1).min(script.len()).max(start);
+        // Underline the full span the error carries, clamped so the range
+        // never extends past the source. A zero-width span is widened to
+        // one byte so ariadne still draws a caret at the position.
+        let start = info.start();
+        let end = info.end().clamp(start + 1, script.len().max(start + 1));
         let span = start..end;
         let report = Report::build(ReportKind::Error, (source_id, span.clone()))
             .with_message(error.kind_label())
@@ -267,36 +267,6 @@ fn write_error_with_source_id<W: std::io::Write>(
     } else {
         writeln!(writer, "Error: {}", message)
     }
-}
-
-/// Convert a 1-based `(line, column)` pair (where `column` is a byte offset
-/// within the line, matching the parser's `LineMap`) into a byte offset
-/// suitable for ariadne's range-based labels.
-///
-/// Returns `None` when the position cannot be resolved against `source` —
-/// this includes columns past the end of the named line, which would
-/// otherwise spill into the next line and underline an unrelated character.
-fn line_col_to_byte_offset(source: &str, line: usize, column: usize) -> Option<usize> {
-    if line == 0 || column == 0 {
-        return None;
-    }
-    let mut line_starts: Vec<usize> = vec![0];
-    for (i, ch) in source.char_indices() {
-        if ch == '\n' {
-            line_starts.push(i + ch.len_utf8());
-        }
-    }
-    let line_start = *line_starts.get(line - 1)?;
-    // Stop the column at the end of its own line. For non-last lines that's
-    // the offset of the next line's first byte (just past the newline); for
-    // the last line we allow a one-past-end (EOF) position so errors
-    // attached to the final character still resolve.
-    let line_end_exclusive = line_starts.get(line).copied().unwrap_or(source.len() + 1);
-    let offset = line_start + (column - 1);
-    if offset >= line_end_exclusive || offset > source.len() {
-        return None;
-    }
-    Some(offset)
 }
 
 #[cfg(test)]
@@ -347,56 +317,56 @@ mod tests {
     /// stay byte-identical to the legacy stringly-typed messages.
     #[test]
     fn structured_variants_render_legacy_messages() {
-        let info = Some(LineInfo::new(3, 7));
+        let info = Some(Span::new(3, 7));
 
         let cases: Vec<(EvalError, &str, &str)> = vec![
             (
-                EvalError::ExpectedType(Type::Arcana, info.clone()),
+                EvalError::ExpectedType(Type::Arcana, info),
                 "Type error: Expected arcana value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Aether, info.clone()),
+                EvalError::ExpectedType(Type::Aether, info),
                 "Type error: Expected aether value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Rune, info.clone()),
+                EvalError::ExpectedType(Type::Rune, info),
                 "Type error: Expected rune value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Omen, info.clone()),
+                EvalError::ExpectedType(Type::Omen, info),
                 "Type error: Expected omen value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Abyss, info.clone()),
+                EvalError::ExpectedType(Type::Abyss, info),
                 "Type error: Expected abyss value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Scroll, info.clone()),
+                EvalError::ExpectedType(Type::Scroll, info),
                 "Type error: Expected scroll value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Lexicon, info.clone()),
+                EvalError::ExpectedType(Type::Lexicon, info),
                 "Type error: Expected lexicon value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Glyph, info.clone()),
+                EvalError::ExpectedType(Type::Glyph, info),
                 "Type error: Expected glyph value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Materia, info.clone()),
+                EvalError::ExpectedType(Type::Materia, info),
                 "Type error: Expected materia value",
                 "Type error",
             ),
             (
-                EvalError::ExpectedType(Type::Artifact("Player".into()), info.clone()),
+                EvalError::ExpectedType(Type::Artifact("Player".into()), info),
                 "Type error: Expected artifact of type Player",
                 "Type error",
             ),
@@ -404,23 +374,23 @@ mod tests {
                 EvalError::ArtifactTypeMismatch {
                     expected: "Player".into(),
                     found: "Enemy".into(),
-                    line_info: info.clone(),
+                    line_info: info,
                 },
                 "Type error: Expected artifact of type Player but received Enemy",
                 "Type error",
             ),
             (
-                EvalError::ImmutableAssignment("sigil".into(), info.clone()),
+                EvalError::ImmutableAssignment("sigil".into(), info),
                 "Invalid operation: Cannot reassign to immutable variable sigil",
                 "Invalid operation",
             ),
             (
-                EvalError::ScrollIndexOutOfBounds(9, info.clone()),
+                EvalError::ScrollIndexOutOfBounds(9, info),
                 "Invalid operation: Index 9 is out of bounds for scroll",
                 "Invalid operation",
             ),
             (
-                EvalError::MissingLexiconKey("port".into(), info.clone()),
+                EvalError::MissingLexiconKey("port".into(), info),
                 "Invalid operation: Lexicon key 'port' does not exist",
                 "Invalid operation",
             ),
@@ -429,69 +399,31 @@ mod tests {
         for (err, expected_display, expected_kind) in cases {
             assert_eq!(err.to_string(), expected_display);
             assert_eq!(err.kind_label(), expected_kind);
-            let returned = err.line_info().expect("line info should be attached");
-            assert_eq!((returned.line, returned.column), (3, 7));
+            let returned = err.line_info().expect("span should be attached");
+            assert_eq!((returned.start(), returned.end()), (3, 7));
         }
     }
 
     #[test]
     fn line_info_returns_attached_position() {
-        let err = EvalError::TypeError("x".into(), Some(LineInfo::new(3, 4)));
-        let info = err.line_info().expect("line info attached");
-        assert_eq!(info.line, 3);
-        assert_eq!(info.column, 4);
+        let err = EvalError::TypeError("x".into(), Some(Span::new(3, 4)));
+        let info = err.line_info().expect("span attached");
+        assert_eq!((info.start(), info.end()), (3, 4));
 
         let plain = EvalError::NegativeExponent(None);
         assert!(plain.line_info().is_none());
     }
 
     #[test]
-    fn line_col_to_byte_offset_resolves_simple_positions() {
-        let source = "abc\ndef\nghi";
-        assert_eq!(line_col_to_byte_offset(source, 1, 1), Some(0));
-        assert_eq!(line_col_to_byte_offset(source, 2, 1), Some(4));
-        assert_eq!(line_col_to_byte_offset(source, 3, 2), Some(9));
-    }
-
-    #[test]
-    fn line_col_to_byte_offset_rejects_out_of_range() {
-        let source = "abc\ndef";
-        assert_eq!(line_col_to_byte_offset(source, 0, 1), None);
-        assert_eq!(line_col_to_byte_offset(source, 1, 0), None);
-        assert_eq!(line_col_to_byte_offset(source, 5, 1), None);
-        // Column past end of source returns None.
-        assert!(line_col_to_byte_offset(source, 2, 100).is_none());
-    }
-
-    #[test]
-    fn line_col_to_byte_offset_rejects_column_past_line_end() {
-        // Line 1 contains "abc" (3 bytes) followed by a newline; column 5
-        // would otherwise spill into "def" on the next line. Reject it so
-        // the highlight cannot point at an unrelated character.
-        let source = "abc\ndef";
-        assert_eq!(line_col_to_byte_offset(source, 1, 4), Some(3));
-        assert!(line_col_to_byte_offset(source, 1, 5).is_none());
-    }
-
-    #[test]
-    fn line_col_to_byte_offset_handles_multibyte_chars() {
-        // "あ" is 3 bytes in UTF-8; the second line starts after the newline
-        // following it.
-        let source = "あ\nb";
-        assert_eq!(line_col_to_byte_offset(source, 1, 1), Some(0));
-        assert_eq!(line_col_to_byte_offset(source, 2, 1), Some(4));
-    }
-
-    #[test]
     fn display_error_with_valid_line_does_not_panic() {
         let script = "sigil = 1\nhex = sigil + 2";
-        let err = EvalError::InvalidOperation("invalid op".into(), Some(LineInfo::new(2, 5)));
+        let err = EvalError::InvalidOperation("invalid op".into(), Some(Span::new(2, 5)));
         display_error_with_source(script, &err);
     }
 
     #[test]
     fn display_error_without_matching_line_falls_back_to_generic() {
-        let err = EvalError::TypeError("out of range".into(), Some(LineInfo::new(99, 1)));
+        let err = EvalError::TypeError("out of range".into(), Some(Span::new(99, 1)));
         display_error_with_source("sigil = 1", &err);
     }
 
@@ -508,7 +440,7 @@ mod tests {
         // returns a non-empty `String`, and the rendered output mentions
         // the underlying message rather than swallowing it.
         let script = "sigil: arcana = 1\nhex = sigil + 2";
-        let err = EvalError::InvalidOperation("invalid op".into(), Some(LineInfo::new(2, 5)));
+        let err = EvalError::InvalidOperation("invalid op".into(), Some(Span::new(2, 5)));
         let rendered = render_error_with_source(script, &err);
         assert!(!rendered.is_empty(), "ariadne rendering produced no output");
         assert!(
@@ -519,7 +451,7 @@ mod tests {
 
     #[test]
     fn render_error_without_position_falls_back_to_plain_line() {
-        // With no `LineInfo` the renderer drops down to the
+        // With no `Span` the renderer drops down to the
         // `Error: …\n` fallback (matching what `display_error_with_source`
         // would print).
         let err = EvalError::NegativeExponent(None);

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1,5 +1,5 @@
 use crate::env::{ArtifactMethod, Callable, EngravedFunction, RuntimeEnv, Value};
-use abyss_core::ast::{AST, AssignmentOp, LineInfo, Type};
+use abyss_core::ast::{AST, AssignmentOp, Span, Type};
 use std::rc::Rc;
 
 use super::artifacts::{
@@ -74,7 +74,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 stored_value,
                 var_type.clone(),
                 *is_morph,
-                line_info.clone(),
+                *line_info,
             );
             Ok(EvalResult::abyss())
         }
@@ -87,10 +87,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             let evaluated_value = evaluate(value, env)?;
             if let Some(var_info) = env.get_var_mut(name) {
                 if !var_info.is_morph {
-                    return Err(EvalError::ImmutableAssignment(
-                        name.clone(),
-                        line_info.clone(),
-                    ));
+                    return Err(EvalError::ImmutableAssignment(name.clone(), *line_info));
                 }
 
                 match (&mut var_info.value, &var_info.var_type) {
@@ -114,7 +111,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                             AssignmentOp::PowArcanaAssign => {
                                 let exponent = extract_arcana(&evaluated_value, line_info)?;
                                 if exponent < 0 {
-                                    return Err(EvalError::NegativeExponent(line_info.clone()));
+                                    return Err(EvalError::NegativeExponent(*line_info));
                                 }
                                 current.pow(exponent as u32)
                             }
@@ -122,7 +119,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                             _ => {
                                 return Err(EvalError::InvalidOperation(
                                     format!("Unsupported operation for variable {}", name),
-                                    line_info.clone(),
+                                    *line_info,
                                 ));
                             }
                         };
@@ -141,7 +138,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                             _ => {
                                 return Err(EvalError::InvalidOperation(
                                     format!("Unsupported operation for variable {}", name),
-                                    line_info.clone(),
+                                    *line_info,
                                 ));
                             }
                         };
@@ -161,7 +158,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         _ => {
                             return Err(EvalError::InvalidOperation(
                                 format!("Unsupported operation for variable {}", name),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
                     },
@@ -169,7 +166,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
                                 format!("Unsupported operation for variable {}", name),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
                         *current = extract_omen(&evaluated_value, line_info)?;
@@ -178,18 +175,18 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
                                 format!("Unsupported operation for variable {}", name),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
                         if !matches!(evaluated_value, EvalResult::Data(Value::Abyss)) {
-                            return Err(EvalError::ExpectedType(Type::Abyss, line_info.clone()));
+                            return Err(EvalError::ExpectedType(Type::Abyss, *line_info));
                         }
                     }
                     (value_slot, Type::Scroll) => {
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
                                 "Scroll reassignment only supports =".to_string(),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
                         *value_slot =
@@ -199,7 +196,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
                                 "Lexicon reassignment only supports =".to_string(),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
                         *value_slot =
@@ -209,11 +206,10 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
                                 "Materia variables only support =".to_string(),
-                                line_info.clone(),
+                                *line_info,
                             ));
                         }
-                        *value_slot =
-                            eval_result_to_value_checked(evaluated_value, line_info.clone())?;
+                        *value_slot = eval_result_to_value_checked(evaluated_value, *line_info)?;
                     }
                     _ => {
                         return Err(EvalError::InvalidOperation(
@@ -221,14 +217,14 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                                 "Type mismatch or unsupported operation for variable {}",
                                 name
                             ),
-                            line_info.clone(),
+                            *line_info,
                         ));
                     }
                 }
 
                 Ok(EvalResult::abyss())
             } else {
-                Err(env.undefined_variable_error(name, line_info.clone()))
+                Err(env.undefined_variable_error(name, *line_info))
             }
         }
         AST::IndexAssignment {
@@ -240,7 +236,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             let (base_name, nested_indices) = collect_index_chain(target).ok_or_else(|| {
                 EvalError::InvalidOperation(
                     "Indexed assignment requires a mutable variable target".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 )
             })?;
 
@@ -250,19 +246,19 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             }
 
             let final_index_value = evaluate(index, env)?;
-            let new_value = eval_result_to_value_checked(evaluate(value, env)?, line_info.clone())?;
+            let new_value = eval_result_to_value_checked(evaluate(value, env)?, *line_info)?;
 
             let var_info = match env.get_var_mut(&base_name) {
                 Some(var_info) => var_info,
                 None => {
-                    return Err(env.undefined_variable_error(&base_name, line_info.clone()));
+                    return Err(env.undefined_variable_error(&base_name, *line_info));
                 }
             };
 
             if !var_info.is_morph {
                 return Err(EvalError::ImmutableAssignment(
                     base_name.clone(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
 
@@ -276,7 +272,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                     let idx = expect_arcana_index(&final_index_value, line_info)?;
                     let mut items = handle.borrow_mut();
                     if idx >= items.len() {
-                        return Err(EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()));
+                        return Err(EvalError::ScrollIndexOutOfBounds(idx, *line_info));
                     }
                     items[idx] = new_value;
                 }
@@ -288,7 +284,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 _ => {
                     return Err(EvalError::InvalidOperation(
                         "Indexed assignment requires a scroll or lexicon".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     ));
                 }
             }
@@ -304,7 +300,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             let (base_name, access_chain) = collect_field_chain(target).ok_or_else(|| {
                 EvalError::InvalidOperation(
                     "Field assignment requires an artifact variable".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 )
             })?;
 
@@ -313,14 +309,14 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             let var_info = match env.get_var_mut(&base_name) {
                 Some(var_info) => var_info,
                 None => {
-                    return Err(env.undefined_variable_error(&base_name, line_info.clone()));
+                    return Err(env.undefined_variable_error(&base_name, *line_info));
                 }
             };
 
             if !var_info.is_morph {
                 return Err(EvalError::ImmutableAssignment(
                     base_name.clone(),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
 
@@ -345,7 +341,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                                 segment,
                                 describe_value(&other)
                             ),
-                            line_info.clone(),
+                            *line_info,
                         ));
                     }
                 };
@@ -441,7 +437,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         Value::Arcana(value),
                         Type::Arcana,
                         true,
-                        line_info.clone(),
+                        *line_info,
                     );
 
                     let remaining_params = params[1..].to_vec();
@@ -452,7 +448,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                             &AST::Orbit {
                                 params: remaining_params,
                                 body: body.clone(),
-                                line_info: line_info.clone(),
+                                line_info: *line_info,
                             },
                             env,
                         )?
@@ -490,7 +486,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             } else {
                 Err(EvalError::InvalidOperation(
                     "Expected OrbitParam in Orbit".to_string(),
-                    line_info.clone(),
+                    *line_info,
                 ))
             }
         }
@@ -525,7 +521,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 params: params.clone(),
                 return_type: return_type.clone(),
                 body: body.clone(),
-                line_info: line_info.clone(),
+                line_info: *line_info,
             };
             if let Some(target) = method_target {
                 let artifact_method = ArtifactMethod {
@@ -546,7 +542,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             if env.artifact_defined_in_current_scope(name) {
                 return Err(EvalError::InvalidOperation(
                     format!("Artifact {} is already defined", name),
-                    line_info.clone(),
+                    *line_info,
                 ));
             }
             let schema = build_artifact_schema(name, fields, env, line_info)?;
@@ -556,7 +552,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 Value::Glyph(Type::Artifact(name.clone())),
                 Type::Glyph,
                 false,
-                line_info.clone(),
+                *line_info,
             );
             Ok(EvalResult::abyss())
         }
@@ -571,7 +567,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
 fn clone_indexed_child(
     value: &Value,
     index: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     match value {
         Value::Scroll(handle) => {
@@ -580,7 +576,7 @@ fn clone_indexed_child(
             borrowed
                 .get(idx)
                 .cloned()
-                .ok_or_else(|| EvalError::ScrollIndexOutOfBounds(idx, line_info.clone()))
+                .ok_or(EvalError::ScrollIndexOutOfBounds(idx, *line_info))
         }
         Value::Lexicon(handle) => {
             let key = expect_rune_key(index, line_info)?;
@@ -588,11 +584,11 @@ fn clone_indexed_child(
             borrowed
                 .get(&key)
                 .cloned()
-                .ok_or_else(|| EvalError::MissingLexiconKey(key.clone(), line_info.clone()))
+                .ok_or_else(|| EvalError::MissingLexiconKey(key.clone(), *line_info))
         }
         _ => Err(EvalError::InvalidOperation(
             "Cannot index into non-collection value".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }
@@ -602,8 +598,8 @@ mod tests {
     use super::*;
     use crate::eval::test_support::{artifact_handle, lexicon, register_artifact, rune, scroll};
 
-    fn line() -> Option<LineInfo> {
-        Some(LineInfo::new(1, 1))
+    fn line() -> Option<Span> {
+        Some(Span::new(1, 1))
     }
 
     #[test]

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -1,5 +1,5 @@
 use crate::env::{ArtifactHandle, ArtifactValue, Value};
-use abyss_core::ast::{LineInfo, Type};
+use abyss_core::ast::{Span, Type};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -24,11 +24,11 @@ pub(crate) fn eval_result_to_value_any(result: EvalResult) -> Result<Value, Eval
 
 pub(crate) fn eval_result_to_value_checked(
     result: EvalResult,
-    line_info: Option<LineInfo>,
+    line_info: Option<Span>,
 ) -> Result<Value, EvalError> {
     eval_result_to_value_any(result).map_err(|err| match err {
-        EvalError::InvalidOperation(msg, _) => EvalError::InvalidOperation(msg, line_info.clone()),
-        EvalError::TypeError(msg, _) => EvalError::TypeError(msg, line_info.clone()),
+        EvalError::InvalidOperation(msg, _) => EvalError::InvalidOperation(msg, line_info),
+        EvalError::TypeError(msg, _) => EvalError::TypeError(msg, line_info),
         other => other,
     })
 }
@@ -36,14 +36,14 @@ pub(crate) fn eval_result_to_value_checked(
 pub(crate) fn convert_to_typed_value(
     result: EvalResult,
     expected: &Type,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     let value = match result {
         EvalResult::Data(value) => value,
         control => {
             return Err(EvalError::InvalidOperation(
                 format!("Expected data value but received {:?}", control),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -55,35 +55,35 @@ pub(crate) fn convert_to_typed_value(
         }),
         Type::Arcana => match value {
             Value::Arcana(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Arcana, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Arcana, *line_info)),
         },
         Type::Aether => match value {
             Value::Aether(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Aether, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Aether, *line_info)),
         },
         Type::Rune => match value {
             Value::Rune(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Rune, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Rune, *line_info)),
         },
         Type::Omen => match value {
             Value::Omen(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Omen, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Omen, *line_info)),
         },
         Type::Abyss => match value {
             Value::Abyss => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Abyss, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Abyss, *line_info)),
         },
         Type::Scroll => match value {
             Value::Scroll(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Scroll, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Scroll, *line_info)),
         },
         Type::Lexicon => match value {
             Value::Lexicon(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Lexicon, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Lexicon, *line_info)),
         },
         Type::Glyph => match value {
             Value::Glyph(_) => Ok(value),
-            _ => Err(EvalError::ExpectedType(Type::Glyph, line_info.clone())),
+            _ => Err(EvalError::ExpectedType(Type::Glyph, *line_info)),
         },
         Type::Artifact(expected) => match value {
             Value::Artifact(handle) => {
@@ -94,13 +94,13 @@ pub(crate) fn convert_to_typed_value(
                     Err(EvalError::ArtifactTypeMismatch {
                         expected: expected.clone(),
                         found: borrowed.type_name.clone(),
-                        line_info: line_info.clone(),
+                        line_info: *line_info,
                     })
                 }
             }
             _ => Err(EvalError::ExpectedType(
                 Type::Artifact(expected.clone()),
-                line_info.clone(),
+                *line_info,
             )),
         },
     }
@@ -108,41 +108,41 @@ pub(crate) fn convert_to_typed_value(
 
 pub(crate) fn extract_arcana(
     result: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<i64, EvalError> {
     match result {
         EvalResult::Data(Value::Arcana(v)) => Ok(*v),
-        _ => Err(EvalError::ExpectedType(Type::Arcana, line_info.clone())),
+        _ => Err(EvalError::ExpectedType(Type::Arcana, *line_info)),
     }
 }
 
 pub(crate) fn extract_aether(
     result: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<f64, EvalError> {
     match result {
         EvalResult::Data(Value::Aether(v)) => Ok(*v),
-        _ => Err(EvalError::ExpectedType(Type::Aether, line_info.clone())),
+        _ => Err(EvalError::ExpectedType(Type::Aether, *line_info)),
     }
 }
 
 pub(crate) fn extract_rune(
     result: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<String, EvalError> {
     match result {
         EvalResult::Data(Value::Rune(rc)) => Ok(rc.as_ref().clone()),
-        _ => Err(EvalError::ExpectedType(Type::Rune, line_info.clone())),
+        _ => Err(EvalError::ExpectedType(Type::Rune, *line_info)),
     }
 }
 
 pub(crate) fn extract_omen(
     result: &EvalResult,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<bool, EvalError> {
     match result {
         EvalResult::Data(Value::Omen(v)) => Ok(*v),
-        _ => Err(EvalError::ExpectedType(Type::Omen, line_info.clone())),
+        _ => Err(EvalError::ExpectedType(Type::Omen, *line_info)),
     }
 }
 
@@ -213,8 +213,8 @@ mod tests {
     use crate::eval::test_support::artifact_handle;
     use std::{cell::RefCell, rc::Rc};
 
-    fn line() -> Option<LineInfo> {
-        Some(LineInfo::new(2, 3))
+    fn line() -> Option<Span> {
+        Some(Span::new(2, 3))
     }
 
     #[test]
@@ -237,12 +237,12 @@ mod tests {
     #[test]
     fn eval_result_to_value_checked_overrides_line_info() {
         let info = line();
-        let err = eval_result_to_value_checked(EvalResult::Resume(None), info.clone())
+        let err = eval_result_to_value_checked(EvalResult::Resume(None), info)
             .expect_err("control flow should error");
         match err {
             EvalError::InvalidOperation(_, returned) => {
-                let returned = returned.expect("line info should propagate");
-                assert_eq!((returned.line, returned.column), (2, 3));
+                let returned = returned.expect("span should propagate");
+                assert_eq!((returned.start(), returned.end()), (2, 3));
             }
             other => panic!("unexpected error {:?}", other),
         }

--- a/crates/abyss-interpreter/src/stdlib/functions/io.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/io.rs
@@ -1,13 +1,13 @@
 use crate::env::{CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
 use crate::io_bridge::IoBridge;
-use abyss_core::ast::{LineInfo, Type};
+use abyss_core::ast::{Span, Type};
 use std::rc::Rc;
 
 pub fn native_unveil(
     env: &mut RuntimeEnv,
     args: Vec<CallArg>,
-    line: Option<LineInfo>,
+    line: Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     // Route writes through the bridge `RuntimeEnv` carries, so non-CLI
     // hosts (Wasm playground, future LSP) can capture output without
@@ -15,13 +15,13 @@ pub fn native_unveil(
     native_unveil_with_io(args, line, env.io_bridge_mut())
 }
 
-fn map_io_error(message: &str, line: &Option<LineInfo>) -> EvalError {
-    EvalError::InvalidOperation(message.to_string(), line.clone())
+fn map_io_error(message: &str, line: &Option<Span>) -> EvalError {
+    EvalError::InvalidOperation(message.to_string(), *line)
 }
 
 pub(crate) fn native_unveil_with_io(
     args: Vec<CallArg>,
-    line: Option<LineInfo>,
+    line: Option<Span>,
     io: &mut dyn IoBridge,
 ) -> Result<EvalResult, EvalError> {
     if args.is_empty() {
@@ -47,14 +47,14 @@ pub(crate) fn native_unveil_with_io(
 pub fn native_summon(
     env: &mut RuntimeEnv,
     args: Vec<CallArg>,
-    line: Option<LineInfo>,
+    line: Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     native_summon_with_io(args, line, env.io_bridge_mut())
 }
 
 pub(crate) fn native_summon_with_io(
     args: Vec<CallArg>,
-    line: Option<LineInfo>,
+    line: Option<Span>,
     io: &mut dyn IoBridge,
 ) -> Result<EvalResult, EvalError> {
     if args.len() != 1 {
@@ -93,22 +93,22 @@ pub(crate) fn native_summon_with_io(
 
 pub(crate) fn format_eval_result(
     value: &EvalResult,
-    line: &Option<LineInfo>,
+    line: &Option<Span>,
 ) -> Result<String, EvalError> {
     match value {
         EvalResult::Data(Value::Artifact(handle)) => format_artifact(handle, line),
         EvalResult::Data(inner) => format_value(inner, line),
         EvalResult::Revealed(_) => Err(EvalError::InvalidOperation(
             "Cannot unveil a Revealed value (control flow construct)".to_string(),
-            line.clone(),
+            *line,
         )),
         EvalResult::Resume(_) => Err(EvalError::InvalidOperation(
             "Cannot unveil a Resume value (control flow construct)".to_string(),
-            line.clone(),
+            *line,
         )),
         EvalResult::Eject(_) => Err(EvalError::InvalidOperation(
             "Cannot unveil an Eject value (control flow construct)".to_string(),
-            line.clone(),
+            *line,
         )),
     }
 }
@@ -128,7 +128,7 @@ fn glyph_label(var_type: &Type) -> String {
     }
 }
 
-pub(crate) fn format_value(value: &Value, line: &Option<LineInfo>) -> Result<String, EvalError> {
+pub(crate) fn format_value(value: &Value, line: &Option<Span>) -> Result<String, EvalError> {
     match value {
         Value::Omen(b) => Ok(if *b { "boon" } else { "hex" }.to_string()),
         Value::Arcana(n) => Ok(n.to_string()),
@@ -158,7 +158,7 @@ pub(crate) fn format_value(value: &Value, line: &Option<LineInfo>) -> Result<Str
 
 pub(crate) fn format_artifact(
     handle: &crate::env::ArtifactHandle,
-    line: &Option<LineInfo>,
+    line: &Option<Span>,
 ) -> Result<String, EvalError> {
     let borrowed = handle.borrow();
     let mut pieces = Vec::new();

--- a/crates/abyss-interpreter/src/stdlib/methods/lexicon.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/lexicon.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 
 use super::{call_arg_to_value, ensure_mutable_receiver, method_table_for};
 
@@ -22,13 +22,13 @@ fn lexicon_tally(
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let entries = expect_lexicon(receiver_value);
     if !args.is_empty() {
         return Err(EvalError::InvalidOperation(
             "tally() does not take any arguments".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
     Ok(EvalResult::data(Value::Arcana(
@@ -42,7 +42,7 @@ fn lexicon_define(
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let entries = expect_lexicon(receiver_value);
     ensure_mutable_receiver(
@@ -56,7 +56,7 @@ fn lexicon_define(
     if args.len() != 2 {
         return Err(EvalError::InvalidOperation(
             "define() expects a rune key and a value".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -67,7 +67,7 @@ fn lexicon_define(
         _ => {
             return Err(EvalError::TypeError(
                 "define() key must be a rune".to_string(),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -82,7 +82,7 @@ fn lexicon_expunge(
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let entries = expect_lexicon(receiver_value);
     ensure_mutable_receiver(
@@ -96,7 +96,7 @@ fn lexicon_expunge(
     if args.len() != 1 {
         return Err(EvalError::InvalidOperation(
             "expunge() expects exactly one rune key".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -110,7 +110,7 @@ fn lexicon_expunge(
         _ => {
             return Err(EvalError::TypeError(
                 "expunge() key must be a rune".to_string(),
-                line_info.clone(),
+                *line_info,
             ));
         }
     };
@@ -124,13 +124,13 @@ fn lexicon_glossary(
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let entries = expect_lexicon(receiver_value);
     if !args.is_empty() {
         return Err(EvalError::InvalidOperation(
             "glossary() does not take any arguments".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 

--- a/crates/abyss-interpreter/src/stdlib/methods/materia.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/materia.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 
 use super::{expect_glyph_argument, method_table_for};
 
@@ -17,7 +17,7 @@ fn materia_trans_method(
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let target_type = expect_glyph_argument(args, "trans()", line_info)?;
     let converted = convert_value_via_trans(receiver_value, &target_type, line_info)?;
@@ -27,7 +27,7 @@ fn materia_trans_method(
 fn convert_value_via_trans(
     receiver: Value,
     target_type: &Type,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     match target_type {
         Type::Arcana => match receiver {
@@ -39,12 +39,12 @@ fn convert_value_via_trans(
                 .map_err(|_| {
                     EvalError::InvalidOperation(
                         "failed to convert rune to arcana".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     )
                 }),
             _ => Err(EvalError::InvalidOperation(
                 "cannot convert to arcana".to_string(),
-                line_info.clone(),
+                *line_info,
             )),
         },
         Type::Aether => match receiver {
@@ -56,12 +56,12 @@ fn convert_value_via_trans(
                 .map_err(|_| {
                     EvalError::InvalidOperation(
                         "failed to convert rune to aether".to_string(),
-                        line_info.clone(),
+                        *line_info,
                     )
                 }),
             _ => Err(EvalError::InvalidOperation(
                 "cannot convert to aether".to_string(),
-                line_info.clone(),
+                *line_info,
             )),
         },
         Type::Rune => match receiver {
@@ -69,24 +69,24 @@ fn convert_value_via_trans(
             Value::Aether(n) => Ok(Value::Rune(Rc::new(n.to_string()))),
             _ => Err(EvalError::InvalidOperation(
                 "cannot convert to rune".to_string(),
-                line_info.clone(),
+                *line_info,
             )),
         },
         Type::Omen => Err(EvalError::InvalidOperation(
             "cannot convert to omen".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
         Type::Glyph => Err(EvalError::InvalidOperation(
             "cannot convert to glyph".to_string(),
-            line_info.clone(),
+            *line_info,
         )),
         Type::Artifact(name) => Err(EvalError::InvalidOperation(
             format!("cannot convert to artifact type {}", name),
-            line_info.clone(),
+            *line_info,
         )),
         _ => Err(EvalError::InvalidOperation(
             format!("cannot convert to type {:?}", target_type),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }

--- a/crates/abyss-interpreter/src/stdlib/methods/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/mod.rs
@@ -8,7 +8,7 @@ use crate::eval::artifacts::collect_field_chain;
 use crate::eval::values::describe_value;
 use crate::eval::values::eval_result_to_value_checked;
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 use std::collections::HashMap;
 
 pub fn get_all_builtin_methods() -> BuiltinMethodRegistry {
@@ -26,7 +26,7 @@ pub fn dispatch_builtin_method(
     receiver_value: Value,
     method_name: &str,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let receiver_type = receiver_type(&receiver_value);
     let fallback_type = Type::Materia;
@@ -57,7 +57,7 @@ pub fn dispatch_builtin_method(
                     describe_value(&receiver_value),
                     hint
                 ),
-                line_info.clone(),
+                *line_info,
             )
         })?;
 
@@ -106,7 +106,7 @@ pub(super) fn ensure_mutable_receiver(
     receiver_var_name: Option<&str>,
     collection_kind: &str,
     method_name: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<(), EvalError> {
     let base_name = receiver_var_name
         .map(|name| name.to_string())
@@ -118,13 +118,13 @@ pub(super) fn ensure_mutable_receiver(
                 "Method {}::{} requires a morph receiver, but the expression is not tied to a mutable variable",
                 collection_kind, method_name
             ),
-            line_info.clone(),
+            *line_info,
         ));
     };
 
     let var_info = env
         .get_var(&var_name)
-        .ok_or_else(|| EvalError::UndefinedVariable(var_name.clone(), line_info.clone()))?;
+        .ok_or_else(|| EvalError::UndefinedVariable(var_name.clone(), *line_info))?;
 
     if var_info.is_morph {
         Ok(())
@@ -134,7 +134,7 @@ pub(super) fn ensure_mutable_receiver(
                 "Cannot call {}::{} with immutable receiver '{}'",
                 collection_kind, method_name, var_name
             ),
-            line_info.clone(),
+            *line_info,
         ))
     }
 }
@@ -142,14 +142,14 @@ pub(super) fn ensure_mutable_receiver(
 pub(super) fn call_arg_to_value(
     arg: CallArg,
     context: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Value, EvalError> {
     match arg.value {
         EvalResult::Data(value) => Ok(value),
         EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
             Err(EvalError::InvalidOperation(
                 format!("{} cannot accept control-flow results", context),
-                line_info.clone(),
+                *line_info,
             ))
         }
     }
@@ -158,17 +158,17 @@ pub(super) fn call_arg_to_value(
 pub(super) fn expect_glyph_argument(
     args: Vec<CallArg>,
     method_name: &str,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<Type, EvalError> {
     if args.len() != 1 {
         return Err(EvalError::InvalidOperation(
             format!("{} expects exactly one glyph argument", method_name),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
     let glyph_arg = args.into_iter().next().expect("argument is present");
-    let glyph_value = eval_result_to_value_checked(glyph_arg.value, line_info.clone())?;
+    let glyph_value = eval_result_to_value_checked(glyph_arg.value, *line_info)?;
     match glyph_value {
         Value::Glyph(ty) => Ok(ty),
         other => Err(EvalError::InvalidOperation(
@@ -177,7 +177,7 @@ pub(super) fn expect_glyph_argument(
                 method_name,
                 describe_value(&other)
             ),
-            line_info.clone(),
+            *line_info,
         )),
     }
 }

--- a/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, LineInfo, Type};
+use abyss_core::ast::{AST, Span, Type};
 
 use super::{call_arg_to_value, ensure_mutable_receiver, method_table_for};
 
@@ -20,13 +20,13 @@ fn scroll_tally(
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let items = expect_scroll(receiver_value);
     if !args.is_empty() {
         return Err(EvalError::InvalidOperation(
             "tally() does not take any arguments".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
     Ok(EvalResult::data(Value::Arcana(items.borrow().len() as i64)))
@@ -38,7 +38,7 @@ fn scroll_scribe(
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let items = expect_scroll(receiver_value);
     ensure_mutable_receiver(
@@ -53,7 +53,7 @@ fn scroll_scribe(
     if args.len() != 1 {
         return Err(EvalError::InvalidOperation(
             "scribe() expects exactly one argument".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
@@ -72,7 +72,7 @@ fn scroll_extract(
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
-    line_info: &Option<LineInfo>,
+    line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let items = expect_scroll(receiver_value);
     ensure_mutable_receiver(
@@ -87,14 +87,14 @@ fn scroll_extract(
     if !args.is_empty() {
         return Err(EvalError::InvalidOperation(
             "extract() does not take any arguments".to_string(),
-            line_info.clone(),
+            *line_info,
         ));
     }
 
     let value = items.borrow_mut().pop().ok_or_else(|| {
         EvalError::InvalidOperation(
             "extract() cannot pop from an empty scroll".to_string(),
-            line_info.clone(),
+            *line_info,
         )
     })?;
 


### PR DESCRIPTION
## Summary

First sub-task of #510 (span threading), pulled forward from the roadmap's v0.8 "Span-tracking Refactor" slot per the owner's decision on the issue.

**AST nodes and `EvalError` now carry `start..end` byte spans instead of point-only `LineInfo`; positions are resolved at render time.**

### abyss-core

- `SimpleSpan` moves from `parser/span.rs` to the crate root (`span.rs`) with a new `Span = SimpleSpan<usize>` alias, re-exported as `ast::Span`.
- `LineInfo`, `LineMap`, and `attach_line_info` are **removed**. The parser previously collapsed each node's span to a `(line, column)` point at build time; `ParserContext::info` now passes the span through untouched, and `build_parser()` no longer takes a line map.
- `Type`/grammar behaviour unchanged; all parser/format integration tests pass unmodified.

### abyss-interpreter

- `EvalError`, `VarInfo`, `EngravedFunction`, `ArtifactSchema`, etc. store `Option<Span>`; the rendering path drops the `line_col_to_byte_offset` round-trip (line/col → byte offset reconstruction) entirely and hands the span straight to ariadne.
- **Runtime diagnostics now underline the full offending range** — e.g. `x = 2 + 3;` against an immutable `x` underlines the whole statement instead of one caret. Error message *texts* are unchanged; only the underline width improves.
- `Span` is `Copy`, so ~197 `clone()` calls on position values became moves (`cargo clippy --fix`).

### Deliberately deferred to the next sub-task (enum split)

- Field/accessor names still read `line_info` (now holding spans). Renaming them touches every construction site, which the Expr/Stmt/Pattern split rewrites anyway — doing it there avoids churning the same lines twice.

### Breaking changes

Removal of `LineInfo` / `LineMap` / `attach_line_info` and the `build_parser` signature change are semver-major for `abyss-core` / `abyss-interpreter`; recorded under `[Unreleased] > Changed` in the CHANGELOG. In-repo consumers (wasm, CLI) needed zero changes — they only use `parse` / `render_*`.

## Verification

- `cargo test --workspace` — all 23 test binaries pass, zero warnings
- `cargo clippy --workspace --all-targets` — clean
- CLI smoke: immutable-reassign script renders the new full-range underline with identical message text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
