### PR TITLE
refactor(core)!: split the AST into Expr / Stmt / Pattern (#510 sub-tasks 2-4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI coding assistants (and humans) working in this repository.
 
 AbySS is a magic-themed scripting language with its own interpreter, formatter, and CLI tooling. The repo is a single Cargo workspace that also hosts the Starlight documentation site and the VS Code extension.
 
-- **`crates/abyss-core`** — AST (`ast.rs`), `chumsky`-based parser (`parser/`), and formatter (`format.rs`). Designed to stay lightweight so a future LSP or Wasm playground can depend on it without pulling in runtime code.
+- **`crates/abyss-core`** — the `Expr` / `Stmt` / `Pattern` AST (`ast.rs`, span-carrying), `chumsky`-based parser (`parser/`), and formatter (`format.rs`). Designed to stay lightweight so a future LSP or Wasm playground can depend on it without pulling in runtime code.
 - **`crates/abyss-interpreter`** — `RuntimeEnv` (`env.rs`), the `Value` enum (`value.rs`), artifact schemas/instances (`artifact.rs`), the evaluator (`eval/`), and the standard library (`stdlib/`, including the per-type method tables).
 - **`crates/abyss-cli`** — the user-facing binary `abyss` (crate name `abyss-lang`, published to crates.io). `main.rs` is `clap` wiring only; the REPL driver (`start_interpreter`) lives in `repl.rs` and the one-shot `invoke` / `align` implementations in `commands.rs`.
 - **`docs/`** — Starlight (Astro + bun) source for <https://abyss-lang.dev>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ### Changed
 
+- **The single `AST` enum is split into `Expr` / `Stmt` / `Pattern`** ([#510](https://github.com/liebe-magi/abyss-lang/issues/510)) — expressions, statements, and oracle match-arm patterns are now distinct types, with `OracleBranch` / `OrbitParam` / `EngraveParam` as plain structs. The evaluator gains honest signatures (`evaluate(&Stmt)` / expression evaluation without the old `Option`-returning probe), the 27-arm `unreachable!()` guard is gone, and `parse` returns `Vec<Stmt>`. `format_ast` is replaced by `format_stmt` / `format_expr` / `format_pattern`. Breaking for `abyss-core` / `abyss-interpreter` consumers; no language-level change — every existing script parses and runs identically.
 - **AST nodes and `EvalError` now carry byte spans instead of point `LineInfo`** ([#510](https://github.com/liebe-magi/abyss-lang/issues/510)) — the parser stores each node's `start..end` byte span (`abyss_core::span::Span`) and diagnostics derive positions at render time, so runtime errors now underline the full offending range instead of a single caret. Pulled forward from the roadmap's v0.8 "Span-tracking Refactor" slot. Breaking for `abyss-core` / `abyss-interpreter` consumers: `LineInfo`, `LineMap`, and `attach_line_info` are gone, and `build_parser` no longer takes a line map. Error message texts are unchanged.
 
 ### Removed

--- a/crates/abyss-cli/src/commands.rs
+++ b/crates/abyss-cli/src/commands.rs
@@ -3,7 +3,7 @@
 //! the REPL.
 
 use abyss_core::{
-    format::format_ast,
+    format::format_stmt,
     parser::{ParserDiagnostic, emit_diagnostics, parse},
 };
 use abyss_interpreter::{
@@ -55,6 +55,6 @@ pub fn execute_format(script: &str) {
     }
 
     for ast in outcome.ast {
-        println!("{}", format_ast(&ast, 0));
+        println!("{}", format_stmt(&ast, 0));
     }
 }

--- a/crates/abyss-cli/src/repl.rs
+++ b/crates/abyss-cli/src/repl.rs
@@ -5,7 +5,7 @@
 //! this must stay in sync with the language's block syntax). History is
 //! persisted under `~/.abyss/`.
 
-use abyss_core::{format::format_ast, parser::parse};
+use abyss_core::{format::format_stmt, parser::parse};
 use abyss_interpreter::{
     env::Value,
     eval::{EvalResult, evaluate},
@@ -119,7 +119,7 @@ pub fn start_interpreter(debug: bool) {
 
                         match evaluate(&ast, &mut env) {
                             Ok(result) => {
-                                current_session_code.push_str(&format_ast(&ast, 0));
+                                current_session_code.push_str(&format_stmt(&ast, 0));
                                 current_session_code.push('\n');
                                 match result {
                                     EvalResult::Data(Value::Omen(true)) => {

--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -1,183 +1,204 @@
 pub use crate::span::Span;
 
-/// Represents the abstract syntax tree (AST) for the language.
+/// Expressions — nodes that evaluate to a value.
+///
+/// `Oracle` lives here (not in [`Stmt`]) because AbySS allows match
+/// expressions in value position (`forge x: arcana = oracle(y) { … };`);
+/// an oracle used as a statement flows through [`Stmt::Expr`].
 #[derive(Debug, Clone)]
-pub enum AST {
-    Statement(Box<AST>, Option<Span>),
+pub enum Expr {
     Omen(bool, Option<Span>),
     Arcana(i64, Option<Span>),
     Aether(f64, Option<Span>),
     Rune(String, Option<Span>),
     Abyss(Option<Span>),
-    Add(Box<AST>, Box<AST>, Option<Span>),
-    Sub(Box<AST>, Box<AST>, Option<Span>),
-    Mul(Box<AST>, Box<AST>, Option<Span>),
-    Div(Box<AST>, Box<AST>, Option<Span>),
-    Mod(Box<AST>, Box<AST>, Option<Span>),
-    PowArcana(Box<AST>, Box<AST>, Option<Span>),
-    PowAether(Box<AST>, Box<AST>, Option<Span>),
-    Equal(Box<AST>, Box<AST>, Option<Span>),
-    NotEqual(Box<AST>, Box<AST>, Option<Span>),
-    LessThan(Box<AST>, Box<AST>, Option<Span>),
-    LessThanOrEqual(Box<AST>, Box<AST>, Option<Span>),
-    GreaterThan(Box<AST>, Box<AST>, Option<Span>),
-    GreaterThanOrEqual(Box<AST>, Box<AST>, Option<Span>),
-    LogicalAnd(Box<AST>, Box<AST>, Option<Span>),
-    LogicalOr(Box<AST>, Box<AST>, Option<Span>),
-    LogicalNot(Box<AST>, Option<Span>),
-    VarAssign {
-        name: String,
-        value: Box<AST>,
-        var_type: Type,
-        is_morph: bool,
-        line_info: Option<Span>,
-    },
-    Assignment {
-        name: String,
-        value: Box<AST>,
-        op: AssignmentOp,
-        line_info: Option<Span>,
-    },
+    Add(Box<Expr>, Box<Expr>, Option<Span>),
+    Sub(Box<Expr>, Box<Expr>, Option<Span>),
+    Mul(Box<Expr>, Box<Expr>, Option<Span>),
+    Div(Box<Expr>, Box<Expr>, Option<Span>),
+    Mod(Box<Expr>, Box<Expr>, Option<Span>),
+    PowArcana(Box<Expr>, Box<Expr>, Option<Span>),
+    PowAether(Box<Expr>, Box<Expr>, Option<Span>),
+    Equal(Box<Expr>, Box<Expr>, Option<Span>),
+    NotEqual(Box<Expr>, Box<Expr>, Option<Span>),
+    LessThan(Box<Expr>, Box<Expr>, Option<Span>),
+    LessThanOrEqual(Box<Expr>, Box<Expr>, Option<Span>),
+    GreaterThan(Box<Expr>, Box<Expr>, Option<Span>),
+    GreaterThanOrEqual(Box<Expr>, Box<Expr>, Option<Span>),
+    LogicalAnd(Box<Expr>, Box<Expr>, Option<Span>),
+    LogicalOr(Box<Expr>, Box<Expr>, Option<Span>),
+    LogicalNot(Box<Expr>, Option<Span>),
     Var(String, Option<Span>),
-    Reveal(Box<AST>, Option<Span>),
+    FuncCall {
+        name: String,
+        args: Vec<Expr>,
+        span: Option<Span>,
+    },
+    MethodCall {
+        receiver: Box<Expr>,
+        method: String,
+        args: Vec<Expr>,
+        span: Option<Span>,
+    },
+    IndexAccess {
+        target: Box<Expr>,
+        index: Box<Expr>,
+        span: Option<Span>,
+    },
+    FieldAccess {
+        target: Box<Expr>,
+        field: String,
+        span: Option<Span>,
+    },
+    ListLiteral {
+        elements: Vec<Expr>,
+        span: Option<Span>,
+    },
+    MapLiteral {
+        entries: Vec<(String, Expr)>,
+        span: Option<Span>,
+    },
+    ArtifactLiteral {
+        type_name: String,
+        fields: Vec<(String, Expr)>,
+        span: Option<Span>,
+    },
     Oracle {
         is_match: bool,
         conditionals: Vec<ConditionalAssignment>,
-        branches: Vec<AST>,
-        line_info: Option<Span>,
+        branches: Vec<OracleBranch>,
+        span: Option<Span>,
     },
-    OracleBranch {
-        pattern: Vec<AST>,
-        guard: Option<Box<AST>>,
-        body: Box<AST>,
-        line_info: Option<Span>,
+}
+
+/// Statements — nodes executed for their effect. A bare expression in
+/// statement position is wrapped in [`Stmt::Expr`].
+#[derive(Debug, Clone)]
+pub enum Stmt {
+    Expr(Expr, Option<Span>),
+    VarAssign {
+        name: String,
+        value: Expr,
+        var_type: Type,
+        is_morph: bool,
+        span: Option<Span>,
     },
-    OracleDontCareItem(Option<Span>),
-    /// Scroll-shape pattern that destructures a `scroll` scrutinee into
-    /// its elements. Each element is one of: `OracleDontCareItem`,
-    /// `OracleScrollRest`, `Var(name)` (binding), or any other AST node
-    /// (treated as a literal expression to compare against).
-    OracleScrollPattern {
-        elements: Vec<AST>,
-        line_info: Option<Span>,
+    Assignment {
+        name: String,
+        value: Expr,
+        op: AssignmentOp,
+        span: Option<Span>,
     },
-    /// Rest segment inside an `OracleScrollPattern`. `name = Some("rest")`
-    /// for `..rest` (binds the unmatched tail to a fresh sub-scroll);
-    /// `name = None` for `..` (anonymous, drops the tail).
-    OracleScrollRest {
-        name: Option<String>,
-        line_info: Option<Span>,
+    IndexAssignment {
+        target: Expr,
+        index: Expr,
+        value: Expr,
+        span: Option<Span>,
     },
-    /// Artifact-shape pattern that matches a `TypeName { field, … }`
-    /// scrutinee. Each `(field_name, sub_pattern)` entry pulls the named
-    /// field out of the artifact and matches it against `sub_pattern`
-    /// (typically `Var` for binding, a literal for compare, or
-    /// `OracleDontCareItem` to ignore). Fields not listed here are not
-    /// matched against — the pattern is non-exhaustive by default, so
-    /// users can pick out only the fields they care about.
-    OracleArtifactPattern {
-        type_name: String,
-        fields: Vec<(String, AST)>,
-        line_info: Option<Span>,
+    FieldAssignment {
+        target: Expr,
+        field: String,
+        value: Expr,
+        span: Option<Span>,
     },
-    /// Lexicon-shape pattern that matches a `{ "key": value, … }`
-    /// scrutinee. Each `(key, sub_pattern)` entry pulls the named entry
-    /// out of the lexicon and matches it against `sub_pattern`. Keys not
-    /// listed here are not matched against — the pattern is
-    /// non-exhaustive by default, mirroring the artifact pattern's
-    /// "pick what you need" ergonomics.
-    OracleLexiconPattern {
-        entries: Vec<(String, AST)>,
-        line_info: Option<Span>,
-    },
-    Block(Vec<AST>, Option<Span>),
+    Reveal(Expr, Option<Span>),
+    Block(Vec<Stmt>, Option<Span>),
+    /// Never produced by the parser (comments are scrubbed before lexing);
+    /// retained so hand-built trees — formatter tests, generated code —
+    /// can round-trip comment text through `format`.
     Comment(String, Option<Span>),
     Orbit {
-        params: Vec<AST>,
-        body: Box<AST>,
-        line_info: Option<Span>,
-    },
-    OrbitParam {
-        name: String,
-        start: Box<AST>,
-        end: Box<AST>,
-        op: String,
-        line_info: Option<Span>,
+        params: Vec<OrbitParam>,
+        body: Box<Stmt>,
+        span: Option<Span>,
     },
     Resume(Option<String>, Option<Span>),
     Eject(Option<String>, Option<Span>),
     Engrave {
         name: String,
-        params: Vec<AST>,
+        params: Vec<EngraveParam>,
         return_type: Type,
-        body: Box<AST>,
+        body: Box<Stmt>,
         method_target: Option<ArtifactMethodTarget>,
-        line_info: Option<Span>,
-    },
-    EngraveParam {
-        name: String,
-        param_type: Type,
-        is_morph: bool,
-        line_info: Option<Span>,
-    },
-    FuncCall {
-        name: String,
-        args: Vec<AST>,
-        line_info: Option<Span>,
-    },
-    ListLiteral {
-        elements: Vec<AST>,
-        line_info: Option<Span>,
-    },
-    MapLiteral {
-        entries: Vec<(String, AST)>,
-        line_info: Option<Span>,
-    },
-    IndexAccess {
-        target: Box<AST>,
-        index: Box<AST>,
-        line_info: Option<Span>,
-    },
-    IndexAssignment {
-        target: Box<AST>,
-        index: Box<AST>,
-        value: Box<AST>,
-        line_info: Option<Span>,
+        span: Option<Span>,
     },
     ArtifactDef {
         name: String,
         fields: Vec<ArtifactField>,
-        line_info: Option<Span>,
+        span: Option<Span>,
     },
-    ArtifactLiteral {
+}
+
+/// Patterns — the shapes an `oracle` match arm can take. Only meaningful
+/// inside [`OracleBranch::pattern`]; a bare [`Pattern::Expr`] is evaluated
+/// and compared against the scrutinee (in match mode a lone
+/// `Expr::Var` instead introduces a fresh binding).
+#[derive(Debug, Clone)]
+pub enum Pattern {
+    /// `_` — matches anything, binds nothing.
+    DontCare(Option<Span>),
+    /// Scroll-shape pattern destructuring a `scroll` scrutinee.
+    Scroll {
+        elements: Vec<Pattern>,
+        span: Option<Span>,
+    },
+    /// Rest segment inside a scroll pattern: `..rest` (named) or `..`
+    /// (anonymous, drops the tail). Only valid as the final element.
+    Rest {
+        name: Option<String>,
+        span: Option<Span>,
+    },
+    /// Artifact-shape pattern: `TypeName { field: sub_pattern, … }`.
+    /// Unlisted fields are not matched (non-exhaustive by default).
+    Artifact {
         type_name: String,
-        fields: Vec<(String, AST)>,
-        line_info: Option<Span>,
+        fields: Vec<(String, Pattern)>,
+        span: Option<Span>,
     },
-    FieldAccess {
-        target: Box<AST>,
-        field: String,
-        line_info: Option<Span>,
+    /// Lexicon-shape pattern: `{ "key": sub_pattern, … }`. Unlisted keys
+    /// are not matched.
+    Lexicon {
+        entries: Vec<(String, Pattern)>,
+        span: Option<Span>,
     },
-    FieldAssignment {
-        target: Box<AST>,
-        field: String,
-        value: Box<AST>,
-        line_info: Option<Span>,
-    },
-    MethodCall {
-        receiver: Box<AST>,
-        method: String,
-        args: Vec<AST>,
-        line_info: Option<Span>,
-    },
+    /// Fallback: an expression evaluated and compared against the
+    /// scrutinee. In match mode a bare `Expr::Var` binds instead.
+    Expr(Expr),
+}
+
+/// One `oracle` match arm: `(pattern, …) ward guard => body`.
+#[derive(Debug, Clone)]
+pub struct OracleBranch {
+    pub pattern: Vec<Pattern>,
+    pub guard: Option<Expr>,
+    pub body: Stmt,
+    pub span: Option<Span>,
+}
+
+/// One `orbit` loop parameter: `name = start..end` (op is `..` or `..=`).
+#[derive(Debug, Clone)]
+pub struct OrbitParam {
+    pub name: String,
+    pub start: Expr,
+    pub end: Expr,
+    pub op: String,
+    pub span: Option<Span>,
+}
+
+/// One `engrave` parameter: `name: type` with optional `morph`.
+#[derive(Debug, Clone)]
+pub struct EngraveParam {
+    pub name: String,
+    pub param_type: Type,
+    pub is_morph: bool,
+    pub span: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ArtifactField {
     pub name: String,
     pub field_type: Type,
-    pub line_info: Option<Span>,
+    pub span: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -190,8 +211,8 @@ pub struct ArtifactMethodTarget {
 #[derive(Debug, Clone)]
 pub struct ConditionalAssignment {
     pub variable: String,
-    pub expression: Box<AST>,
-    pub line_info: Option<Span>,
+    pub expression: Box<Expr>,
+    pub span: Option<Span>,
 }
 
 /// Represents the type of a variable or expression.

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -1,4 +1,4 @@
-use crate::ast::{AST, AssignmentOp, Type};
+use crate::ast::{AssignmentOp, Expr, Pattern, Stmt, Type};
 
 fn type_keyword(var_type: &Type) -> String {
     match var_type {
@@ -15,98 +15,23 @@ fn type_keyword(var_type: &Type) -> String {
     }
 }
 
-/// Formats an AST node into a readable string with appropriate indentation.
-/// This function handles various types of AST nodes, applying formatting rules based on node type.
-/// It also manages operator precedence to ensure correct placement of parentheses.
-///
-/// # Arguments
-/// * `ast` - The AST node to format.
-/// * `indent_level` - The level of indentation for the formatted output.
-///
-/// # Returns
-/// A formatted string representation of the AST node.
-pub fn format_ast(ast: &AST, indent_level: usize) -> String {
+/// Formats a top-level statement as a terminated line: indentation,
+/// the statement body, and the trailing semicolon. This is the entry
+/// point the CLI's `align` subcommand and the REPL echo use.
+pub fn format_stmt(stmt: &Stmt, indent_level: usize) -> String {
+    let indent = "    ".repeat(indent_level);
+    format!("{}{};", indent, format_stmt_body(stmt, indent_level))
+}
+
+/// Formats the body of a statement without indentation or the trailing
+/// semicolon — the shape used inside oracle arm bodies and by
+/// [`format_stmt`].
+fn format_stmt_body(stmt: &Stmt, indent_level: usize) -> String {
     let indent = "    ".repeat(indent_level);
 
-    // Determines the precedence level for an AST node to handle operator precedence.
-    let precedence = |node: &AST| match node {
-        AST::LogicalOr(_, _, _) => 10,
-        AST::LogicalAnd(_, _, _) => 20,
-        AST::Equal(_, _, _) | AST::NotEqual(_, _, _) => 30,
-        AST::LessThan(_, _, _)
-        | AST::LessThanOrEqual(_, _, _)
-        | AST::GreaterThan(_, _, _)
-        | AST::GreaterThanOrEqual(_, _, _) => 40,
-        AST::Add(_, _, _) | AST::Sub(_, _, _) => 50,
-        AST::Mul(_, _, _) | AST::Div(_, _, _) | AST::Mod(_, _, _) => 60,
-        AST::PowArcana(_, _, _) | AST::PowAether(_, _, _) => 70,
-        AST::LogicalNot(_, _) => 80,
-        AST::IndexAccess { .. } | AST::FieldAccess { .. } => 90,
-        _ => 100,
-    };
-
-    let current_precedence = precedence(ast);
-
-    // Formats a sub-expression, adding parentheses if necessary based on precedence.
-    let format_with_parentheses = |expr: &AST, parent_precedence: u8| -> String {
-        let sub_precedence = precedence(expr);
-        let code = format_ast(expr, indent_level);
-
-        if sub_precedence < parent_precedence {
-            format!("({})", code)
-        } else {
-            code
-        }
-    };
-
-    match ast {
-        AST::Statement(statement, _) => {
-            format!("{}{};", indent, format_ast(statement, indent_level))
-        }
-        AST::Add(left, right, _)
-        | AST::Sub(left, right, _)
-        | AST::Mul(left, right, _)
-        | AST::Div(left, right, _)
-        | AST::Mod(left, right, _)
-        | AST::PowArcana(left, right, _)
-        | AST::PowAether(left, right, _)
-        | AST::LogicalAnd(left, right, _)
-        | AST::LogicalOr(left, right, _)
-        | AST::Equal(left, right, _)
-        | AST::NotEqual(left, right, _)
-        | AST::LessThan(left, right, _)
-        | AST::LessThanOrEqual(left, right, _)
-        | AST::GreaterThan(left, right, _)
-        | AST::GreaterThanOrEqual(left, right, _) => {
-            let operator = match ast {
-                AST::Add(_, _, _) => "+",
-                AST::Sub(_, _, _) => "-",
-                AST::Mul(_, _, _) => "*",
-                AST::Div(_, _, _) => "/",
-                AST::Mod(_, _, _) => "%",
-                AST::PowArcana(_, _, _) => "^",
-                AST::PowAether(_, _, _) => "**",
-                AST::LogicalAnd(_, _, _) => "&&",
-                AST::LogicalOr(_, _, _) => "||",
-                AST::Equal(_, _, _) => "==",
-                AST::NotEqual(_, _, _) => "!=",
-                AST::LessThan(_, _, _) => "<",
-                AST::LessThanOrEqual(_, _, _) => "<=",
-                AST::GreaterThan(_, _, _) => ">",
-                AST::GreaterThanOrEqual(_, _, _) => ">=",
-                _ => unreachable!(),
-            };
-            format!(
-                "{} {} {}",
-                format_with_parentheses(left, current_precedence),
-                operator,
-                format_with_parentheses(right, current_precedence)
-            )
-        }
-        AST::LogicalNot(expr, _) => {
-            format!("!{}", format_with_parentheses(expr, current_precedence))
-        }
-        AST::VarAssign {
+    match stmt {
+        Stmt::Expr(expr, _) => format_expr(expr, indent_level),
+        Stmt::VarAssign {
             name,
             value,
             var_type,
@@ -118,228 +43,66 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                 if *is_morph { "morph " } else { "" },
                 name,
                 type_keyword(var_type),
-                format_ast(value, indent_level)
+                format_expr(value, indent_level)
             )
         }
-        AST::Assignment {
+        Stmt::Assignment {
             name, value, op, ..
-        } => match op {
-            AssignmentOp::Assign => format!("{} = {}", name, format_ast(value, indent_level)),
-            AssignmentOp::AddAssign => {
-                format!("{} += {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::SubAssign => {
-                format!("{} -= {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::MulAssign => {
-                format!("{} *= {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::DivAssign => {
-                format!("{} /= {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::ModAssign => {
-                format!("{} %= {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::PowArcanaAssign => {
-                format!("{} ^= {}", name, format_ast(value, indent_level))
-            }
-            AssignmentOp::PowAetherAssign => {
-                format!("{} **= {}", name, format_ast(value, indent_level))
-            }
-        },
-        AST::Var(name, _) => name.clone(),
-        AST::FieldAccess { target, field, .. } => {
-            format!("{}.{}", format_ast(target, indent_level), field)
+        } => {
+            let operator = match op {
+                AssignmentOp::Assign => "=",
+                AssignmentOp::AddAssign => "+=",
+                AssignmentOp::SubAssign => "-=",
+                AssignmentOp::MulAssign => "*=",
+                AssignmentOp::DivAssign => "/=",
+                AssignmentOp::ModAssign => "%=",
+                AssignmentOp::PowArcanaAssign => "^=",
+                AssignmentOp::PowAetherAssign => "**=",
+            };
+            format!("{} {} {}", name, operator, format_expr(value, indent_level))
         }
-        AST::Arcana(value, _) => format!("{}", value),
-        AST::Aether(value, _) => {
-            if value.fract() == 0.0 {
-                format!("{:.1}", value)
-            } else {
-                format!("{}", value)
-            }
-        }
-        AST::Rune(value, _) => format!("\"{}\"", value),
-        AST::Omen(value, _) => match value {
-            true => "boon".to_string(),
-            false => "hex".to_string(),
-        },
-        AST::Abyss(_) => "abyss".to_string(),
-        AST::Reveal(value, _) => {
-            let val = format_ast(value, indent_level);
+        Stmt::Reveal(value, _) => {
+            let val = format_expr(value, indent_level);
             let trimmed_val = val.trim();
             match trimmed_val {
                 "abyss" => "reveal".to_string(),
                 _ => format!("reveal {}", trimmed_val),
             }
         }
-        AST::Block(statements, _) => {
+        Stmt::Block(statements, _) => {
             let mut result = format!("{}{{\n", indent);
             for statement in statements {
-                result.push_str(&format!("{}\n", format_ast(statement, indent_level + 1)));
+                result.push_str(&format!("{}\n", format_stmt(statement, indent_level + 1)));
             }
             result.push_str(&format!("{}}}", indent));
             result
         }
-        AST::Oracle {
-            is_match,
-            conditionals,
-            branches,
-            ..
-        } => {
-            let mut result = "oracle".to_string();
-            if !conditionals.is_empty() {
-                let conditions = conditionals
-                    .iter()
-                    .map(|cond| {
-                        if *is_match {
-                            format_ast(cond.expression.as_ref(), indent_level)
-                        } else {
-                            format!(
-                                "{} = {}",
-                                cond.variable,
-                                format_ast(cond.expression.as_ref(), indent_level)
-                            )
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                result.push_str(&format!(" ({})", conditions));
-            }
-            result.push_str(" {\n");
-            for branch in branches {
-                if let AST::Comment(text, _) = branch {
-                    result.push_str(&format!("{}{}\n", "    ".repeat(indent_level + 1), text));
-                    continue;
-                }
-
-                if let AST::OracleBranch {
-                    pattern,
-                    guard,
-                    body,
-                    ..
-                } = branch
-                {
-                    // Top-level scroll / artifact patterns keep their natural
-                    // form (`[…] =>`, `Player { name } =>`) rather than
-                    // getting re-wrapped in `(…)`. The single-element AST
-                    // already self-formats in the right shape, so the outer
-                    // parens would be redundant noise on round-trip.
-                    let pattern_text = match pattern.as_slice() {
-                        [] => "_".to_string(),
-                        [only @ AST::OracleScrollPattern { .. }]
-                        | [only @ AST::OracleArtifactPattern { .. }]
-                        | [only @ AST::OracleLexiconPattern { .. }] => {
-                            format_ast(only, indent_level + 1)
-                        }
-                        elems => {
-                            let inner = elems
-                                .iter()
-                                .map(|pat| format_ast(pat, indent_level + 1))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            format!("({})", inner)
-                        }
-                    };
-                    let guard_text = guard
-                        .as_ref()
-                        .map(|expr| {
-                            format!(" ward {}", format_ast(expr.as_ref(), indent_level + 1))
-                        })
-                        .unwrap_or_default();
-                    result.push_str(&format!(
-                        "{}{}{} => {}\n",
-                        "    ".repeat(indent_level + 1),
-                        pattern_text,
-                        guard_text,
-                        format_ast(body.as_ref(), indent_level + 1).trim()
-                    ));
-                }
-            }
-            result.push_str(&format!("{}}}", indent));
-            result
-        }
-        AST::OracleDontCareItem(_) => "_".to_string(),
-        AST::OracleScrollPattern { elements, .. } => {
-            let inner = elements
-                .iter()
-                .map(|elem| format_ast(elem, indent_level))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("[{}]", inner)
-        }
-        AST::OracleScrollRest { name, .. } => match name {
-            Some(name) => format!("..{}", name),
-            None => "..".to_string(),
-        },
-        AST::OracleArtifactPattern {
-            type_name, fields, ..
-        } => {
-            if fields.is_empty() {
-                // `Type {}` matches by type alone (any artifact of this
-                // type). Mirror `ArtifactLiteral`'s empty-fields formatting
-                // rather than emitting `Type {  }` with double spaces.
-                format!("{} {{}}", type_name)
-            } else {
-                let inner = fields
-                    .iter()
-                    .map(|(name, sub)| match sub {
-                        // Shorthand `{ name }` keeps its compact form when the
-                        // sub-pattern is just `Var(name)` with the same name.
-                        AST::Var(var_name, _) if var_name == name => name.clone(),
-                        other => format!("{}: {}", name, format_ast(other, indent_level)),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{} {{ {} }}", type_name, inner)
-            }
-        }
-        AST::OracleLexiconPattern { entries, .. } => {
-            if entries.is_empty() {
-                // `{}` matches any lexicon (the "by shape" catch-all).
-                "{}".to_string()
-            } else {
-                let inner = entries
-                    .iter()
-                    .map(|(key, sub)| format!("\"{}\": {}", key, format_ast(sub, indent_level)))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{{ {} }}", inner)
-            }
-        }
-        AST::Orbit { params, body, .. } => {
+        Stmt::Orbit { params, body, .. } => {
             let mut result = "orbit".to_string();
             if !params.is_empty() {
                 let params_str = params
                     .iter()
-                    .map(|param| format_ast(param, indent_level))
+                    .map(|param| {
+                        let start_expr = format_expr(&param.start, 0);
+                        let end_expr = format_expr(&param.end, 0);
+                        format!("{} = {}{}{}", param.name, start_expr, param.op, end_expr)
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
                 result.push_str(&format!(" ({})", params_str));
             }
-            result.push_str(format_ast(body.as_ref(), indent_level).trim());
+            result.push_str(format_stmt_body(body.as_ref(), indent_level).trim());
             result
         }
-        AST::OrbitParam {
-            name,
-            start,
-            end,
-            op,
-            ..
-        } => {
-            let start_expr = format_ast(start, 0);
-            let end_expr = format_ast(end, 0);
-            format!("{} = {}{}{}", name, start_expr, op, end_expr)
-        }
-        AST::Resume(value, _) => match value {
-            Some(idendifier) => format!("resume {}", idendifier),
+        Stmt::Resume(value, _) => match value {
+            Some(identifier) => format!("resume {}", identifier),
             None => "resume".to_string(),
         },
-        AST::Eject(value, _) => match value {
-            Some(idendifier) => format!("eject {}", idendifier),
+        Stmt::Eject(value, _) => match value {
+            Some(identifier) => format!("eject {}", identifier),
             None => "eject".to_string(),
         },
-        AST::Engrave {
+        Stmt::Engrave {
             name,
             params,
             return_type,
@@ -367,7 +130,13 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                 iter.next();
             }
             for param in iter {
-                param_strings.push(format_ast(param, indent_level));
+                let qualifier = if param.is_morph { "morph " } else { "" };
+                param_strings.push(format!(
+                    "{}{}: {}",
+                    qualifier,
+                    param.name,
+                    type_keyword(&param.param_type)
+                ));
             }
             let params_str = param_strings.join(", ");
             let qualified_name = if let Some(target) = method_target {
@@ -380,112 +149,40 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
                     "engrave {}({}) {}",
                     qualified_name,
                     params_str,
-                    format_ast(body, indent_level)
+                    format_stmt_body(body, indent_level)
                 ),
                 Some(ret) => format!(
                     "engrave {}({}) -> {} {}",
                     qualified_name,
                     params_str,
                     ret,
-                    format_ast(body, indent_level)
+                    format_stmt_body(body, indent_level)
                 ),
             }
         }
-        AST::EngraveParam {
-            name,
-            param_type,
-            is_morph,
-            ..
-        } => {
-            let qualifier = if *is_morph { "morph " } else { "" };
-            format!("{}{}: {}", qualifier, name, type_keyword(param_type))
-        }
-        AST::FuncCall { name, args, .. } => {
-            let args_str = args
-                .iter()
-                .map(|arg| format_ast(arg, indent_level))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{}({})", name, args_str)
-        }
-        AST::ListLiteral { elements, .. } => {
-            let contents = elements
-                .iter()
-                .map(|elem| format_ast(elem, indent_level))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("[{}]", contents)
-        }
-        AST::MapLiteral { entries, .. } => {
-            let contents = entries
-                .iter()
-                .map(|(key, value)| format!("\"{}\": {}", key, format_ast(value, indent_level)))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{{{}}}", contents)
-        }
-        AST::ArtifactLiteral {
-            type_name, fields, ..
-        } => {
-            if fields.is_empty() {
-                format!("{} {{}}", type_name)
-            } else {
-                let contents = fields
-                    .iter()
-                    .map(|(field, value)| format!("{}: {}", field, format_ast(value, indent_level)))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{} {{ {} }}", type_name, contents)
-            }
-        }
-        AST::IndexAccess { target, index, .. } => {
-            format!(
-                "{}[{}]",
-                format_ast(target, indent_level),
-                format_ast(index, indent_level)
-            )
-        }
-        AST::IndexAssignment {
+        Stmt::IndexAssignment {
             target,
             index,
             value,
             ..
         } => format!(
             "{}[{}] = {}",
-            format_ast(target, indent_level),
-            format_ast(index, indent_level),
-            format_ast(value, indent_level)
+            format_expr(target, indent_level),
+            format_expr(index, indent_level),
+            format_expr(value, indent_level)
         ),
-        AST::FieldAssignment {
+        Stmt::FieldAssignment {
             target,
             field,
             value,
             ..
         } => format!(
             "{}.{} = {}",
-            format_ast(target, indent_level),
+            format_expr(target, indent_level),
             field,
-            format_ast(value, indent_level)
+            format_expr(value, indent_level)
         ),
-        AST::MethodCall {
-            receiver,
-            method,
-            args,
-            ..
-        } => {
-            let args_str = args
-                .iter()
-                .map(|arg| format_ast(arg, indent_level))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(
-                "{}.{}({})",
-                format_ast(receiver, indent_level),
-                method,
-                args_str
-            )
-        }
-        AST::ArtifactDef { name, fields, .. } => {
+        Stmt::ArtifactDef { name, fields, .. } => {
             let mut result = format!("artifact {} {{\n", name);
             for field in fields {
                 result.push_str(&format!(
@@ -498,7 +195,298 @@ pub fn format_ast(ast: &AST, indent_level: usize) -> String {
             result.push_str(&format!("{}}}", indent));
             result
         }
-        AST::Comment(text, _) => text.clone(),
-        _ => format!("Not implemented: {:?}", ast),
+        Stmt::Comment(text, _) => text.clone(),
+    }
+}
+
+// Determines the precedence level for an expression to decide where
+// parentheses are required on round-trip.
+fn precedence(node: &Expr) -> u8 {
+    match node {
+        Expr::LogicalOr(_, _, _) => 10,
+        Expr::LogicalAnd(_, _, _) => 20,
+        Expr::Equal(_, _, _) | Expr::NotEqual(_, _, _) => 30,
+        Expr::LessThan(_, _, _)
+        | Expr::LessThanOrEqual(_, _, _)
+        | Expr::GreaterThan(_, _, _)
+        | Expr::GreaterThanOrEqual(_, _, _) => 40,
+        Expr::Add(_, _, _) | Expr::Sub(_, _, _) => 50,
+        Expr::Mul(_, _, _) | Expr::Div(_, _, _) | Expr::Mod(_, _, _) => 60,
+        Expr::PowArcana(_, _, _) | Expr::PowAether(_, _, _) => 70,
+        Expr::LogicalNot(_, _) => 80,
+        Expr::IndexAccess { .. } | Expr::FieldAccess { .. } => 90,
+        _ => 100,
+    }
+}
+
+/// Formats an expression into a readable string, adding parentheses
+/// where operator precedence requires them for a faithful round-trip.
+pub fn format_expr(expr: &Expr, indent_level: usize) -> String {
+    let indent = "    ".repeat(indent_level);
+    let current_precedence = precedence(expr);
+
+    // Formats a sub-expression, adding parentheses if necessary based on precedence.
+    let format_with_parentheses = |sub: &Expr, parent_precedence: u8| -> String {
+        let sub_precedence = precedence(sub);
+        let code = format_expr(sub, indent_level);
+
+        if sub_precedence < parent_precedence {
+            format!("({})", code)
+        } else {
+            code
+        }
+    };
+
+    match expr {
+        Expr::Add(left, right, _)
+        | Expr::Sub(left, right, _)
+        | Expr::Mul(left, right, _)
+        | Expr::Div(left, right, _)
+        | Expr::Mod(left, right, _)
+        | Expr::PowArcana(left, right, _)
+        | Expr::PowAether(left, right, _)
+        | Expr::LogicalAnd(left, right, _)
+        | Expr::LogicalOr(left, right, _)
+        | Expr::Equal(left, right, _)
+        | Expr::NotEqual(left, right, _)
+        | Expr::LessThan(left, right, _)
+        | Expr::LessThanOrEqual(left, right, _)
+        | Expr::GreaterThan(left, right, _)
+        | Expr::GreaterThanOrEqual(left, right, _) => {
+            let operator = match expr {
+                Expr::Add(_, _, _) => "+",
+                Expr::Sub(_, _, _) => "-",
+                Expr::Mul(_, _, _) => "*",
+                Expr::Div(_, _, _) => "/",
+                Expr::Mod(_, _, _) => "%",
+                Expr::PowArcana(_, _, _) => "^",
+                Expr::PowAether(_, _, _) => "**",
+                Expr::LogicalAnd(_, _, _) => "&&",
+                Expr::LogicalOr(_, _, _) => "||",
+                Expr::Equal(_, _, _) => "==",
+                Expr::NotEqual(_, _, _) => "!=",
+                Expr::LessThan(_, _, _) => "<",
+                Expr::LessThanOrEqual(_, _, _) => "<=",
+                Expr::GreaterThan(_, _, _) => ">",
+                Expr::GreaterThanOrEqual(_, _, _) => ">=",
+                _ => unreachable!(),
+            };
+            format!(
+                "{} {} {}",
+                format_with_parentheses(left, current_precedence),
+                operator,
+                format_with_parentheses(right, current_precedence)
+            )
+        }
+        Expr::LogicalNot(inner, _) => {
+            format!("!{}", format_with_parentheses(inner, current_precedence))
+        }
+        Expr::Var(name, _) => name.clone(),
+        Expr::FieldAccess { target, field, .. } => {
+            format!("{}.{}", format_expr(target, indent_level), field)
+        }
+        Expr::Arcana(value, _) => format!("{}", value),
+        Expr::Aether(value, _) => {
+            if value.fract() == 0.0 {
+                format!("{:.1}", value)
+            } else {
+                format!("{}", value)
+            }
+        }
+        Expr::Rune(value, _) => format!("\"{}\"", value),
+        Expr::Omen(value, _) => match value {
+            true => "boon".to_string(),
+            false => "hex".to_string(),
+        },
+        Expr::Abyss(_) => "abyss".to_string(),
+        Expr::Oracle {
+            is_match,
+            conditionals,
+            branches,
+            ..
+        } => {
+            let mut result = "oracle".to_string();
+            if !conditionals.is_empty() {
+                let conditions = conditionals
+                    .iter()
+                    .map(|cond| {
+                        if *is_match {
+                            format_expr(cond.expression.as_ref(), indent_level)
+                        } else {
+                            format!(
+                                "{} = {}",
+                                cond.variable,
+                                format_expr(cond.expression.as_ref(), indent_level)
+                            )
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                result.push_str(&format!(" ({})", conditions));
+            }
+            result.push_str(" {\n");
+            for branch in branches {
+                // Top-level scroll / artifact patterns keep their natural
+                // form (`[…] =>`, `Player { name } =>`) rather than
+                // getting re-wrapped in `(…)`. The single-element pattern
+                // already self-formats in the right shape, so the outer
+                // parens would be redundant noise on round-trip.
+                let pattern_text = match branch.pattern.as_slice() {
+                    [] => "_".to_string(),
+                    [only @ Pattern::Scroll { .. }]
+                    | [only @ Pattern::Artifact { .. }]
+                    | [only @ Pattern::Lexicon { .. }] => format_pattern(only, indent_level + 1),
+                    elems => {
+                        let inner = elems
+                            .iter()
+                            .map(|pat| format_pattern(pat, indent_level + 1))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("({})", inner)
+                    }
+                };
+                let guard_text = branch
+                    .guard
+                    .as_ref()
+                    .map(|guard| format!(" ward {}", format_expr(guard, indent_level + 1)))
+                    .unwrap_or_default();
+                // Single-statement arm bodies are semicolon-terminated on
+                // round-trip (`=> reveal x;`), while block bodies end at
+                // their closing brace — mirroring what the parser accepts.
+                let body_text = match &branch.body {
+                    Stmt::Block(..) => format_stmt_body(&branch.body, indent_level + 1),
+                    other => format_stmt(other, indent_level + 1),
+                };
+                result.push_str(&format!(
+                    "{}{}{} => {}\n",
+                    "    ".repeat(indent_level + 1),
+                    pattern_text,
+                    guard_text,
+                    body_text.trim()
+                ));
+            }
+            result.push_str(&format!("{}}}", indent));
+            result
+        }
+        Expr::FuncCall { name, args, .. } => {
+            let args_str = args
+                .iter()
+                .map(|arg| format_expr(arg, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{}({})", name, args_str)
+        }
+        Expr::ListLiteral { elements, .. } => {
+            let contents = elements
+                .iter()
+                .map(|elem| format_expr(elem, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{}]", contents)
+        }
+        Expr::MapLiteral { entries, .. } => {
+            let contents = entries
+                .iter()
+                .map(|(key, value)| format!("\"{}\": {}", key, format_expr(value, indent_level)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{}}}", contents)
+        }
+        Expr::ArtifactLiteral {
+            type_name, fields, ..
+        } => {
+            if fields.is_empty() {
+                format!("{} {{}}", type_name)
+            } else {
+                let contents = fields
+                    .iter()
+                    .map(|(field, value)| {
+                        format!("{}: {}", field, format_expr(value, indent_level))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{} {{ {} }}", type_name, contents)
+            }
+        }
+        Expr::IndexAccess { target, index, .. } => {
+            format!(
+                "{}[{}]",
+                format_expr(target, indent_level),
+                format_expr(index, indent_level)
+            )
+        }
+        Expr::MethodCall {
+            receiver,
+            method,
+            args,
+            ..
+        } => {
+            let args_str = args
+                .iter()
+                .map(|arg| format_expr(arg, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "{}.{}({})",
+                format_expr(receiver, indent_level),
+                method,
+                args_str
+            )
+        }
+    }
+}
+
+/// Formats an oracle match-arm pattern.
+pub fn format_pattern(pattern: &Pattern, indent_level: usize) -> String {
+    match pattern {
+        Pattern::DontCare(_) => "_".to_string(),
+        Pattern::Scroll { elements, .. } => {
+            let inner = elements
+                .iter()
+                .map(|elem| format_pattern(elem, indent_level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{}]", inner)
+        }
+        Pattern::Rest { name, .. } => match name {
+            Some(name) => format!("..{}", name),
+            None => "..".to_string(),
+        },
+        Pattern::Artifact {
+            type_name, fields, ..
+        } => {
+            if fields.is_empty() {
+                // `Type {}` matches by type alone (any artifact of this
+                // type). Mirror `ArtifactLiteral`'s empty-fields formatting
+                // rather than emitting `Type {  }` with double spaces.
+                format!("{} {{}}", type_name)
+            } else {
+                let inner = fields
+                    .iter()
+                    .map(|(name, sub)| match sub {
+                        // Shorthand `{ name }` keeps its compact form when the
+                        // sub-pattern is just `Var(name)` with the same name.
+                        Pattern::Expr(Expr::Var(var_name, _)) if var_name == name => name.clone(),
+                        other => format!("{}: {}", name, format_pattern(other, indent_level)),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{} {{ {} }}", type_name, inner)
+            }
+        }
+        Pattern::Lexicon { entries, .. } => {
+            if entries.is_empty() {
+                // `{}` matches any lexicon (the "by shape" catch-all).
+                "{}".to_string()
+            } else {
+                let inner = entries
+                    .iter()
+                    .map(|(key, sub)| format!("\"{}\": {}", key, format_pattern(sub, indent_level)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{{ {} }}", inner)
+            }
+        }
+        Pattern::Expr(expr) => format_expr(expr, indent_level),
     }
 }

--- a/crates/abyss-core/src/parser/grammar/expressions.rs
+++ b/crates/abyss-core/src/parser/grammar/expressions.rs
@@ -4,7 +4,7 @@
 
 use chumsky::prelude::*;
 
-use crate::ast::AST;
+use crate::ast::Expr;
 
 use crate::parser::SimpleSpan;
 use crate::parser::tokens::Token;
@@ -13,8 +13,8 @@ use super::*;
 
 pub(super) fn range_expr_parser<'src>(
     _ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, (AST, AST, String, SimpleSpan<usize>)> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, (Expr, Expr, String, SimpleSpan<usize>)> {
     let op = choice((
         just(Token::RangeInclusive).to(String::from("..=")),
         just(Token::RangeExclusive).to(String::from("..")),
@@ -33,8 +33,8 @@ pub(super) fn range_expr_parser<'src>(
 
 pub(super) fn or_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let and_expr = and_expr_parser(ctx, expression);
 
@@ -51,7 +51,7 @@ pub(super) fn or_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 (
-                    AST::LogicalOr(Box::new(left.0), Box::new(right.0), info),
+                    Expr::LogicalOr(Box::new(left.0), Box::new(right.0), info),
                     span,
                 )
             })
@@ -61,8 +61,8 @@ pub(super) fn or_expr_parser<'src>(
 
 pub(super) fn and_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let not_expr = not_expr_parser(ctx, expression);
 
@@ -79,7 +79,7 @@ pub(super) fn and_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 (
-                    AST::LogicalAnd(Box::new(left.0), Box::new(right.0), info),
+                    Expr::LogicalAnd(Box::new(left.0), Box::new(right.0), info),
                     span,
                 )
             })
@@ -89,8 +89,8 @@ pub(super) fn and_expr_parser<'src>(
 
 pub(super) fn not_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     just(Token::Bang)
         .map_with(|_, extra| extra.span())
@@ -101,7 +101,7 @@ pub(super) fn not_expr_parser<'src>(
             for span in nots.into_iter().rev() {
                 let total_span = SimpleSpan::new(span.start(), current.1.end());
                 let info = ctx_for_map.info(total_span);
-                current = (AST::LogicalNot(Box::new(current.0), info), total_span);
+                current = (Expr::LogicalNot(Box::new(current.0), info), total_span);
             }
             current
         })
@@ -110,8 +110,8 @@ pub(super) fn not_expr_parser<'src>(
 
 pub(super) fn comp_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let add_expr = add_expr_parser(ctx, expression);
 
@@ -132,17 +132,17 @@ pub(super) fn comp_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Equal => AST::Equal(Box::new(left.0), Box::new(right.0), info),
-                    Token::NotEqual => AST::NotEqual(Box::new(left.0), Box::new(right.0), info),
-                    Token::LessThan => AST::LessThan(Box::new(left.0), Box::new(right.0), info),
+                    Token::Equal => Expr::Equal(Box::new(left.0), Box::new(right.0), info),
+                    Token::NotEqual => Expr::NotEqual(Box::new(left.0), Box::new(right.0), info),
+                    Token::LessThan => Expr::LessThan(Box::new(left.0), Box::new(right.0), info),
                     Token::LessThanOrEqual => {
-                        AST::LessThanOrEqual(Box::new(left.0), Box::new(right.0), info)
+                        Expr::LessThanOrEqual(Box::new(left.0), Box::new(right.0), info)
                     }
                     Token::GreaterThan => {
-                        AST::GreaterThan(Box::new(left.0), Box::new(right.0), info)
+                        Expr::GreaterThan(Box::new(left.0), Box::new(right.0), info)
                     }
                     Token::GreaterThanOrEqual => {
-                        AST::GreaterThanOrEqual(Box::new(left.0), Box::new(right.0), info)
+                        Expr::GreaterThanOrEqual(Box::new(left.0), Box::new(right.0), info)
                     }
                     _ => unreachable!(),
                 };
@@ -156,8 +156,8 @@ pub(super) fn comp_expr_parser<'src>(
 
 pub(super) fn add_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let mul_expr = mul_expr_parser(ctx, expression);
 
@@ -174,8 +174,8 @@ pub(super) fn add_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Plus => AST::Add(Box::new(left.0), Box::new(right.0), info),
-                    Token::Minus => AST::Sub(Box::new(left.0), Box::new(right.0), info),
+                    Token::Plus => Expr::Add(Box::new(left.0), Box::new(right.0), info),
+                    Token::Minus => Expr::Sub(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -186,8 +186,8 @@ pub(super) fn add_expr_parser<'src>(
 
 pub(super) fn mul_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let pow_expr = pow_expr_parser(ctx, expression);
 
@@ -204,9 +204,9 @@ pub(super) fn mul_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::Star => AST::Mul(Box::new(left.0), Box::new(right.0), info),
-                    Token::Slash => AST::Div(Box::new(left.0), Box::new(right.0), info),
-                    Token::Percent => AST::Mod(Box::new(left.0), Box::new(right.0), info),
+                    Token::Star => Expr::Mul(Box::new(left.0), Box::new(right.0), info),
+                    Token::Slash => Expr::Div(Box::new(left.0), Box::new(right.0), info),
+                    Token::Percent => Expr::Mod(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -217,8 +217,8 @@ pub(super) fn mul_expr_parser<'src>(
 
 pub(super) fn pow_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let factor = factor_parser(ctx, expression);
 
@@ -235,8 +235,8 @@ pub(super) fn pow_expr_parser<'src>(
                 let span = merge_span(left.1, right.1);
                 let info = ctx_for_map.info(span);
                 let ast = match op_token {
-                    Token::DoubleStar => AST::PowAether(Box::new(left.0), Box::new(right.0), info),
-                    Token::Caret => AST::PowArcana(Box::new(left.0), Box::new(right.0), info),
+                    Token::DoubleStar => Expr::PowAether(Box::new(left.0), Box::new(right.0), info),
+                    Token::Caret => Expr::PowArcana(Box::new(left.0), Box::new(right.0), info),
                     _ => unreachable!(),
                 };
                 (ast, span)
@@ -247,16 +247,16 @@ pub(super) fn pow_expr_parser<'src>(
 
 pub(super) fn factor_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let primary = primary_expr_parser(ctx.clone(), expression.clone());
     apply_postfix_suffixes(ctx, expression, primary).boxed()
 }
 
 pub(super) fn primary_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     choice((
         list_literal_parser(ctx.clone(), expression.clone()),
         map_literal_parser(ctx.clone(), expression.clone()),
@@ -270,22 +270,22 @@ pub(super) fn primary_expr_parser<'src>(
 }
 
 pub(super) enum PostfixSuffix {
-    Index((AST, SimpleSpan<usize>)),
+    Index((Expr, SimpleSpan<usize>)),
     Field((String, SimpleSpan<usize>)),
     Method(MethodSuffix),
 }
 
 pub(super) struct MethodSuffix {
     name: String,
-    args: Vec<AST>,
+    args: Vec<Expr>,
     span: SimpleSpan<usize>,
 }
 
 pub(super) fn apply_postfix_suffixes<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    base: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+    base: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
 
     base.then(
@@ -313,7 +313,7 @@ pub(super) fn apply_postfix_suffixes<'src>(
 
 pub(super) fn postfix_suffix_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
+    expression: BoxedParser<'src, SpannedExpr>,
 ) -> BoxedParser<'src, PostfixSuffix> {
     let index = index_suffix_parser(ctx.clone(), expression.clone()).map(PostfixSuffix::Index);
 
@@ -361,8 +361,8 @@ pub(super) fn postfix_suffix_parser<'src>(
 
 pub(super) fn index_suffix_parser<'src>(
     _ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, (AST, SimpleSpan<usize>)> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, (Expr, SimpleSpan<usize>)> {
     just(Token::OpenBracket)
         .map_with(|_, extra| extra.span())
         .then(expression)
@@ -376,16 +376,16 @@ pub(super) fn index_suffix_parser<'src>(
 
 pub(super) fn create_field_access(
     ctx: ParserContext,
-    current: SpannedAst,
+    current: SpannedExpr,
     field_suffix: (String, SimpleSpan<usize>),
-) -> SpannedAst {
+) -> SpannedExpr {
     let span = SimpleSpan::new(current.1.start(), field_suffix.1.end());
     let info = ctx.info(span);
     (
-        AST::FieldAccess {
+        Expr::FieldAccess {
             target: Box::new(current.0),
             field: field_suffix.0,
-            line_info: info,
+            span: info,
         },
         span,
     )
@@ -393,17 +393,17 @@ pub(super) fn create_field_access(
 
 pub(super) fn create_method_call(
     ctx: ParserContext,
-    current: SpannedAst,
+    current: SpannedExpr,
     method_suffix: MethodSuffix,
-) -> SpannedAst {
+) -> SpannedExpr {
     let span = SimpleSpan::new(current.1.start(), method_suffix.span.end());
     let info = ctx.info(span);
     (
-        AST::MethodCall {
+        Expr::MethodCall {
             receiver: Box::new(current.0),
             method: method_suffix.name,
             args: method_suffix.args,
-            line_info: info,
+            span: info,
         },
         span,
     )
@@ -411,16 +411,16 @@ pub(super) fn create_method_call(
 
 pub(super) fn create_index_access(
     ctx: ParserContext,
-    current: SpannedAst,
-    index_suffix: (AST, SimpleSpan<usize>),
-) -> SpannedAst {
+    current: SpannedExpr,
+    index_suffix: (Expr, SimpleSpan<usize>),
+) -> SpannedExpr {
     let span = SimpleSpan::new(current.1.start(), index_suffix.1.end());
     let info = ctx.info(span);
     (
-        AST::IndexAccess {
+        Expr::IndexAccess {
             target: Box::new(current.0),
             index: Box::new(index_suffix.0),
-            line_info: info,
+            span: info,
         },
         span,
     )
@@ -428,8 +428,8 @@ pub(super) fn create_index_access(
 
 pub(super) fn func_call_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     select! { Token::Identifier(name) => name }
         .map_with(|name, extra| (name, extra.span()))
@@ -451,10 +451,10 @@ pub(super) fn func_call_parser<'src>(
                     .map(|(ast, _)| ast)
                     .collect();
                 (
-                    AST::FuncCall {
+                    Expr::FuncCall {
                         name,
                         args,
-                        line_info: info,
+                        span: info,
                     },
                     span,
                 )
@@ -465,8 +465,8 @@ pub(super) fn func_call_parser<'src>(
 
 pub(super) fn list_literal_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     just(Token::OpenBracket)
         .map_with(|_, extra| extra.span())
@@ -487,9 +487,9 @@ pub(super) fn list_literal_parser<'src>(
                 .map(|(ast, _)| ast)
                 .collect();
             (
-                AST::ListLiteral {
+                Expr::ListLiteral {
                     elements,
-                    line_info: info,
+                    span: info,
                 },
                 span,
             )
@@ -499,8 +499,8 @@ pub(super) fn list_literal_parser<'src>(
 
 pub(super) fn map_literal_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let entry = select! { Token::Rune(key) => key }
         .map_with(|key, extra| (key, extra.span()))
@@ -525,9 +525,9 @@ pub(super) fn map_literal_parser<'src>(
                 .map(|((key, _), (value_ast, _))| (key, value_ast))
                 .collect();
             (
-                AST::MapLiteral {
+                Expr::MapLiteral {
                     entries,
-                    line_info: info,
+                    span: info,
                 },
                 span,
             )
@@ -537,8 +537,8 @@ pub(super) fn map_literal_parser<'src>(
 
 pub(super) fn artifact_literal_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     let entry = select! { Token::Identifier(name) => name }
         .map_with(|name, extra| (name, extra.span()))
@@ -565,10 +565,10 @@ pub(super) fn artifact_literal_parser<'src>(
                     .map(|((field, _), (value_ast, _))| (field, value_ast))
                     .collect();
                 (
-                    AST::ArtifactLiteral {
+                    Expr::ArtifactLiteral {
                         type_name,
                         fields,
-                        line_info: info,
+                        span: info,
                     },
                     span,
                 )
@@ -577,45 +577,45 @@ pub(super) fn artifact_literal_parser<'src>(
         .boxed()
 }
 
-pub(super) fn literal_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedAst> {
+pub(super) fn literal_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedExpr> {
     let ctx_omen = ctx.clone();
     let omen = select! { Token::OmenLiteral(value) => value }.map_with(move |value, extra| {
         let span = extra.span();
         let info = ctx_omen.info(span);
-        (AST::Omen(value, info), span)
+        (Expr::Omen(value, info), span)
     });
 
     let ctx_arcana = ctx.clone();
     let arcana = select! { Token::Arcana(value) => value }.map_with(move |value, extra| {
         let span = extra.span();
         let info = ctx_arcana.info(span);
-        (AST::Arcana(value, info), span)
+        (Expr::Arcana(value, info), span)
     });
 
     let ctx_aether = ctx.clone();
     let aether = select! { Token::Aether(value) => value }.map_with(move |value, extra| {
         let span = extra.span();
         let info = ctx_aether.info(span);
-        (AST::Aether(value.into_inner(), info), span)
+        (Expr::Aether(value.into_inner(), info), span)
     });
 
     let ctx_rune = ctx;
     let rune = select! { Token::Rune(value) => value }.map_with(move |value, extra| {
         let span = extra.span();
         let info = ctx_rune.info(span);
-        (AST::Rune(value, info), span)
+        (Expr::Rune(value, info), span)
     });
 
     choice((omen, arcana, aether, rune)).boxed()
 }
 
-pub(super) fn identifier_node<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedAst> {
+pub(super) fn identifier_node<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_map = ctx.clone();
     select! { Token::Identifier(name) => name, Token::Core => "core".to_string(), Token::Type(ty) => type_keyword_name(&ty) }
         .map_with(move |name, extra| {
             let span = extra.span();
             let info = ctx_for_map.info(span);
-            (AST::Var(name, info), span)
+            (Expr::Var(name, info), span)
         })
         .boxed()
 }

--- a/crates/abyss-core/src/parser/grammar/mod.rs
+++ b/crates/abyss-core/src/parser/grammar/mod.rs
@@ -6,7 +6,7 @@ use chumsky::{
     recursive::{self, Direct},
 };
 
-use crate::ast::{AST, Span};
+use crate::ast::{Expr, Span, Stmt};
 
 use super::SimpleSpan;
 use super::tokens::{SpannedToken, Token};
@@ -18,8 +18,9 @@ pub(super) type BoxedParser<'src, T> =
     chumsky::Boxed<'src, 'src, ParserInput<'src>, T, ParserExtra<'src>>;
 pub(super) type RecursiveParser<'src, T> =
     recursive::Recursive<Direct<'src, 'src, ParserInput<'src>, T, ParserExtra<'src>>>;
-pub(super) type SpannedAst = (AST, SimpleSpan<usize>);
-pub(super) type IndexedTarget = (SpannedAst, SpannedAst);
+pub(super) type SpannedExpr = (Expr, SimpleSpan<usize>);
+pub(super) type SpannedStmt = (Stmt, SimpleSpan<usize>);
+pub(super) type IndexedTarget = (SpannedExpr, SpannedExpr);
 
 /// Shared per-parser context. Since the span refactor it carries no
 /// state — nodes store byte spans directly — but it is kept as the
@@ -32,17 +33,13 @@ impl ParserContext {
     fn info(&self, span: SimpleSpan<usize>) -> Option<Span> {
         Some(span)
     }
-
-    fn wrap_statement(&self, ast: AST, span: SimpleSpan<usize>) -> AST {
-        AST::Statement(Box::new(ast), self.info(span))
-    }
 }
 
 pub(super) fn merge_span(a: SimpleSpan<usize>, b: SimpleSpan<usize>) -> SimpleSpan<usize> {
     SimpleSpan::new(a.start().min(b.start()), a.end().max(b.end()))
 }
 
-pub fn build_parser<'src>() -> BoxedParser<'src, Vec<AST>> {
+pub fn build_parser<'src>() -> BoxedParser<'src, Vec<Stmt>> {
     let ctx = ParserContext {};
 
     let ctx_for_recursive = ctx.clone();
@@ -53,50 +50,43 @@ pub fn build_parser<'src>() -> BoxedParser<'src, Vec<AST>> {
         let block = block_parser(ctx.clone(), statement.clone());
         let expression = expression_parser(ctx.clone(), block.clone());
         let body = statement_body_parser(ctx.clone(), expression.clone(), block.clone());
-        let ctx_for_stmt = ctx.clone();
 
-        body.then(just(Token::Semicolon).map_with(|_, extra| {
-            let span: SimpleSpan<usize> = extra.span();
-            span
-        }))
-        .map(move |((ast, body_span), semi_span)| {
-            let total_span = merge_span(body_span, semi_span);
-            ctx_for_stmt.wrap_statement(ast, total_span)
-        })
-        .boxed()
+        body.then_ignore(just(Token::Semicolon))
+            .map(|(stmt, _)| stmt)
+            .boxed()
     })
     .boxed();
 
     statement
         .clone()
         .repeated()
-        .collect::<Vec<AST>>()
+        .collect::<Vec<Stmt>>()
         .then_ignore(end())
         .boxed()
 }
 
 pub(super) fn block_parser<'src>(
     ctx: ParserContext,
-    statement: RecursiveParser<'src, AST>,
-) -> BoxedParser<'src, SpannedAst> {
+    statement: RecursiveParser<'src, Stmt>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     just(Token::OpenBrace)
         .map_with(|_, extra| extra.span())
-        .then(statement.clone().repeated().collect::<Vec<AST>>())
+        .then(statement.clone().repeated().collect::<Vec<Stmt>>())
         .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
         .map(move |((open_span, statements), close_span)| {
             let span = SimpleSpan::new(open_span.start(), close_span.end());
             let info = ctx_for_map.info(span);
-            (AST::Block(statements, info), span)
+            (Stmt::Block(statements, info), span)
         })
         .boxed()
 }
 
 pub(super) fn expression_parser<'src>(
     ctx: ParserContext,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
-    recursive(|expression: RecursiveParser<'src, SpannedAst>| {
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, SpannedExpr> {
+    recursive(|expression: RecursiveParser<'src, SpannedExpr>| {
         let ctx = ctx.clone();
         let block = block.clone();
         let expr = expression.clone().boxed();
@@ -109,9 +99,14 @@ pub(super) fn expression_parser<'src>(
 
 pub(super) fn statement_body_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, SpannedStmt> {
+    let ctx_for_expr = ctx.clone();
+    let expression_stmt = expression
+        .clone()
+        .map(move |(expr, span)| (Stmt::Expr(expr, ctx_for_expr.info(span)), span))
+        .boxed();
     choice((
         artifact_def_parser(ctx.clone()),
         forge_parser(ctx.clone(), expression.clone()),
@@ -121,8 +116,8 @@ pub(super) fn statement_body_parser<'src>(
         orbit_flow_parser(ctx.clone()),
         index_assignment_parser(ctx.clone(), expression.clone()),
         field_assignment_parser(ctx.clone(), expression.clone()),
-        assignment_parser(ctx.clone(), expression.clone()),
-        expression,
+        assignment_parser(ctx.clone(), expression),
+        expression_stmt,
     ))
     .boxed()
 }

--- a/crates/abyss-core/src/parser/grammar/patterns.rs
+++ b/crates/abyss-core/src/parser/grammar/patterns.rs
@@ -3,7 +3,7 @@
 
 use chumsky::prelude::*;
 
-use crate::ast::{AST, ConditionalAssignment};
+use crate::ast::{ConditionalAssignment, Expr, OracleBranch, Pattern};
 
 use crate::parser::SimpleSpan;
 use crate::parser::tokens::Token;
@@ -12,9 +12,9 @@ use super::*;
 
 pub(super) fn oracle_expr_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, SpannedExpr> {
     let ctx_for_cond = ctx.clone();
 
     let match_scrutinee = expression
@@ -26,10 +26,10 @@ pub(super) fn oracle_expr_parser<'src>(
             exprs
                 .into_iter()
                 .enumerate()
-                .map(|(idx, (ast, _))| ConditionalAssignment {
+                .map(|(idx, (expr, _))| ConditionalAssignment {
                     variable: format!("__match_{}", idx),
-                    expression: Box::new(ast),
-                    line_info: None,
+                    expression: Box::new(expr),
+                    span: None,
                 })
                 .collect::<Vec<_>>()
         });
@@ -45,7 +45,11 @@ pub(super) fn oracle_expr_parser<'src>(
         .map_with(|_, extra| extra.span())
         .then(conditional)
         .then_ignore(just(Token::OpenBrace))
-        .then(branch.repeated().collect::<Vec<SpannedAst>>())
+        .then(
+            branch
+                .repeated()
+                .collect::<Vec<(OracleBranch, SimpleSpan<usize>)>>(),
+        )
         .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
         .map(
             move |(((oracle_span, conditional_opt), branches), close_span)| {
@@ -58,20 +62,17 @@ pub(super) fn oracle_expr_parser<'src>(
                     (false, Vec::new())
                 };
                 for cond in &mut conditionals {
-                    cond.line_info = info;
+                    cond.span = info;
                 }
 
-                let mut branch_asts = Vec::with_capacity(branches.len());
-                for (branch_ast, _branch_span) in branches {
-                    branch_asts.push(branch_ast);
-                }
+                let branches = branches.into_iter().map(|(branch, _)| branch).collect();
 
                 (
-                    AST::Oracle {
+                    Expr::Oracle {
                         is_match,
                         conditionals,
-                        branches: branch_asts,
-                        line_info: info,
+                        branches,
+                        span: info,
                     },
                     span,
                 )
@@ -82,16 +83,13 @@ pub(super) fn oracle_expr_parser<'src>(
 
 pub(super) fn oracle_branch_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
-    let ctx_for_stmt = ctx.clone();
-
+    expression: BoxedParser<'src, SpannedExpr>,
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, (OracleBranch, SimpleSpan<usize>)> {
     let single_statement = statement_body_parser(ctx.clone(), expression.clone(), block.clone())
         .then(just(Token::Semicolon).map_with(|_, extra| extra.span()))
-        .map(move |((ast, body_span), semi_span)| {
+        .map(move |((stmt, body_span), semi_span)| {
             let span = merge_span(body_span, semi_span);
-            let stmt = ctx_for_stmt.wrap_statement(ast, span);
             (stmt, span)
         });
 
@@ -99,7 +97,7 @@ pub(super) fn oracle_branch_parser<'src>(
 
     let guard = just(Token::Ward)
         .ignore_then(expression.clone())
-        .map(|(ast, _)| Box::new(ast))
+        .map(|(expr, _)| expr)
         .or_not();
 
     // The pattern element parser is mutually recursive with the scroll- and
@@ -107,8 +105,8 @@ pub(super) fn oracle_branch_parser<'src>(
     // value may itself be a scroll / artifact / wildcard pattern). Build it
     // once via `recursive` and thread it into both the top-level pattern
     // recogniser and the inner sub-parsers so nested patterns like
-    // `Player { items: [head, ..rest] }` actually parse into the AST nodes
-    // the evaluator already knows how to match.
+    // `Player { items: [head, ..rest] }` actually parse into the pattern
+    // nodes the evaluator already knows how to match.
     let pattern_element = pattern_element_parser(ctx.clone(), expression.clone());
     let pattern = pattern_parser(ctx.clone(), expression.clone(), pattern_element);
 
@@ -117,15 +115,15 @@ pub(super) fn oracle_branch_parser<'src>(
         .then_ignore(just(Token::FatArrow))
         .then(body)
         .map(
-            move |(((pattern, pattern_span), guard_ast), (body_ast, body_span))| {
+            move |(((pattern, pattern_span), guard_expr), (body_stmt, body_span))| {
                 let span = merge_span(pattern_span, body_span);
                 let info = ctx.info(span);
                 (
-                    AST::OracleBranch {
+                    OracleBranch {
                         pattern,
-                        guard: guard_ast,
-                        body: Box::new(body_ast),
-                        line_info: info,
+                        guard: guard_expr,
+                        body: body_stmt,
+                        span: info,
                     },
                     span,
                 )
@@ -136,9 +134,9 @@ pub(super) fn oracle_branch_parser<'src>(
 
 pub(super) fn pattern_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    pattern_element: BoxedParser<'src, AST>,
-) -> BoxedParser<'src, (Vec<AST>, SimpleSpan<usize>)> {
+    expression: BoxedParser<'src, SpannedExpr>,
+    pattern_element: BoxedParser<'src, Pattern>,
+) -> BoxedParser<'src, (Vec<Pattern>, SimpleSpan<usize>)> {
     let wildcard = select! { Token::Identifier(name) if name == "_" => () }
         .map_with(|_, extra| (Vec::new(), extra.span()));
 
@@ -163,9 +161,9 @@ pub(super) fn pattern_parser<'src>(
     // is also referenced through `pattern_element` so scroll patterns can sit
     // alongside other elements in a multi-scrutinee tuple pattern.
     let scroll = scroll_pattern_parser(ctx.clone(), pattern_element.clone(), expression.clone())
-        .map_with(|ast, extra| {
+        .map_with(|pattern, extra| {
             let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
-            (vec![ast], span)
+            (vec![pattern], span)
         });
 
     // An artifact pattern `TypeName { … }` at the top of an arm — same shape
@@ -173,10 +171,10 @@ pub(super) fn pattern_parser<'src>(
     // field value itself be a nested scroll / artifact / wildcard pattern.
     let artifact =
         artifact_pattern_parser(ctx.clone(), pattern_element.clone(), expression.clone()).map_with(
-            |ast, extra| {
+            |pattern, extra| {
                 let span: SimpleSpan<usize> =
                     SimpleSpan::new(extra.span().start(), extra.span().end());
-                (vec![ast], span)
+                (vec![pattern], span)
             },
         );
 
@@ -187,9 +185,9 @@ pub(super) fn pattern_parser<'src>(
     // `pattern_element`, so nested patterns work the same way as inside
     // artifact patterns.
     let lexicon =
-        lexicon_pattern_parser(ctx, pattern_element, expression).map_with(|ast, extra| {
+        lexicon_pattern_parser(ctx, pattern_element, expression).map_with(|pattern, extra| {
             let span: SimpleSpan<usize> = SimpleSpan::new(extra.span().start(), extra.span().end());
-            (vec![ast], span)
+            (vec![pattern], span)
         });
 
     wildcard
@@ -202,14 +200,14 @@ pub(super) fn pattern_parser<'src>(
 
 pub(super) fn pattern_element_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, AST> {
-    recursive(|pattern_elem: RecursiveParser<'src, AST>| {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, Pattern> {
+    recursive(|pattern_elem: RecursiveParser<'src, Pattern>| {
         let ctx_for_wild = ctx.clone();
         let dont_care =
             select! { Token::Identifier(name) if name == "_" => () }.map_with(move |_, extra| {
                 let span = extra.span();
-                AST::OracleDontCareItem(ctx_for_wild.info(span))
+                Pattern::DontCare(ctx_for_wild.info(span))
             });
 
         let pattern_elem_boxed = pattern_elem.clone().boxed();
@@ -228,7 +226,7 @@ pub(super) fn pattern_element_parser<'src>(
         // map literal it would otherwise be.
         let lexicon = lexicon_pattern_parser(ctx.clone(), pattern_elem_boxed, expression.clone());
 
-        let expr = expression.clone().map(|(ast, _)| ast);
+        let expr = expression.clone().map(|(expr, _)| Pattern::Expr(expr));
 
         dont_care
             .or(scroll)
@@ -259,27 +257,27 @@ pub(super) fn pattern_element_parser<'src>(
 /// would be in expression position.
 pub(super) fn artifact_pattern_parser<'src>(
     ctx: ParserContext,
-    pattern_element: BoxedParser<'src, AST>,
-    _expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, AST> {
+    pattern_element: BoxedParser<'src, Pattern>,
+    _expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, Pattern> {
     // Each field entry is `name (: value)?`. The shorthand expands to a
-    // `Var(name)` so the evaluator's existing `Var`-as-binding path applies
-    // uniformly with tuple and scroll patterns. The explicit `: value` form
-    // accepts any pattern element (wildcard, nested scroll/artifact patterns,
-    // bindings, literal expressions), so nested destructuring like
-    // `Player { items: [head, ..rest], friend: Enemy { name } }` parses into
-    // the `OracleScrollPattern` / `OracleArtifactPattern` nodes the evaluator
-    // already knows how to match.
+    // `Pattern::Expr(Expr::Var(name))` so the evaluator's existing
+    // `Var`-as-binding path applies uniformly with tuple and scroll
+    // patterns. The explicit `: value` form accepts any pattern element
+    // (wildcard, nested scroll/artifact patterns, bindings, literal
+    // expressions), so nested destructuring like
+    // `Player { items: [head, ..rest], friend: Enemy { name } }` parses
+    // into the pattern nodes the evaluator already knows how to match.
     let ctx_for_field = ctx.clone();
     let field = select! { Token::Identifier(name) => name }
         .map_with(move |name, extra| (name, extra.span()))
         .then(just(Token::Colon).ignore_then(pattern_element).or_not())
         .map(move |((name, name_span), value)| {
             let pattern = value.unwrap_or_else(|| {
-                AST::Var(
+                Pattern::Expr(Expr::Var(
                     name.clone(),
                     ctx_for_field.info(SimpleSpan::new(name_span.start(), name_span.end())),
-                )
+                ))
             });
             (name, pattern)
         });
@@ -297,10 +295,10 @@ pub(super) fn artifact_pattern_parser<'src>(
         .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
         .map(move |(((type_name, type_span), fields), close_span)| {
             let span = SimpleSpan::new(type_span.start(), close_span.end());
-            AST::OracleArtifactPattern {
+            Pattern::Artifact {
                 type_name,
                 fields,
-                line_info: ctx_for_outer.info(span),
+                span: ctx_for_outer.info(span),
             }
         })
         .boxed()
@@ -320,9 +318,9 @@ pub(super) fn artifact_pattern_parser<'src>(
 /// pattern position is a destructuring pattern rather than the map literal.
 pub(super) fn lexicon_pattern_parser<'src>(
     ctx: ParserContext,
-    pattern_element: BoxedParser<'src, AST>,
-    _expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, AST> {
+    pattern_element: BoxedParser<'src, Pattern>,
+    _expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, Pattern> {
     let entry = select! { Token::Rune(key) => key }
         .map_with(|key, extra| (key, extra.span()))
         .then_ignore(just(Token::Colon))
@@ -341,9 +339,9 @@ pub(super) fn lexicon_pattern_parser<'src>(
         .then(just(Token::CloseBrace).map_with(|_, extra| extra.span()))
         .map(move |((open_span, entries), close_span)| {
             let span = SimpleSpan::new(open_span.start(), close_span.end());
-            AST::OracleLexiconPattern {
+            Pattern::Lexicon {
                 entries,
-                line_info: ctx_for_outer.info(span),
+                span: ctx_for_outer.info(span),
             }
         })
         .boxed()
@@ -364,9 +362,9 @@ pub(super) fn lexicon_pattern_parser<'src>(
 /// than the list literal it would be in expression position.
 pub(super) fn scroll_pattern_parser<'src>(
     ctx: ParserContext,
-    pattern_element: BoxedParser<'src, AST>,
-    _expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, AST> {
+    pattern_element: BoxedParser<'src, Pattern>,
+    _expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, Pattern> {
     let ctx_for_rest = ctx.clone();
     let rest = just(Token::RangeExclusive)
         .map_with(|_, extra| extra.span())
@@ -379,9 +377,9 @@ pub(super) fn scroll_pattern_parser<'src>(
             let close_span: SimpleSpan<usize> =
                 named.as_ref().map(|(_, span)| *span).unwrap_or(open_span);
             let span = SimpleSpan::new(open_span.start(), close_span.end());
-            AST::OracleScrollRest {
+            Pattern::Rest {
                 name: named.map(|(name, _)| name),
-                line_info: ctx_for_rest.info(span),
+                span: ctx_for_rest.info(span),
             }
         });
 
@@ -403,9 +401,9 @@ pub(super) fn scroll_pattern_parser<'src>(
         .then(just(Token::CloseBracket).map_with(|_, extra| extra.span()))
         .map(move |((open_span, elements), close_span)| {
             let span = SimpleSpan::new(open_span.start(), close_span.end());
-            AST::OracleScrollPattern {
+            Pattern::Scroll {
                 elements,
-                line_info: ctx_for_outer.info(span),
+                span: ctx_for_outer.info(span),
             }
         })
         .boxed()

--- a/crates/abyss-core/src/parser/grammar/statements.rs
+++ b/crates/abyss-core/src/parser/grammar/statements.rs
@@ -5,14 +5,16 @@ use std::collections::HashMap;
 
 use chumsky::{error::Rich, prelude::*};
 
-use crate::ast::{AST, ArtifactField, ArtifactMethodTarget, AssignmentOp, Type};
+use crate::ast::{
+    ArtifactField, ArtifactMethodTarget, AssignmentOp, EngraveParam, Expr, OrbitParam, Stmt, Type,
+};
 
 use crate::parser::SimpleSpan;
 use crate::parser::tokens::Token;
 
 use super::*;
 
-pub(super) fn artifact_def_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedAst> {
+pub(super) fn artifact_def_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     let ident =
         select! { Token::Identifier(name) => name }.map_with(|name, extra| (name, extra.span()));
@@ -25,10 +27,10 @@ pub(super) fn artifact_def_parser<'src>(ctx: ParserContext) -> BoxedParser<'src,
             let span = SimpleSpan::new(artifact_span.start(), body_span.end());
             let info = ctx_for_map.info(span);
             (
-                AST::ArtifactDef {
+                Stmt::ArtifactDef {
                     name,
                     fields,
-                    line_info: info,
+                    span: info,
                 },
                 span,
             )
@@ -66,7 +68,7 @@ pub(super) fn artifact_fields_parser<'src>(
                 fields.push(ArtifactField {
                     name,
                     field_type,
-                    line_info: info,
+                    span: info,
                 });
             }
             Ok((fields, span))
@@ -76,8 +78,8 @@ pub(super) fn artifact_fields_parser<'src>(
 
 pub(super) fn forge_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     let morph_flag = just(Token::Morph)
         .to(true)
@@ -103,12 +105,12 @@ pub(super) fn forge_parser<'src>(
                 let span = SimpleSpan::new(forge_span.start(), value_span.end());
                 let info = ctx_for_map.info(span);
                 (
-                    AST::VarAssign {
+                    Stmt::VarAssign {
                         name,
-                        value: Box::new(value_ast),
+                        value: value_ast,
                         var_type: ty,
                         is_morph,
-                        line_info: info,
+                        span: info,
                     },
                     span,
                 )
@@ -125,7 +127,7 @@ pub(super) enum RawEngraveParam {
         is_morph: bool,
         span: SimpleSpan<usize>,
     },
-    Param(AST),
+    Param(EngraveParam),
 }
 
 /// Internal representation for engrave target classification.
@@ -169,8 +171,8 @@ pub(super) fn core_keyword_span<'src>() -> BoxedParser<'src, SimpleSpan<usize>> 
 
 pub(super) fn engrave_parser<'src>(
     ctx: ParserContext,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
 
     let params = choice((
@@ -237,13 +239,13 @@ pub(super) fn engrave_parser<'src>(
                         }
 
                         Ok((
-                            AST::Engrave {
+                            Stmt::Engrave {
                                 name,
                                 params,
                                 return_type,
                                 body: Box::new(body_ast),
                                 method_target: None,
-                                line_info: info,
+                                span: info,
                             },
                             span,
                         ))
@@ -281,11 +283,11 @@ pub(super) fn engrave_parser<'src>(
                                     receiver_seen = true;
                                     target_meta.requires_morph = is_morph;
                                     let info = ctx_for_map.info(recv_span);
-                                    params.push(AST::EngraveParam {
+                                    params.push(EngraveParam {
                                         name: "core".to_string(),
                                         param_type: Type::Artifact(target_meta.artifact.clone()),
                                         is_morph,
-                                        line_info: info,
+                                        span: info,
                                     });
                                 }
                                 RawEngraveParam::Param(node) => params.push(node),
@@ -300,13 +302,13 @@ pub(super) fn engrave_parser<'src>(
                         }
 
                         Ok((
-                            AST::Engrave {
+                            Stmt::Engrave {
                                 name: method,
                                 params,
                                 return_type,
                                 body: Box::new(body_ast),
                                 method_target: Some(target_meta),
-                                line_info: info,
+                                span: info,
                             },
                             span,
                         ))
@@ -319,8 +321,8 @@ pub(super) fn engrave_parser<'src>(
 
 pub(super) fn reveal_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     just(Token::Reveal)
         .map_with(|_, extra| extra.span())
@@ -332,18 +334,18 @@ pub(super) fn reveal_parser<'src>(
                 .unwrap_or(reveal_span);
             let info = ctx_for_map.info(span);
             let value = maybe_expr
-                .map(|(ast, _)| Box::new(ast))
-                .unwrap_or_else(|| Box::new(AST::Abyss(info)));
-            (AST::Reveal(value, info), span)
+                .map(|(expr, _)| expr)
+                .unwrap_or_else(|| Expr::Abyss(info));
+            (Stmt::Reveal(value, info), span)
         })
         .boxed()
 }
 
 pub(super) fn orbit_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-    block: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+    block: BoxedParser<'src, SpannedStmt>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     let params = orbit_param_parser(ctx.clone(), expression.clone())
         .separated_by(just(Token::Comma))
@@ -360,10 +362,10 @@ pub(super) fn orbit_parser<'src>(
             let span = SimpleSpan::new(orbit_span.start(), body_span.end());
             let info = ctx_for_map.info(span);
             (
-                AST::Orbit {
+                Stmt::Orbit {
                     params: params_opt.unwrap_or_default(),
                     body: Box::new(body_ast),
-                    line_info: info,
+                    span: info,
                 },
                 span,
             )
@@ -371,7 +373,7 @@ pub(super) fn orbit_parser<'src>(
         .boxed()
 }
 
-pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedAst> {
+pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, SpannedStmt> {
     let ctx_resume = ctx.clone();
     let ident: BoxedParser<'src, (String, SimpleSpan<usize>)> = select! {
         Token::Identifier(name) => name
@@ -392,7 +394,7 @@ pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, S
                     .map(|(_, id_span)| SimpleSpan::new(resume_span.start(), id_span.end()))
                     .unwrap_or(resume_span);
                 let info = ctx_resume.info(span);
-                (AST::Resume(maybe_ident.map(|(name, _)| name), info), span)
+                (Stmt::Resume(maybe_ident.map(|(name, _)| name), info), span)
             },
         );
 
@@ -410,7 +412,7 @@ pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, S
                     .map(|(_, id_span)| SimpleSpan::new(eject_span.start(), id_span.end()))
                     .unwrap_or(eject_span);
                 let info = ctx_eject.info(span);
-                (AST::Eject(maybe_ident.map(|(name, _)| name), info), span)
+                (Stmt::Eject(maybe_ident.map(|(name, _)| name), info), span)
             },
         );
 
@@ -419,8 +421,8 @@ pub(super) fn orbit_flow_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, S
 
 pub(super) fn assignment_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     let ident =
         select! { Token::Identifier(name) => name }.map_with(|name, extra| (name, extra.span()));
@@ -445,11 +447,11 @@ pub(super) fn assignment_parser<'src>(
                 let span = SimpleSpan::new(name_span.start(), value_span.end());
                 let info = ctx_for_map.info(span);
                 (
-                    AST::Assignment {
+                    Stmt::Assignment {
                         name,
-                        value: Box::new(value_ast),
+                        value: value_ast,
                         op: assignment_op_from_token(token),
-                        line_info: info,
+                        span: info,
                     },
                     span,
                 )
@@ -460,8 +462,8 @@ pub(super) fn assignment_parser<'src>(
 
 pub(super) fn field_assignment_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     expression
         .clone()
@@ -469,15 +471,15 @@ pub(super) fn field_assignment_parser<'src>(
         .then(expression)
         .try_map(
             move |((target_ast, target_span), (value_ast, value_span)), _extra| {
-                if let AST::FieldAccess { target, field, .. } = target_ast {
+                if let Expr::FieldAccess { target, field, .. } = target_ast {
                     let span = SimpleSpan::new(target_span.start(), value_span.end());
                     let info = ctx_for_map.info(span);
                     Ok((
-                        AST::FieldAssignment {
-                            target,
+                        Stmt::FieldAssignment {
+                            target: *target,
                             field,
-                            value: Box::new(value_ast),
-                            line_info: info,
+                            value: value_ast,
+                            span: info,
                         },
                         span,
                     ))
@@ -508,8 +510,8 @@ pub(super) fn assignment_op_from_token(token: Token) -> AssignmentOp {
 
 pub(super) fn index_assignment_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, SpannedAst> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, SpannedStmt> {
     let ctx_for_map = ctx.clone();
     indexed_target_parser(ctx, expression.clone())
         .then_ignore(just(Token::Assign))
@@ -523,11 +525,11 @@ pub(super) fn index_assignment_parser<'src>(
                 let span = SimpleSpan::new(lhs_span.start(), value_span.end());
                 let info = ctx_for_map.info(span);
                 (
-                    AST::IndexAssignment {
-                        target: Box::new(target_ast),
-                        index: Box::new(index_ast),
-                        value: Box::new(value_ast),
-                        line_info: info,
+                    Stmt::IndexAssignment {
+                        target: target_ast,
+                        index: index_ast,
+                        value: value_ast,
+                        span: info,
                     },
                     span,
                 )
@@ -538,7 +540,7 @@ pub(super) fn index_assignment_parser<'src>(
 
 pub(super) fn indexed_target_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
+    expression: BoxedParser<'src, SpannedExpr>,
 ) -> BoxedParser<'src, IndexedTarget> {
     let ctx_for_map = ctx.clone();
     primary_expr_parser(ctx.clone(), expression.clone())
@@ -562,8 +564,8 @@ pub(super) fn indexed_target_parser<'src>(
 
 pub(super) fn orbit_param_parser<'src>(
     ctx: ParserContext,
-    expression: BoxedParser<'src, SpannedAst>,
-) -> BoxedParser<'src, AST> {
+    expression: BoxedParser<'src, SpannedExpr>,
+) -> BoxedParser<'src, OrbitParam> {
     let ctx_for_map = ctx.clone();
     select! { Token::Identifier(name) => name }
         .map_with(|name, extra| (name, extra.span()))
@@ -573,19 +575,19 @@ pub(super) fn orbit_param_parser<'src>(
             move |((name, name_span), (start_ast, end_ast, op, range_span))| {
                 let span = merge_span(name_span, range_span);
                 let info = ctx_for_map.info(span);
-                AST::OrbitParam {
+                OrbitParam {
                     name,
-                    start: Box::new(start_ast),
-                    end: Box::new(end_ast),
+                    start: start_ast,
+                    end: end_ast,
                     op,
-                    line_info: info,
+                    span: info,
                 }
             },
         )
         .boxed()
 }
 
-pub(super) fn engrave_param_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, AST> {
+pub(super) fn engrave_param_parser<'src>(ctx: ParserContext) -> BoxedParser<'src, EngraveParam> {
     let ctx_for_map = ctx.clone();
     select! { Token::Identifier(name) => name }
         .map_with(|name, extra| (name, extra.span()))
@@ -594,11 +596,11 @@ pub(super) fn engrave_param_parser<'src>(ctx: ParserContext) -> BoxedParser<'src
         .map(move |((name, name_span), (ty, ty_span))| {
             let span = merge_span(name_span, ty_span);
             let info = ctx_for_map.info(span);
-            AST::EngraveParam {
+            EngraveParam {
                 name,
                 param_type: ty,
                 is_morph: false,
-                line_info: info,
+                span: info,
             }
         })
         .boxed()

--- a/crates/abyss-core/src/parser/mod.rs
+++ b/crates/abyss-core/src/parser/mod.rs
@@ -11,12 +11,12 @@ pub use diagnostics::{ParserDiagnostic, emit_diagnostics, render_diagnostics};
 use chumsky::{Parser, input::IterInput};
 use ordered_float::OrderedFloat;
 
-use crate::ast::AST;
+use crate::ast::Stmt;
 
 use diagnostics::convert_rich_error;
 use grammar::build_parser;
 pub struct ParseOutcome {
-    pub ast: Vec<AST>,
+    pub ast: Vec<Stmt>,
     pub diagnostics: Vec<ParserDiagnostic>,
 }
 

--- a/crates/abyss-core/tests/test_artifact_parser.rs
+++ b/crates/abyss-core/tests/test_artifact_parser.rs
@@ -1,7 +1,7 @@
-use abyss_core::ast::{AST, Type};
+use abyss_core::ast::{Expr, Stmt, Type};
 use abyss_core::parser::parse;
 
-fn parse_single(source: &str) -> Vec<AST> {
+fn parse_single(source: &str) -> Vec<Stmt> {
     let outcome = parse(source);
     assert!(
         outcome.diagnostics.is_empty(),
@@ -24,18 +24,15 @@ artifact Player {
 
     assert_eq!(ast.len(), 1);
     match &ast[0] {
-        AST::Statement(inner, _) => match inner.as_ref() {
-            AST::ArtifactDef { name, fields, .. } => {
-                assert_eq!(name, "Player");
-                assert_eq!(fields.len(), 2);
-                assert_eq!(fields[0].name, "name");
-                assert_eq!(fields[0].field_type, Type::Rune);
-                assert_eq!(fields[1].name, "health");
-                assert_eq!(fields[1].field_type, Type::Arcana);
-            }
-            other => panic!("expected artifact definition, found {:?}", other),
-        },
-        other => panic!("expected statement node, found {:?}", other),
+        Stmt::ArtifactDef { name, fields, .. } => {
+            assert_eq!(name, "Player");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "name");
+            assert_eq!(fields[0].field_type, Type::Rune);
+            assert_eq!(fields[1].name, "health");
+            assert_eq!(fields[1].field_type, Type::Arcana);
+        }
+        other => panic!("expected artifact definition, found {:?}", other),
     }
 }
 
@@ -50,21 +47,18 @@ forge hero: Player = Player { name: "Ardyn", health: 100 };
 
     assert_eq!(ast.len(), 2);
     match &ast[1] {
-        AST::Statement(inner, _) => match inner.as_ref() {
-            AST::VarAssign { value, .. } => match value.as_ref() {
-                AST::ArtifactLiteral {
-                    type_name, fields, ..
-                } => {
-                    assert_eq!(type_name, "Player");
-                    assert_eq!(fields.len(), 2);
-                    assert_eq!(fields[0].0, "name");
-                    assert_eq!(fields[1].0, "health");
-                }
-                other => panic!("expected artifact literal, found {:?}", other),
-            },
-            other => panic!("expected variable assignment, found {:?}", other),
+        Stmt::VarAssign { value, .. } => match value {
+            Expr::ArtifactLiteral {
+                type_name, fields, ..
+            } => {
+                assert_eq!(type_name, "Player");
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields[0].0, "name");
+                assert_eq!(fields[1].0, "health");
+            }
+            other => panic!("expected artifact literal, found {:?}", other),
         },
-        other => panic!("expected statement node, found {:?}", other),
+        other => panic!("expected variable assignment, found {:?}", other),
     }
 }
 
@@ -80,26 +74,23 @@ hero.health = 75;
 
     assert_eq!(ast.len(), 3);
     match &ast[2] {
-        AST::Statement(inner, _) => match inner.as_ref() {
-            AST::FieldAssignment {
-                target,
-                field,
-                value,
-                ..
-            } => {
-                assert_eq!(field, "health");
-                match target.as_ref() {
-                    AST::Var(name, _) => assert_eq!(name, "hero"),
-                    other => panic!("expected base variable, found {:?}", other),
-                }
-                match value.as_ref() {
-                    AST::Arcana(number, _) => assert_eq!(*number, 75),
-                    other => panic!("expected arcana literal, found {:?}", other),
-                }
+        Stmt::FieldAssignment {
+            target,
+            field,
+            value,
+            ..
+        } => {
+            assert_eq!(field, "health");
+            match target {
+                Expr::Var(name, _) => assert_eq!(name, "hero"),
+                other => panic!("expected base variable, found {:?}", other),
             }
-            other => panic!("expected field assignment, found {:?}", other),
-        },
-        other => panic!("expected statement node, found {:?}", other),
+            match value {
+                Expr::Arcana(number, _) => assert_eq!(*number, 75),
+                other => panic!("expected arcana literal, found {:?}", other),
+            }
+        }
+        other => panic!("expected field assignment, found {:?}", other),
     }
 }
 
@@ -137,39 +128,26 @@ engrave Player::get_level(core) -> arcana {
 
     assert_eq!(ast.len(), 2);
     match &ast[1] {
-        AST::Statement(inner, _) => match inner.as_ref() {
-            AST::Engrave {
-                name,
-                params,
-                return_type,
-                method_target,
-                ..
-            } => {
-                assert_eq!(name, "get_level");
-                assert_eq!(*return_type, Type::Arcana);
-                let target = method_target
-                    .as_ref()
-                    .expect("expected method metadata on engrave statement");
-                assert_eq!(target.artifact, "Player");
-                assert!(!target.requires_morph);
-                assert_eq!(params.len(), 1);
-                match &params[0] {
-                    AST::EngraveParam {
-                        name,
-                        param_type,
-                        is_morph,
-                        ..
-                    } => {
-                        assert_eq!(name, "core");
-                        assert_eq!(*param_type, Type::Artifact("Player".into()));
-                        assert!(!is_morph);
-                    }
-                    other => panic!("expected engrave param, found {:?}", other),
-                }
-            }
-            other => panic!("expected engrave statement, found {:?}", other),
-        },
-        other => panic!("expected statement node, found {:?}", other),
+        Stmt::Engrave {
+            name,
+            params,
+            return_type,
+            method_target,
+            ..
+        } => {
+            assert_eq!(name, "get_level");
+            assert_eq!(*return_type, Type::Arcana);
+            let target = method_target
+                .as_ref()
+                .expect("expected method metadata on engrave statement");
+            assert_eq!(target.artifact, "Player");
+            assert!(!target.requires_morph);
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "core");
+            assert_eq!(params[0].param_type, Type::Artifact("Player".into()));
+            assert!(!params[0].is_morph);
+        }
+        other => panic!("expected engrave statement, found {:?}", other),
     }
 }
 
@@ -185,22 +163,22 @@ hero.get_level();
 
     assert_eq!(ast.len(), 3);
     match &ast[2] {
-        AST::Statement(inner, _) => match inner.as_ref() {
-            AST::MethodCall {
+        Stmt::Expr(
+            Expr::MethodCall {
                 receiver,
                 method,
                 args,
                 ..
-            } => {
-                assert_eq!(method, "get_level");
-                assert!(args.is_empty());
-                match receiver.as_ref() {
-                    AST::Var(name, _) => assert_eq!(name, "hero"),
-                    other => panic!("expected receiver variable, found {:?}", other),
-                }
+            },
+            _,
+        ) => {
+            assert_eq!(method, "get_level");
+            assert!(args.is_empty());
+            match receiver.as_ref() {
+                Expr::Var(name, _) => assert_eq!(name, "hero"),
+                other => panic!("expected receiver variable, found {:?}", other),
             }
-            other => panic!("expected method call, found {:?}", other),
-        },
-        other => panic!("expected statement node, found {:?}", other),
+        }
+        other => panic!("expected method-call statement, found {:?}", other),
     }
 }

--- a/crates/abyss-core/tests/test_format.rs
+++ b/crates/abyss-core/tests/test_format.rs
@@ -1,472 +1,507 @@
-use abyss_core::ast::{AST, ArtifactField, ArtifactMethodTarget, AssignmentOp, Type};
-use abyss_core::format::format_ast;
+use abyss_core::ast::{
+    ArtifactField, ArtifactMethodTarget, AssignmentOp, ConditionalAssignment, EngraveParam, Expr,
+    OracleBranch, OrbitParam, Pattern, Stmt, Type,
+};
+use abyss_core::format::{format_expr, format_pattern, format_stmt};
 
-fn arcana(value: i64) -> Box<AST> {
-    Box::new(AST::Arcana(value, None))
+fn arcana(value: i64) -> Box<Expr> {
+    Box::new(Expr::Arcana(value, None))
 }
 
-fn rune(value: &str) -> Box<AST> {
-    Box::new(AST::Rune(value.to_string(), None))
+fn rune(value: &str) -> Expr {
+    Expr::Rune(value.to_string(), None)
 }
 
-fn omen(value: bool) -> Box<AST> {
-    Box::new(AST::Omen(value, None))
+fn omen(value: bool) -> Box<Expr> {
+    Box::new(Expr::Omen(value, None))
 }
 
-fn var(name: &str) -> Box<AST> {
-    Box::new(AST::Var(name.to_string(), None))
+fn var(name: &str) -> Expr {
+    Expr::Var(name.to_string(), None)
 }
 
-fn abyss() -> Box<AST> {
-    Box::new(AST::Abyss(None))
+fn reveal(value: Expr) -> Stmt {
+    Stmt::Reveal(value, None)
 }
 
 #[test]
 fn format_basic_expressions_and_assignments() {
-    let expr_stmt = AST::Statement(
-        Box::new(AST::Mul(
-            Box::new(AST::Add(arcana(1), arcana(2), None)),
+    let expr_stmt = Stmt::Expr(
+        Expr::Mul(
+            Box::new(Expr::Add(arcana(1), arcana(2), None)),
             arcana(3),
             None,
-        )),
+        ),
         None,
     );
-    assert_eq!(format_ast(&expr_stmt, 1), "    (1 + 2) * 3;");
+    assert_eq!(format_stmt(&expr_stmt, 1), "    (1 + 2) * 3;");
 
-    let logical = AST::LogicalNot(omen(false), None);
-    assert_eq!(format_ast(&logical, 0), "!hex");
+    let logical = Expr::LogicalNot(omen(false), None);
+    assert_eq!(format_expr(&logical, 0), "!hex");
 
-    let var_assign = AST::VarAssign {
+    let var_assign = Stmt::VarAssign {
         name: "sigil".into(),
         value: rune("alpha"),
         var_type: Type::Rune,
         is_morph: true,
-        line_info: None,
+        span: None,
     };
     assert_eq!(
-        format_ast(&var_assign, 0),
-        "forge morph sigil: rune = \"alpha\""
+        format_stmt(&var_assign, 0),
+        "forge morph sigil: rune = \"alpha\";"
     );
 
-    let assign = AST::Assignment {
+    let assign = Stmt::Assignment {
         name: "sigil".into(),
         value: var("base"),
         op: AssignmentOp::PowAetherAssign,
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&assign, 0), "sigil **= base");
+    assert_eq!(format_stmt(&assign, 0), "sigil **= base;");
 
-    assert_eq!(format_ast(&AST::Arcana(7, None), 0), "7");
-    assert_eq!(format_ast(&AST::Aether(7.0, None), 0), "7.0");
-    assert_eq!(format_ast(&AST::Aether(7.25, None), 0), "7.25");
-    assert_eq!(format_ast(&AST::Rune("echo".into(), None), 0), "\"echo\"");
-    assert_eq!(format_ast(&AST::Omen(true, None), 0), "boon");
-    assert_eq!(format_ast(&AST::Abyss(None), 0), "abyss");
+    assert_eq!(format_expr(&Expr::Arcana(7, None), 0), "7");
+    assert_eq!(format_expr(&Expr::Aether(7.0, None), 0), "7.0");
+    assert_eq!(format_expr(&Expr::Aether(7.25, None), 0), "7.25");
+    assert_eq!(format_expr(&Expr::Rune("echo".into(), None), 0), "\"echo\"");
+    assert_eq!(format_expr(&Expr::Omen(true, None), 0), "boon");
+    assert_eq!(format_expr(&Expr::Abyss(None), 0), "abyss");
 
-    let reveal_core = AST::Reveal(var("sigil"), None);
-    assert_eq!(format_ast(&reveal_core, 0), "reveal sigil");
+    let reveal_core = reveal(var("sigil"));
+    assert_eq!(format_stmt(&reveal_core, 0), "reveal sigil;");
 
-    let reveal_abyss = AST::Reveal(abyss(), None);
-    assert_eq!(format_ast(&reveal_abyss, 0), "reveal");
+    let reveal_abyss = reveal(Expr::Abyss(None));
+    assert_eq!(format_stmt(&reveal_abyss, 0), "reveal;");
 
-    let field_access = AST::FieldAccess {
+    let field_access = Expr::FieldAccess {
+        target: Box::new(var("relic")),
+        field: "core".into(),
+        span: None,
+    };
+    assert_eq!(format_expr(&field_access, 0), "relic.core");
+
+    let field_assignment = Stmt::FieldAssignment {
         target: var("relic"),
         field: "core".into(),
-        line_info: None,
+        value: *arcana(5),
+        span: None,
     };
-    assert_eq!(format_ast(&field_access, 0), "relic.core");
+    assert_eq!(format_stmt(&field_assignment, 0), "relic.core = 5;");
 
-    let field_assignment = AST::FieldAssignment {
-        target: var("relic"),
-        field: "core".into(),
-        value: arcana(5),
-        line_info: None,
-    };
-    assert_eq!(format_ast(&field_assignment, 0), "relic.core = 5");
-
-    let index_assignment = AST::IndexAssignment {
+    let index_assignment = Stmt::IndexAssignment {
         target: var("sigils"),
-        index: arcana(2),
+        index: *arcana(2),
         value: rune("beta"),
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&index_assignment, 0), "sigils[2] = \"beta\"");
+    assert_eq!(format_stmt(&index_assignment, 0), "sigils[2] = \"beta\";");
 
-    let method_call = AST::MethodCall {
-        receiver: var("relic"),
+    let method_call = Expr::MethodCall {
+        receiver: Box::new(var("relic")),
         method: "ignite".into(),
-        args: vec![*rune("spark")],
-        line_info: None,
+        args: vec![rune("spark")],
+        span: None,
     };
-    assert_eq!(format_ast(&method_call, 0), "relic.ignite(\"spark\")");
+    assert_eq!(format_expr(&method_call, 0), "relic.ignite(\"spark\")");
 }
 
 #[test]
 fn format_collections_and_literals() {
-    let list = AST::ListLiteral {
+    let list = Expr::ListLiteral {
         elements: vec![
-            AST::Arcana(1, None),
-            AST::Arcana(2, None),
-            AST::Arcana(3, None),
+            Expr::Arcana(1, None),
+            Expr::Arcana(2, None),
+            Expr::Arcana(3, None),
         ],
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&list, 0), "[1, 2, 3]");
+    assert_eq!(format_expr(&list, 0), "[1, 2, 3]");
 
-    let map = AST::MapLiteral {
+    let map = Expr::MapLiteral {
         entries: vec![
-            ("name".into(), AST::Rune("abyss".into(), None)),
-            ("value".into(), AST::Arcana(3, None)),
+            ("name".into(), Expr::Rune("abyss".into(), None)),
+            ("value".into(), Expr::Arcana(3, None)),
         ],
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&map, 0), "{\"name\": \"abyss\", \"value\": 3}");
+    assert_eq!(format_expr(&map, 0), "{\"name\": \"abyss\", \"value\": 3}");
 
-    let artifact_literal = AST::ArtifactLiteral {
+    let artifact_literal = Expr::ArtifactLiteral {
         type_name: "Relic".into(),
         fields: vec![
-            ("sigil".into(), AST::Rune("alpha".into(), None)),
-            ("power".into(), AST::Arcana(9, None)),
+            ("sigil".into(), Expr::Rune("alpha".into(), None)),
+            ("power".into(), Expr::Arcana(9, None)),
         ],
-        line_info: None,
+        span: None,
     };
     assert_eq!(
-        format_ast(&artifact_literal, 0),
+        format_expr(&artifact_literal, 0),
         "Relic { sigil: \"alpha\", power: 9 }"
     );
 
-    let artifact_empty = AST::ArtifactLiteral {
+    let artifact_empty = Expr::ArtifactLiteral {
         type_name: "Relic".into(),
         fields: vec![],
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&artifact_empty, 0), "Relic {}");
+    assert_eq!(format_expr(&artifact_empty, 0), "Relic {}");
 
-    let artifact_def = AST::ArtifactDef {
+    let artifact_def = Stmt::ArtifactDef {
         name: "Relic".into(),
         fields: vec![
             ArtifactField {
                 name: "sigil".into(),
                 field_type: Type::Rune,
-                line_info: None,
+                span: None,
             },
             ArtifactField {
                 name: "power".into(),
                 field_type: Type::Arcana,
-                line_info: None,
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let expected = concat!(
         "artifact Relic {\n",
         "    sigil: rune;\n",
         "    power: arcana;\n",
-        "}"
+        "};"
     );
-    assert_eq!(format_ast(&artifact_def, 0), expected);
+    assert_eq!(format_stmt(&artifact_def, 0), expected);
 
-    let list_access = AST::IndexAccess {
-        target: var("sigils"),
+    let list_access = Expr::IndexAccess {
+        target: Box::new(var("sigils")),
         index: arcana(0),
-        line_info: None,
+        span: None,
     };
-    assert_eq!(format_ast(&list_access, 0), "sigils[0]");
+    assert_eq!(format_expr(&list_access, 0), "sigils[0]");
 
-    let func_call = AST::FuncCall {
+    let func_call = Expr::FuncCall {
         name: "summon".into(),
-        args: vec![AST::Rune("echo".into(), None), AST::Arcana(1, None)],
-        line_info: None,
+        args: vec![Expr::Rune("echo".into(), None), Expr::Arcana(1, None)],
+        span: None,
     };
-    assert_eq!(format_ast(&func_call, 0), "summon(\"echo\", 1)");
+    assert_eq!(format_expr(&func_call, 0), "summon(\"echo\", 1)");
 }
 
 #[test]
 fn format_control_flow_and_functions() {
-    let block = AST::Block(
-        vec![AST::Statement(
-            Box::new(AST::Reveal(var("sigil"), None)),
-            None,
-        )],
-        None,
-    );
-    assert_eq!(format_ast(&block, 0), "{\n    reveal sigil;\n}");
+    let block = Stmt::Block(vec![reveal(var("sigil"))], None);
+    assert_eq!(format_stmt(&block, 0), "{\n    reveal sigil;\n};");
 
-    let oracle = AST::Oracle {
+    let oracle = Expr::Oracle {
         is_match: false,
         conditionals: Vec::new(),
         branches: vec![
-            AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, None)],
+            OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, None))],
                 guard: None,
-                body: Box::new(AST::Reveal(var("spark"), None)),
-                line_info: None,
+                body: reveal(var("spark")),
+                span: None,
             },
-            AST::Comment("// fallback".into(), None),
-            AST::OracleBranch {
-                pattern: vec![AST::OracleDontCareItem(None)],
+            OracleBranch {
+                pattern: vec![Pattern::DontCare(None)],
                 guard: None,
-                body: Box::new(AST::Reveal(Box::new(AST::Rune("wild".into(), None)), None)),
-                line_info: None,
+                body: reveal(rune("wild")),
+                span: None,
             },
-            AST::OracleBranch {
+            OracleBranch {
                 pattern: vec![],
                 guard: None,
-                body: Box::new(AST::Reveal(abyss(), None)),
-                line_info: None,
+                body: reveal(Expr::Abyss(None)),
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let oracle_expected = concat!(
         "oracle {\n",
-        "    (1) => reveal spark\n",
-        "    // fallback\n",
-        "    (_) => reveal \"wild\"\n",
-        "    _ => reveal\n",
+        "    (1) => reveal spark;\n",
+        "    (_) => reveal \"wild\";\n",
+        "    _ => reveal;\n",
         "}"
     );
-    assert_eq!(format_ast(&oracle, 0), oracle_expected);
+    assert_eq!(format_expr(&oracle, 0), oracle_expected);
 
-    let oracle_with_ward = AST::Oracle {
+    let oracle_with_ward = Expr::Oracle {
         is_match: true,
-        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+        conditionals: vec![ConditionalAssignment {
             variable: "__match_0".into(),
-            expression: var("count"),
-            line_info: None,
+            expression: Box::new(var("count")),
+            span: None,
         }],
         branches: vec![
-            AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, None)],
-                guard: Some(Box::new(AST::GreaterThan(var("count"), arcana(0), None))),
-                body: Box::new(AST::Reveal(Box::new(AST::Rune("ready".into(), None)), None)),
-                line_info: None,
+            OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, None))],
+                guard: Some(Expr::GreaterThan(Box::new(var("count")), arcana(0), None)),
+                body: reveal(rune("ready")),
+                span: None,
             },
-            AST::OracleBranch {
-                pattern: vec![AST::OracleDontCareItem(None)],
+            OracleBranch {
+                pattern: vec![Pattern::DontCare(None)],
                 guard: None,
-                body: Box::new(AST::Reveal(Box::new(AST::Rune("idle".into(), None)), None)),
-                line_info: None,
+                body: reveal(rune("idle")),
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let oracle_with_ward_expected = concat!(
         "oracle (count) {\n",
-        "    (1) ward count > 0 => reveal \"ready\"\n",
-        "    (_) => reveal \"idle\"\n",
+        "    (1) ward count > 0 => reveal \"ready\";\n",
+        "    (_) => reveal \"idle\";\n",
         "}"
     );
-    assert_eq!(format_ast(&oracle_with_ward, 0), oracle_with_ward_expected);
+    assert_eq!(format_expr(&oracle_with_ward, 0), oracle_with_ward_expected);
 
-    let oracle_with_scroll_pattern = AST::Oracle {
+    let oracle_with_scroll_pattern = Expr::Oracle {
         is_match: true,
-        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+        conditionals: vec![ConditionalAssignment {
             variable: "__match_0".into(),
-            expression: var("xs"),
-            line_info: None,
+            expression: Box::new(var("xs")),
+            span: None,
         }],
         branches: vec![
-            AST::OracleBranch {
-                pattern: vec![AST::OracleScrollPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Scroll {
                     elements: vec![],
-                    line_info: None,
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(Box::new(AST::Rune("empty".into(), None)), None)),
-                line_info: None,
+                body: reveal(rune("empty")),
+                span: None,
             },
-            AST::OracleBranch {
-                pattern: vec![AST::OracleScrollPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Scroll {
                     elements: vec![
-                        AST::Var("head".into(), None),
-                        AST::OracleScrollRest {
+                        Pattern::Expr(var("head")),
+                        Pattern::Rest {
                             name: Some("rest".into()),
-                            line_info: None,
+                            span: None,
                         },
                     ],
-                    line_info: None,
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(var("head"), None)),
-                line_info: None,
+                body: reveal(var("head")),
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let oracle_with_scroll_pattern_expected = concat!(
         "oracle (xs) {\n",
-        "    [] => reveal \"empty\"\n",
-        "    [head, ..rest] => reveal head\n",
+        "    [] => reveal \"empty\";\n",
+        "    [head, ..rest] => reveal head;\n",
         "}"
     );
     assert_eq!(
-        format_ast(&oracle_with_scroll_pattern, 0),
+        format_expr(&oracle_with_scroll_pattern, 0),
         oracle_with_scroll_pattern_expected
     );
 
-    let oracle_with_artifact_pattern = AST::Oracle {
+    let oracle_with_artifact_pattern = Expr::Oracle {
         is_match: true,
-        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+        conditionals: vec![ConditionalAssignment {
             variable: "__match_0".into(),
-            expression: var("hero"),
-            line_info: None,
+            expression: Box::new(var("hero")),
+            span: None,
         }],
         branches: vec![
             // Shorthand `Player { name }` (one binding, sub-pattern is
             // `Var(name)` matching the field name).
-            AST::OracleBranch {
-                pattern: vec![AST::OracleArtifactPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Artifact {
                     type_name: "Player".into(),
-                    fields: vec![("name".into(), AST::Var("name".into(), None))],
-                    line_info: None,
+                    fields: vec![("name".into(), Pattern::Expr(var("name")))],
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(var("name"), None)),
-                line_info: None,
+                body: reveal(var("name")),
+                span: None,
             },
             // Explicit field with literal compare and a trailing binding.
-            AST::OracleBranch {
-                pattern: vec![AST::OracleArtifactPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Artifact {
                     type_name: "Player".into(),
                     fields: vec![
-                        ("name".into(), AST::Rune("Ardyn".into(), None)),
-                        ("health".into(), AST::Var("health".into(), None)),
+                        ("name".into(), Pattern::Expr(rune("Ardyn"))),
+                        ("health".into(), Pattern::Expr(var("health"))),
                     ],
-                    line_info: None,
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(var("health"), None)),
-                line_info: None,
+                body: reveal(var("health")),
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let oracle_with_artifact_pattern_expected = concat!(
         "oracle (hero) {\n",
-        "    Player { name } => reveal name\n",
-        "    Player { name: \"Ardyn\", health } => reveal health\n",
+        "    Player { name } => reveal name;\n",
+        "    Player { name: \"Ardyn\", health } => reveal health;\n",
         "}"
     );
     assert_eq!(
-        format_ast(&oracle_with_artifact_pattern, 0),
+        format_expr(&oracle_with_artifact_pattern, 0),
         oracle_with_artifact_pattern_expected
     );
 
-    let oracle_with_lexicon_pattern = AST::Oracle {
+    let oracle_with_lexicon_pattern = Expr::Oracle {
         is_match: true,
-        conditionals: vec![abyss_core::ast::ConditionalAssignment {
+        conditionals: vec![ConditionalAssignment {
             variable: "__match_0".into(),
-            expression: var("config"),
-            line_info: None,
+            expression: Box::new(var("config")),
+            span: None,
         }],
         branches: vec![
             // Empty `{}` — matches any lexicon.
-            AST::OracleBranch {
-                pattern: vec![AST::OracleLexiconPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Lexicon {
                     entries: vec![],
-                    line_info: None,
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(rune("a lexicon"), None)),
-                line_info: None,
+                body: reveal(rune("a lexicon")),
+                span: None,
             },
             // Two-key shape with a binding and a literal compare.
-            AST::OracleBranch {
-                pattern: vec![AST::OracleLexiconPattern {
+            OracleBranch {
+                pattern: vec![Pattern::Lexicon {
                     entries: vec![
-                        ("name".into(), AST::Var("n".into(), None)),
-                        ("port".into(), AST::Arcana(8080, None)),
+                        ("name".into(), Pattern::Expr(var("n"))),
+                        ("port".into(), Pattern::Expr(Expr::Arcana(8080, None))),
                     ],
-                    line_info: None,
+                    span: None,
                 }],
                 guard: None,
-                body: Box::new(AST::Reveal(var("n"), None)),
-                line_info: None,
+                body: reveal(var("n")),
+                span: None,
             },
         ],
-        line_info: None,
+        span: None,
     };
     let oracle_with_lexicon_pattern_expected = concat!(
         "oracle (config) {\n",
-        "    {} => reveal \"a lexicon\"\n",
-        "    { \"name\": n, \"port\": 8080 } => reveal n\n",
+        "    {} => reveal \"a lexicon\";\n",
+        "    { \"name\": n, \"port\": 8080 } => reveal n;\n",
         "}"
     );
     assert_eq!(
-        format_ast(&oracle_with_lexicon_pattern, 0),
+        format_expr(&oracle_with_lexicon_pattern, 0),
         oracle_with_lexicon_pattern_expected
     );
 
-    let orbit = AST::Orbit {
-        params: vec![AST::OrbitParam {
+    let block_stmt = Stmt::Block(vec![reveal(var("sigil"))], None);
+    let orbit = Stmt::Orbit {
+        params: vec![OrbitParam {
             name: "i".into(),
-            start: arcana(0),
-            end: arcana(2),
+            start: *arcana(0),
+            end: *arcana(2),
             op: "..".into(),
-            line_info: None,
+            span: None,
         }],
-        body: Box::new(block.clone()),
-        line_info: None,
+        body: Box::new(block_stmt.clone()),
+        span: None,
     };
-    let orbit_expected = concat!("orbit (i = 0..2)", "{\n    reveal sigil;\n}");
-    assert_eq!(format_ast(&orbit, 0), orbit_expected);
+    let orbit_expected = concat!("orbit (i = 0..2)", "{\n    reveal sigil;\n};");
+    assert_eq!(format_stmt(&orbit, 0), orbit_expected);
 
-    let resume_named = AST::Resume(Some("outer".into()), None);
-    assert_eq!(format_ast(&resume_named, 0), "resume outer");
-    let resume_default = AST::Resume(None, None);
-    assert_eq!(format_ast(&resume_default, 0), "resume");
+    let resume_named = Stmt::Resume(Some("outer".into()), None);
+    assert_eq!(format_stmt(&resume_named, 0), "resume outer;");
+    let resume_default = Stmt::Resume(None, None);
+    assert_eq!(format_stmt(&resume_default, 0), "resume;");
 
-    let eject_named = AST::Eject(Some("inner".into()), None);
-    assert_eq!(format_ast(&eject_named, 0), "eject inner");
-    let eject_default = AST::Eject(None, None);
-    assert_eq!(format_ast(&eject_default, 0), "eject");
+    let eject_named = Stmt::Eject(Some("inner".into()), None);
+    assert_eq!(format_stmt(&eject_named, 0), "eject inner;");
+    let eject_default = Stmt::Eject(None, None);
+    assert_eq!(format_stmt(&eject_default, 0), "eject;");
 
-    let method = AST::Engrave {
+    let method = Stmt::Engrave {
         name: "ignite".into(),
         params: vec![
-            AST::EngraveParam {
+            EngraveParam {
                 name: "core".into(),
                 param_type: Type::Artifact("Pyre".into()),
                 is_morph: true,
-                line_info: None,
+                span: None,
             },
-            AST::EngraveParam {
+            EngraveParam {
                 name: "ember".into(),
                 param_type: Type::Arcana,
                 is_morph: false,
-                line_info: None,
+                span: None,
             },
         ],
         return_type: Type::Arcana,
-        body: Box::new(block.clone()),
+        body: Box::new(block_stmt.clone()),
         method_target: Some(ArtifactMethodTarget {
             artifact: "Pyre".into(),
             requires_morph: true,
         }),
-        line_info: None,
+        span: None,
     };
     let method_expected = concat!(
         "engrave Pyre::ignite(morph core, ember: arcana) -> arcana ",
-        "{\n    reveal sigil;\n}"
+        "{\n    reveal sigil;\n};"
     );
-    assert_eq!(format_ast(&method, 0), method_expected);
+    assert_eq!(format_stmt(&method, 0), method_expected);
 
-    let function = AST::Engrave {
+    let function = Stmt::Engrave {
         name: "summon".into(),
-        params: vec![AST::EngraveParam {
+        params: vec![EngraveParam {
             name: "target".into(),
             param_type: Type::Scroll,
             is_morph: false,
-            line_info: None,
+            span: None,
         }],
         return_type: Type::Abyss,
-        body: Box::new(block),
+        body: Box::new(block_stmt),
         method_target: None,
-        line_info: None,
+        span: None,
     };
-    let function_expected = concat!("engrave summon(target: scroll) ", "{\n    reveal sigil;\n}");
-    assert_eq!(format_ast(&function, 0), function_expected);
+    let function_expected = concat!(
+        "engrave summon(target: scroll) ",
+        "{\n    reveal sigil;\n};"
+    );
+    assert_eq!(format_stmt(&function, 0), function_expected);
+}
+
+#[test]
+fn format_pattern_shapes() {
+    assert_eq!(format_pattern(&Pattern::DontCare(None), 0), "_");
+    assert_eq!(
+        format_pattern(
+            &Pattern::Rest {
+                name: None,
+                span: None
+            },
+            0
+        ),
+        ".."
+    );
+    assert_eq!(
+        format_pattern(
+            &Pattern::Rest {
+                name: Some("tail".into()),
+                span: None
+            },
+            0
+        ),
+        "..tail"
+    );
+    assert_eq!(
+        format_pattern(
+            &Pattern::Artifact {
+                type_name: "Tag".into(),
+                fields: vec![],
+                span: None
+            },
+            0
+        ),
+        "Tag {}"
+    );
 }
 
 #[test]
@@ -485,14 +520,16 @@ fn format_type_keyword_variants() {
     ];
 
     for (index, (ty, expected)) in variants.into_iter().enumerate() {
-        let param = AST::EngraveParam {
+        let is_morph = index % 2 == 1;
+        let stmt = Stmt::VarAssign {
             name: format!("param{}", index),
-            param_type: ty,
-            is_morph: index % 2 == 1,
-            line_info: None,
+            value: *arcana(1),
+            var_type: ty,
+            is_morph,
+            span: None,
         };
-        let prefix = if index % 2 == 1 { "morph " } else { "" };
-        let expected_text = format!("{}param{}: {}", prefix, index, expected);
-        assert_eq!(format_ast(&param, 0), expected_text);
+        let prefix = if is_morph { "morph " } else { "" };
+        let expected_text = format!("forge {}param{}: {} = 1;", prefix, index, expected);
+        assert_eq!(format_stmt(&stmt, 0), expected_text);
     }
 }

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{did_you_mean, label_with_suggestions};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{EngraveParam, Expr, Span, Stmt, Type};
 use std::collections::HashMap;
 
 // Value and artifact types moved to dedicated modules; re-exported here so
@@ -16,7 +16,7 @@ pub type BuiltinFunc =
 
 pub type BuiltinMethodHandler = fn(
     &mut RuntimeEnv,
-    &AST,
+    &Expr,
     Option<&str>,
     Value,
     Vec<CallArg>,
@@ -40,9 +40,9 @@ pub enum Callable {
 #[derive(Debug, Clone)]
 pub struct EngravedFunction {
     pub name: String,
-    pub params: Vec<AST>,
+    pub params: Vec<EngraveParam>,
     pub return_type: Type,
-    pub body: Box<AST>,
+    pub body: Box<Stmt>,
     pub line_info: Option<Span>,
 }
 
@@ -371,7 +371,7 @@ mod tests {
             name: name.to_string(),
             params: Vec::new(),
             return_type: Type::Abyss,
-            body: Box::new(AST::Abyss(None)),
+            body: Box::new(Stmt::Expr(Expr::Abyss(None), None)),
             line_info: None,
         }
     }

--- a/crates/abyss-interpreter/src/eval/artifacts.rs
+++ b/crates/abyss-interpreter/src/eval/artifacts.rs
@@ -1,7 +1,7 @@
 use crate::env::{
     ArtifactFieldSchema, ArtifactHandle, ArtifactSchema, ArtifactValue, RuntimeEnv, Value,
 };
-use abyss_core::ast::{AST, ArtifactField, Span, Type};
+use abyss_core::ast::{ArtifactField, Expr, Span, Type};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -42,7 +42,7 @@ pub(crate) fn ensure_field_type_known(
                         "Artifact field {} references undefined type {}",
                         field.name, name
                     ),
-                    field.line_info,
+                    field.span,
                 ))
             }
         }
@@ -63,7 +63,7 @@ pub(crate) fn build_artifact_schema(
         if !seen.insert(field.name.clone()) {
             return Err(EvalError::InvalidOperation(
                 format!("Field '{}' is defined multiple times", field.name),
-                field.line_info.or(*line_info),
+                field.span.or(*line_info),
             ));
         }
         ensure_field_type_known(field, env, name)?;
@@ -225,12 +225,12 @@ pub(crate) fn compare_artifacts(
     Ok(true)
 }
 
-/// Extracts the base variable name and field access chain from an AST expression.
+/// Extracts the base variable name and field access chain from an Expr expression.
 ///
-/// This function only handles direct variable access (`AST::Var`) and field access chains
-/// (`AST::FieldAccess`). It returns `None` for all other AST node types, including:
-/// - Method calls (`AST::MethodCall`)
-/// - Index access (`AST::IndexAccess`)
+/// This function only handles direct variable access (`Expr::Var`) and field access chains
+/// (`Expr::FieldAccess`). It returns `None` for all other Expr node types, including:
+/// - Method calls (`Expr::MethodCall`)
+/// - Index access (`Expr::IndexAccess`)
 /// - Other complex expressions
 ///
 /// This means that mutable method calls are only supported on direct variable/field access
@@ -239,10 +239,10 @@ pub(crate) fn compare_artifacts(
 ///
 /// Returns `Some((base_var_name, field_chain))` if the expression can be traced to a variable,
 /// or `None` if the expression type is not supported for mutability tracking.
-pub(crate) fn collect_field_chain(ast: &AST) -> Option<(String, Vec<String>)> {
+pub(crate) fn collect_field_chain(ast: &Expr) -> Option<(String, Vec<String>)> {
     match ast {
-        AST::Var(name, _) => Some((name.clone(), Vec::new())),
-        AST::FieldAccess { target, field, .. } => {
+        Expr::Var(name, _) => Some((name.clone(), Vec::new())),
+        Expr::FieldAccess { target, field, .. } => {
             let (base, mut chain) = collect_field_chain(target)?;
             chain.push(field.clone());
             Some((base, chain))
@@ -369,14 +369,14 @@ mod tests {
         let valid = ArtifactField {
             name: "ally".into(),
             field_type: Type::Artifact("Glyph".into()),
-            line_info: None,
+            span: None,
         };
         ensure_field_type_known(&valid, &env, "Sigil").unwrap();
 
         let invalid = ArtifactField {
             name: "unknown".into(),
             field_type: Type::Artifact("Missing".into()),
-            line_info: None,
+            span: None,
         };
         let err = ensure_field_type_known(&invalid, &env, "Sigil").unwrap_err();
         match err {
@@ -392,12 +392,12 @@ mod tests {
             ArtifactField {
                 name: "power".into(),
                 field_type: Type::Arcana,
-                line_info: None,
+                span: None,
             },
             ArtifactField {
                 name: "power".into(),
                 field_type: Type::Arcana,
-                line_info: None,
+                span: None,
             },
         ];
 
@@ -480,21 +480,21 @@ mod tests {
 
     #[test]
     fn collect_field_chain_tracks_nested_field_access() {
-        let chain = AST::FieldAccess {
-            target: Box::new(AST::FieldAccess {
-                target: Box::new(AST::Var("sigil".into(), None)),
+        let chain = Expr::FieldAccess {
+            target: Box::new(Expr::FieldAccess {
+                target: Box::new(Expr::Var("sigil".into(), None)),
                 field: "inner".into(),
-                line_info: None,
+                span: None,
             }),
             field: "deep".into(),
-            line_info: None,
+            span: None,
         };
 
         let (base, fields) = collect_field_chain(&chain).expect("chain should resolve");
         assert_eq!(base, "sigil");
         assert_eq!(fields, vec!["inner".to_string(), "deep".to_string()]);
 
-        assert!(collect_field_chain(&AST::Abyss(None)).is_none());
+        assert!(collect_field_chain(&Expr::Abyss(None)).is_none());
     }
 
     #[test]

--- a/crates/abyss-interpreter/src/eval/collections.rs
+++ b/crates/abyss-interpreter/src/eval/collections.rs
@@ -1,5 +1,5 @@
 use crate::env::Value;
-use abyss_core::ast::AST;
+use abyss_core::ast::Expr;
 use abyss_core::ast::Span;
 
 use super::result::{EvalError, EvalResult};
@@ -38,17 +38,17 @@ pub(crate) fn expect_rune_key(
     }
 }
 
-pub(crate) fn collect_index_chain(target: &AST) -> Option<(String, Vec<&AST>)> {
+pub(crate) fn collect_index_chain(target: &Expr) -> Option<(String, Vec<&Expr>)> {
     let mut indices = Vec::new();
     let mut current = target;
 
     loop {
         match current {
-            AST::Var(name, _) => {
+            Expr::Var(name, _) => {
                 indices.reverse();
                 return Some((name.clone(), indices));
             }
-            AST::IndexAccess { target, index, .. } => {
+            Expr::IndexAccess { target, index, .. } => {
                 indices.push(index.as_ref());
                 current = target.as_ref();
             }
@@ -115,40 +115,40 @@ mod tests {
 
     #[test]
     fn collect_index_chain_extracts_indices_in_order() {
-        let ast = AST::IndexAccess {
-            target: Box::new(AST::IndexAccess {
-                target: Box::new(AST::Var("sigils".into(), None)),
-                index: Box::new(AST::Arcana(1, None)),
-                line_info: None,
+        let ast = Expr::IndexAccess {
+            target: Box::new(Expr::IndexAccess {
+                target: Box::new(Expr::Var("sigils".into(), None)),
+                index: Box::new(Expr::Arcana(1, None)),
+                span: None,
             }),
-            index: Box::new(AST::Rune("beta".into(), None)),
-            line_info: None,
+            index: Box::new(Expr::Rune("beta".into(), None)),
+            span: None,
         };
 
         let (name, indices) = collect_index_chain(&ast).expect("expected chain");
         assert_eq!(name, "sigils");
         assert_eq!(indices.len(), 2);
         match indices[0] {
-            AST::Arcana(value, _) => assert_eq!(*value, 1),
+            Expr::Arcana(value, _) => assert_eq!(*value, 1),
             other => panic!("Unexpected first index: {:?}", other),
         }
         match indices[1] {
-            AST::Rune(value, _) => assert_eq!(value, "beta"),
+            Expr::Rune(value, _) => assert_eq!(value, "beta"),
             other => panic!("Unexpected second index: {:?}", other),
         }
     }
 
     #[test]
     fn collect_index_chain_handles_non_chain_inputs() {
-        let var = AST::Var("sigils".into(), None);
+        let var = Expr::Var("sigils".into(), None);
         let (name, indices) = collect_index_chain(&var).expect("var should be recognized");
         assert_eq!(name, "sigils");
         assert!(indices.is_empty());
 
-        let field_access = AST::FieldAccess {
-            target: Box::new(AST::Var("sigils".into(), None)),
+        let field_access = Expr::FieldAccess {
+            target: Box::new(Expr::Var("sigils".into(), None)),
             field: "core".into(),
-            line_info: None,
+            span: None,
         };
         assert!(collect_index_chain(&field_access).is_none());
     }

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::diagnostics::did_you_mean_hint;
 use crate::env::{CallArg, Callable, EngravedFunction, RuntimeEnv, Value};
 use crate::stdlib::methods;
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{Expr, Span, Type};
 
 use super::artifacts::{
     collect_field_chain, compare_artifacts, ensure_field_exists, expect_artifact_from_eval,
@@ -19,56 +19,60 @@ use super::values::{
     convert_to_typed_value, describe_value, eval_result_to_value_checked, value_to_eval_result,
 };
 
-pub(crate) fn try_evaluate_expression(
-    ast: &AST,
-    env: &mut RuntimeEnv,
-) -> Result<Option<EvalResult>, EvalError> {
-    let result = match ast {
-        AST::Omen(value, _) => return Ok(Some(EvalResult::data(Value::Omen(*value)))),
-        AST::Arcana(value, _) => return Ok(Some(EvalResult::data(Value::Arcana(*value)))),
-        AST::Aether(value, _) => return Ok(Some(EvalResult::data(Value::Aether(*value)))),
-        AST::Rune(value, _) => {
-            return Ok(Some(EvalResult::data(Value::Rune(Rc::new(value.clone())))));
+/// Evaluates an expression in the given environment.
+///
+/// Returns an [`EvalResult`] rather than a bare [`Value`] because an
+/// expression may contain an `oracle` whose arm body triggers control
+/// flow (`reveal` / `resume` / `eject`) that must propagate outward.
+pub(crate) fn evaluate_expr(expr: &Expr, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError> {
+    let result = match expr {
+        Expr::Omen(value, _) => return Ok(EvalResult::data(Value::Omen(*value))),
+        Expr::Arcana(value, _) => return Ok(EvalResult::data(Value::Arcana(*value))),
+        Expr::Aether(value, _) => return Ok(EvalResult::data(Value::Aether(*value))),
+        Expr::Rune(value, _) => {
+            return Ok(EvalResult::data(Value::Rune(Rc::new(value.clone()))));
         }
-        AST::Abyss(_) => return Ok(Some(EvalResult::abyss())),
-        AST::ListLiteral {
+        Expr::Abyss(_) => return Ok(EvalResult::abyss()),
+        Expr::ListLiteral {
             elements,
-            line_info,
+            span: line_info,
         } => {
             let mut evaluated = Vec::with_capacity(elements.len());
             for element in elements {
                 evaluated.push(eval_result_to_value_checked(
-                    statements::evaluate(element, env)?,
+                    evaluate_expr(element, env)?,
                     *line_info,
                 )?);
             }
             EvalResult::data(Value::Scroll(Rc::new(RefCell::new(evaluated))))
         }
-        AST::MapLiteral { entries, line_info } => {
+        Expr::MapLiteral {
+            entries,
+            span: line_info,
+        } => {
             let mut map = HashMap::new();
             for (key, expr) in entries {
-                let value =
-                    eval_result_to_value_checked(statements::evaluate(expr, env)?, *line_info)?;
+                let value = eval_result_to_value_checked(evaluate_expr(expr, env)?, *line_info)?;
                 map.insert(key.clone(), value);
             }
             EvalResult::data(Value::Lexicon(Rc::new(RefCell::new(map))))
         }
-        AST::ArtifactLiteral {
+        Expr::ArtifactLiteral {
             type_name,
             fields,
-            line_info,
+            span: line_info,
         } => instantiate_artifact_literal(env, type_name, fields, line_info)?,
-        AST::FieldAccess {
+        Expr::FieldAccess {
             target,
             field,
-            line_info,
+            span: line_info,
         } => {
-            let value = statements::evaluate(target, env)?;
+            let value = evaluate_expr(target, env)?;
             let handle = expect_artifact_from_eval(value, line_info)?;
             let field_value = read_artifact_field(env, &handle, field, line_info)?;
             EvalResult::data(field_value)
         }
-        AST::Add(left, right, line_info) => binary_numeric_op(
+        Expr::Add(left, right, line_info) => binary_numeric_op(
             env,
             left,
             right,
@@ -77,7 +81,7 @@ pub(crate) fn try_evaluate_expression(
             |l, r| l + r,
             Some(|l: String, r: String| format!("{}{}", l, r)),
         )?,
-        AST::Sub(left, right, line_info) => binary_numeric_op(
+        Expr::Sub(left, right, line_info) => binary_numeric_op(
             env,
             left,
             right,
@@ -86,7 +90,7 @@ pub(crate) fn try_evaluate_expression(
             |l, r| l - r,
             None,
         )?,
-        AST::Mul(left, right, line_info) => binary_numeric_op(
+        Expr::Mul(left, right, line_info) => binary_numeric_op(
             env,
             left,
             right,
@@ -95,7 +99,7 @@ pub(crate) fn try_evaluate_expression(
             |l, r| l * r,
             None,
         )?,
-        AST::Div(left, right, line_info) => binary_numeric_op(
+        Expr::Div(left, right, line_info) => binary_numeric_op(
             env,
             left,
             right,
@@ -104,7 +108,7 @@ pub(crate) fn try_evaluate_expression(
             |l, r| l / r,
             None,
         )?,
-        AST::Mod(left, right, line_info) => binary_numeric_op(
+        Expr::Mod(left, right, line_info) => binary_numeric_op(
             env,
             left,
             right,
@@ -113,61 +117,59 @@ pub(crate) fn try_evaluate_expression(
             |l, r| l % r,
             None,
         )?,
-        AST::PowArcana(left, right, line_info) => match (
-            statements::evaluate(left, env)?,
-            statements::evaluate(right, env)?,
-        ) {
-            (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => {
-                if r < 0 {
-                    return Err(EvalError::NegativeExponent(*line_info));
+        Expr::PowArcana(left, right, line_info) => {
+            match (evaluate_expr(left, env)?, evaluate_expr(right, env)?) {
+                (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => {
+                    if r < 0 {
+                        return Err(EvalError::NegativeExponent(*line_info));
+                    }
+                    EvalResult::data(Value::Arcana(l.pow(r as u32)))
                 }
-                EvalResult::data(Value::Arcana(l.pow(r as u32)))
+                _ => {
+                    return Err(EvalError::InvalidOperation(
+                        "PowArcana operation requires two Arcana!".to_string(),
+                        *line_info,
+                    ));
+                }
             }
-            _ => {
-                return Err(EvalError::InvalidOperation(
-                    "PowArcana operation requires two Arcana!".to_string(),
-                    *line_info,
-                ));
+        }
+        Expr::PowAether(left, right, line_info) => {
+            match (evaluate_expr(left, env)?, evaluate_expr(right, env)?) {
+                (EvalResult::Data(Value::Aether(l)), EvalResult::Data(Value::Aether(r))) => {
+                    EvalResult::data(Value::Aether(l.powf(r)))
+                }
+                _ => {
+                    return Err(EvalError::InvalidOperation(
+                        "PowAether operation requires two Aether!".to_string(),
+                        *line_info,
+                    ));
+                }
             }
-        },
-        AST::PowAether(left, right, line_info) => match (
-            statements::evaluate(left, env)?,
-            statements::evaluate(right, env)?,
-        ) {
-            (EvalResult::Data(Value::Aether(l)), EvalResult::Data(Value::Aether(r))) => {
-                EvalResult::data(Value::Aether(l.powf(r)))
-            }
-            _ => {
-                return Err(EvalError::InvalidOperation(
-                    "PowAether operation requires two Aether!".to_string(),
-                    *line_info,
-                ));
-            }
-        },
-        AST::Equal(left, right, line_info) => compare_values(env, left, right, line_info, true)?,
-        AST::NotEqual(left, right, line_info) => {
+        }
+        Expr::Equal(left, right, line_info) => compare_values(env, left, right, line_info, true)?,
+        Expr::NotEqual(left, right, line_info) => {
             compare_values(env, left, right, line_info, false)?
         }
-        AST::LessThan(left, right, line_info) => {
+        Expr::LessThan(left, right, line_info) => {
             order_values(env, left, right, line_info, |l, r| l < r)?
         }
-        AST::LessThanOrEqual(left, right, line_info) => {
+        Expr::LessThanOrEqual(left, right, line_info) => {
             order_values(env, left, right, line_info, |l, r| l <= r)?
         }
-        AST::GreaterThan(left, right, line_info) => {
+        Expr::GreaterThan(left, right, line_info) => {
             order_values(env, left, right, line_info, |l, r| l > r)?
         }
-        AST::GreaterThanOrEqual(left, right, line_info) => {
+        Expr::GreaterThanOrEqual(left, right, line_info) => {
             order_values(env, left, right, line_info, |l, r| l >= r)?
         }
-        AST::LogicalAnd(left, right, line_info) => {
+        Expr::LogicalAnd(left, right, line_info) => {
             logical_op(env, left, right, line_info, |l, r| l && r)?
         }
-        AST::LogicalOr(left, right, line_info) => {
+        Expr::LogicalOr(left, right, line_info) => {
             logical_op(env, left, right, line_info, |l, r| l || r)?
         }
-        AST::LogicalNot(expr, line_info) => {
-            let result = statements::evaluate(expr, env)?;
+        Expr::LogicalNot(expr, line_info) => {
+            let result = evaluate_expr(expr, env)?;
             match result {
                 EvalResult::Data(Value::Omen(value)) => EvalResult::data(Value::Omen(!value)),
                 _ => {
@@ -178,19 +180,19 @@ pub(crate) fn try_evaluate_expression(
                 }
             }
         }
-        AST::Var(name, line_info) => match env.get_var(name) {
+        Expr::Var(name, line_info) => match env.get_var(name) {
             Some(var_info) => value_to_eval_result(&var_info.value),
             None => {
                 return Err(env.undefined_variable_error(name, *line_info));
             }
         },
-        AST::IndexAccess {
+        Expr::IndexAccess {
             target,
             index,
-            line_info,
+            span: line_info,
         } => {
-            let collection = statements::evaluate(target, env)?;
-            let idx_value = statements::evaluate(index, env)?;
+            let collection = evaluate_expr(target, env)?;
+            let idx_value = evaluate_expr(index, env)?;
             match collection {
                 EvalResult::Data(Value::Scroll(items)) => {
                     let idx = expect_arcana_index(&idx_value, line_info)?;
@@ -218,28 +220,42 @@ pub(crate) fn try_evaluate_expression(
                 }
             }
         }
-        AST::FuncCall {
+        Expr::FuncCall {
             name,
             args,
-            line_info,
+            span: line_info,
         } => evaluate_function_call(env, name, args, line_info)?,
-        AST::MethodCall {
+        Expr::MethodCall {
             receiver,
             method,
             args,
-            line_info,
+            span: line_info,
         } => evaluate_method_call(env, receiver, method, args, line_info)?,
-        AST::OracleDontCareItem(_) => EvalResult::data(Value::Omen(true)),
-        _ => return Ok(None),
+        Expr::Oracle {
+            is_match,
+            conditionals,
+            branches,
+            span: line_info,
+        } => {
+            // Push the oracle's local scope, run the body, and unconditionally
+            // pop on the way out — including error paths — so a failing
+            // scrutinee, pattern, ward, or body cannot leak a scope back into
+            // the REPL. The helper itself uses `?` freely.
+            env.push_scope();
+            let result =
+                super::patterns::evaluate_oracle(*is_match, conditionals, branches, line_info, env);
+            env.pop_scope();
+            result?
+        }
     };
 
-    Ok(Some(result))
+    Ok(result)
 }
 
 fn binary_numeric_op<TArc, TAether>(
     env: &mut RuntimeEnv,
-    left: &AST,
-    right: &AST,
+    left: &Expr,
+    right: &Expr,
     line_info: &Option<Span>,
     arcana_op: TArc,
     aether_op: TAether,
@@ -249,8 +265,8 @@ where
     TArc: FnOnce(i64, i64) -> i64,
     TAether: FnOnce(f64, f64) -> f64,
 {
-    let left_result = statements::evaluate(left, env)?;
-    let right_result = statements::evaluate(right, env)?;
+    let left_result = evaluate_expr(left, env)?;
+    let right_result = evaluate_expr(right, env)?;
 
     match (left_result, right_result) {
         (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => {
@@ -278,7 +294,7 @@ where
 fn instantiate_artifact_literal(
     env: &mut RuntimeEnv,
     type_name: &str,
-    fields: &[(String, AST)],
+    fields: &[(String, Expr)],
     line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let schema = lookup_schema_by_name(env, type_name, line_info)?.clone();
@@ -294,7 +310,7 @@ fn instantiate_artifact_literal(
         }
 
         let field_schema = ensure_field_exists(&schema, field_name, line_info)?;
-        let evaluated = statements::evaluate(expr, env)?;
+        let evaluated = evaluate_expr(expr, env)?;
         let typed_value = convert_to_typed_value(evaluated, &field_schema.field_type, line_info)?;
         values.insert(field_name.clone(), typed_value);
     }
@@ -325,13 +341,13 @@ fn instantiate_artifact_literal(
 
 fn compare_values(
     env: &mut RuntimeEnv,
-    left: &AST,
-    right: &AST,
+    left: &Expr,
+    right: &Expr,
     line_info: &Option<Span>,
     equality: bool,
 ) -> Result<EvalResult, EvalError> {
-    let left_result = statements::evaluate(left, env)?;
-    let right_result = statements::evaluate(right, env)?;
+    let left_result = evaluate_expr(left, env)?;
+    let right_result = evaluate_expr(right, env)?;
 
     let comparison = match (left_result, right_result) {
         (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => l == r,
@@ -356,16 +372,16 @@ fn compare_values(
 
 fn order_values<F>(
     env: &mut RuntimeEnv,
-    left: &AST,
-    right: &AST,
+    left: &Expr,
+    right: &Expr,
     line_info: &Option<Span>,
     comparator: F,
 ) -> Result<EvalResult, EvalError>
 where
     F: FnOnce(f64, f64) -> bool,
 {
-    let left_result = statements::evaluate(left, env)?;
-    let right_result = statements::evaluate(right, env)?;
+    let left_result = evaluate_expr(left, env)?;
+    let right_result = evaluate_expr(right, env)?;
 
     match (left_result, right_result) {
         (EvalResult::Data(Value::Arcana(l)), EvalResult::Data(Value::Arcana(r))) => Ok(
@@ -383,16 +399,16 @@ where
 
 fn logical_op<F>(
     env: &mut RuntimeEnv,
-    left: &AST,
-    right: &AST,
+    left: &Expr,
+    right: &Expr,
     line_info: &Option<Span>,
     op: F,
 ) -> Result<EvalResult, EvalError>
 where
     F: FnOnce(bool, bool) -> bool,
 {
-    let left_result = statements::evaluate(left, env)?;
-    let right_result = statements::evaluate(right, env)?;
+    let left_result = evaluate_expr(left, env)?;
+    let right_result = evaluate_expr(right, env)?;
 
     match (left_result, right_result) {
         (EvalResult::Data(Value::Omen(l)), EvalResult::Data(Value::Omen(r))) => {
@@ -407,13 +423,13 @@ where
 
 fn evaluate_method_call(
     env: &mut RuntimeEnv,
-    receiver: &AST,
+    receiver: &Expr,
     method_name: &str,
-    args: &[AST],
+    args: &[Expr],
     line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
-    let receiver_result = statements::evaluate(receiver, env)?;
-    let receiver_var_name = if let AST::Var(var_name, _) = receiver {
+    let receiver_result = evaluate_expr(receiver, env)?;
+    let receiver_var_name = if let Expr::Var(var_name, _) = receiver {
         Some(var_name.clone())
     } else {
         None
@@ -421,8 +437,8 @@ fn evaluate_method_call(
 
     let mut evaluated_args = Vec::with_capacity(args.len());
     for arg in args {
-        let evaluated_arg = statements::evaluate(arg, env)?;
-        let var_name = if let AST::Var(var_name, _) = arg {
+        let evaluated_arg = evaluate_expr(arg, env)?;
+        let var_name = if let Expr::Var(var_name, _) = arg {
             Some(var_name.clone())
         } else {
             None
@@ -464,7 +480,7 @@ fn evaluate_method_call(
 
 fn ensure_method_receiver_mutability(
     env: &RuntimeEnv,
-    receiver: &AST,
+    receiver: &Expr,
     artifact_name: &str,
     method_name: &str,
     line_info: &Option<Span>,
@@ -497,7 +513,7 @@ fn ensure_method_receiver_mutability(
 
 fn evaluate_artifact_method_call(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<String>,
     receiver_handle: crate::env::ArtifactHandle,
     method_name: &str,
@@ -551,7 +567,7 @@ fn evaluate_artifact_method_call(
 fn evaluate_function_call(
     env: &mut RuntimeEnv,
     name: &str,
-    args: &[AST],
+    args: &[Expr],
     line_info: &Option<Span>,
 ) -> Result<EvalResult, EvalError> {
     let callable = match env.get_function(name) {
@@ -563,8 +579,8 @@ fn evaluate_function_call(
 
     let mut evaluated_args = Vec::new();
     for arg in args {
-        let evaluated_arg = statements::evaluate(arg, env)?;
-        let var_name = if let AST::Var(var_name, _) = arg {
+        let evaluated_arg = evaluate_expr(arg, env)?;
+        let var_name = if let Expr::Var(var_name, _) = arg {
             Some(var_name.clone())
         } else {
             None
@@ -606,23 +622,8 @@ fn evaluate_engraved_function(
     }
 
     for (evaluated_arg, param) in eval_args.into_iter().zip(params.iter()) {
-        let (param_name, param_type, is_morph_param) = match param {
-            AST::EngraveParam {
-                name,
-                param_type,
-                is_morph,
-                ..
-            } => (name, param_type, *is_morph),
-            _ => {
-                return Err(EvalError::InvalidOperation(
-                    format!(
-                        "Expected EngraveParam in function definition: {}",
-                        function.name
-                    ),
-                    *line_info,
-                ));
-            }
-        };
+        let (param_name, param_type, is_morph_param) =
+            (&param.name, &param.param_type, param.is_morph);
         let value = if is_morph_param {
             convert_morph_param_value(evaluated_arg, param_type, line_info)?
         } else {
@@ -727,22 +728,22 @@ mod tests {
     #[test]
     fn test_pow_arcana_negative_exponent() {
         let mut env = RuntimeEnv::new();
-        let left = AST::Arcana(2, dummy_line_info());
-        let right = AST::Arcana(-1, dummy_line_info());
-        let expr = AST::PowArcana(Box::new(left), Box::new(right), dummy_line_info());
+        let left = Expr::Arcana(2, dummy_line_info());
+        let right = Expr::Arcana(-1, dummy_line_info());
+        let expr = Expr::PowArcana(Box::new(left), Box::new(right), dummy_line_info());
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(result, Err(EvalError::NegativeExponent(_))));
     }
 
     #[test]
     fn test_pow_aether_invalid_types() {
         let mut env = RuntimeEnv::new();
-        let left = AST::Arcana(2, dummy_line_info()); // Should be Aether
-        let right = AST::Aether(2.0, dummy_line_info());
-        let expr = AST::PowAether(Box::new(left), Box::new(right), dummy_line_info());
+        let left = Expr::Arcana(2, dummy_line_info()); // Should be Aether
+        let right = Expr::Aether(2.0, dummy_line_info());
+        let expr = Expr::PowAether(Box::new(left), Box::new(right), dummy_line_info());
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("requires two Aether")
@@ -752,10 +753,10 @@ mod tests {
     #[test]
     fn test_logical_not_invalid_type() {
         let mut env = RuntimeEnv::new();
-        let operand = AST::Arcana(1, dummy_line_info()); // Should be Omen
-        let expr = AST::LogicalNot(Box::new(operand), dummy_line_info());
+        let operand = Expr::Arcana(1, dummy_line_info()); // Should be Omen
+        let expr = Expr::LogicalNot(Box::new(operand), dummy_line_info());
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("requires Omen")
@@ -765,18 +766,18 @@ mod tests {
     #[test]
     fn test_index_access_out_of_bounds() {
         let mut env = RuntimeEnv::new();
-        let scroll = AST::ListLiteral {
+        let scroll = Expr::ListLiteral {
             elements: vec![],
-            line_info: dummy_line_info(),
+            span: dummy_line_info(),
         };
-        let index = AST::Arcana(0, dummy_line_info());
-        let expr = AST::IndexAccess {
+        let index = Expr::Arcana(0, dummy_line_info());
+        let expr = Expr::IndexAccess {
             target: Box::new(scroll),
             index: Box::new(index),
-            line_info: dummy_line_info(),
+            span: dummy_line_info(),
         };
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(
             result,
             Err(EvalError::ScrollIndexOutOfBounds(_, _))
@@ -796,13 +797,13 @@ mod tests {
             None,
         );
 
-        let expr = AST::IndexAccess {
-            target: Box::new(AST::Var("lex".to_string(), dummy_line_info())),
-            index: Box::new(AST::Rune("missing".to_string(), dummy_line_info())),
-            line_info: dummy_line_info(),
+        let expr = Expr::IndexAccess {
+            target: Box::new(Expr::Var("lex".to_string(), dummy_line_info())),
+            index: Box::new(Expr::Rune("missing".to_string(), dummy_line_info())),
+            span: dummy_line_info(),
         };
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(
             result,
             Err(EvalError::MissingLexiconKey(key, _)) if key == "missing"
@@ -812,15 +813,15 @@ mod tests {
     #[test]
     fn test_index_access_invalid_target() {
         let mut env = RuntimeEnv::new();
-        let target = AST::Arcana(1, dummy_line_info()); // Not a collection
-        let index = AST::Arcana(0, dummy_line_info());
-        let expr = AST::IndexAccess {
+        let target = Expr::Arcana(1, dummy_line_info()); // Not a collection
+        let index = Expr::Arcana(0, dummy_line_info());
+        let expr = Expr::IndexAccess {
             target: Box::new(target),
             index: Box::new(index),
-            line_info: dummy_line_info(),
+            span: dummy_line_info(),
         };
 
-        let result = try_evaluate_expression(&expr, &mut env);
+        let result = evaluate_expr(&expr, &mut env);
         assert!(matches!(
             result,
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("only supported for scroll or lexicon")

--- a/crates/abyss-interpreter/src/eval/patterns.rs
+++ b/crates/abyss-interpreter/src/eval/patterns.rs
@@ -1,23 +1,24 @@
 //! Oracle evaluation and pattern matching.
 //!
-//! Hosts the `AST::Oracle` machinery extracted from `statements.rs`:
-//! scrutinee evaluation, per-branch scope handling, and the three
-//! destructuring shapes (scroll, artifact, lexicon) with their shared
-//! literal-compare fallback. [`evaluate_oracle`] is the only entry point;
-//! the caller (the `AST::Oracle` arm in [`super::statements::evaluate`])
-//! pushes the outer oracle scope before calling and pops it after.
+//! Hosts the `Expr::Oracle` machinery: scrutinee evaluation, per-branch
+//! scope handling, and the three destructuring shapes (scroll, artifact,
+//! lexicon) with their shared literal-compare fallback.
+//! [`evaluate_oracle`] is the only entry point; the caller (the
+//! `Expr::Oracle` arm in [`super::expressions::evaluate_expr`]) pushes
+//! the outer oracle scope before calling and pops it after.
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::env::{RuntimeEnv, Value};
-use abyss_core::ast::{AST, ConditionalAssignment, Span, Type};
+use abyss_core::ast::{ConditionalAssignment, Expr, OracleBranch, Pattern, Span, Stmt, Type};
 
 use super::artifacts::{lookup_schema_from_handle, read_artifact_field, values_equal};
+use super::expressions::evaluate_expr;
 use super::result::{EvalError, EvalResult};
 use super::statements::evaluate;
 
-/// Inner body of `AST::Oracle` evaluation. The caller is responsible for
+/// Inner body of `Expr::Oracle` evaluation. The caller is responsible for
 /// pairing one `env.push_scope()` before this call with one `env.pop_scope()`
 /// after, so every `?` inside this helper unwinds through the caller and the
 /// outer oracle scope is always popped.
@@ -29,13 +30,13 @@ use super::statements::evaluate;
 pub(super) fn evaluate_oracle(
     is_match: bool,
     conditionals: &[ConditionalAssignment],
-    branches: &[AST],
+    branches: &[OracleBranch],
     line_info: &Option<Span>,
     env: &mut RuntimeEnv,
 ) -> Result<EvalResult, EvalError> {
     let mut scrutinee_values = Vec::with_capacity(conditionals.len());
     for conditional in conditionals {
-        let result = evaluate(&conditional.expression, env)?;
+        let result = evaluate_expr(&conditional.expression, env)?;
         let stored = match result {
             EvalResult::Data(Value::Arcana(n)) => Value::Arcana(n),
             EvalResult::Data(Value::Aether(n)) => Value::Aether(n),
@@ -67,27 +68,13 @@ pub(super) fn evaluate_oracle(
     }
 
     for branch in branches {
-        if let AST::Comment(_, _) = branch {
-            continue;
-        }
-
-        let AST::OracleBranch {
-            pattern,
-            guard,
-            body,
-            line_info,
-        } = branch
-        else {
-            continue;
-        };
-
         env.push_scope();
         let outcome = evaluate_oracle_branch(
             is_match,
-            pattern,
-            guard.as_deref(),
-            body,
-            line_info,
+            &branch.pattern,
+            branch.guard.as_ref(),
+            &branch.body,
+            &branch.span,
             &scrutinee_values,
             env,
         );
@@ -116,9 +103,9 @@ pub(super) fn evaluate_oracle(
 /// caller pops.
 fn evaluate_oracle_branch(
     is_match: bool,
-    pattern: &[AST],
-    guard: Option<&AST>,
-    body: &AST,
+    pattern: &[Pattern],
+    guard: Option<&Expr>,
+    body: &Stmt,
     line_info: &Option<Span>,
     scrutinee_values: &[Value],
     env: &mut RuntimeEnv,
@@ -139,7 +126,7 @@ fn evaluate_oracle_branch(
 
         let mut matched = true;
         for (idx, pattern_elem) in pattern.iter().enumerate() {
-            if let AST::OracleDontCareItem(_) = pattern_elem {
+            if let Pattern::DontCare(_) = pattern_elem {
                 continue;
             }
 
@@ -155,7 +142,7 @@ fn evaluate_oracle_branch(
             // identifier up as an expression). The binding lives in the
             // per-branch scope the caller pushed, so it is visible to the
             // ward and body of this arm and disappears when the arm finishes.
-            if let AST::Var(name, var_line) = pattern_elem {
+            if let Pattern::Expr(Expr::Var(name, var_line)) = pattern_elem {
                 env.set_var(
                     name.clone(),
                     scrutinee_value.clone(),
@@ -168,9 +155,9 @@ fn evaluate_oracle_branch(
 
             // Scroll-shape pattern destructures the scrutinee — which must be
             // a `scroll` — into its elements, with optional trailing rest.
-            if let AST::OracleScrollPattern {
+            if let Pattern::Scroll {
                 elements,
-                line_info: scroll_line,
+                span: scroll_line,
             } = pattern_elem
             {
                 if !match_scroll_pattern(elements, scrutinee_value, scroll_line, env)? {
@@ -184,10 +171,10 @@ fn evaluate_oracle_branch(
             // be an artifact of the named type — by pulling out the listed
             // fields. Fields not listed are not matched against, so partial
             // patterns like `Player { name }` are valid.
-            if let AST::OracleArtifactPattern {
+            if let Pattern::Artifact {
                 type_name,
                 fields,
-                line_info: artifact_line,
+                span: artifact_line,
             } = pattern_elem
             {
                 if !match_artifact_pattern(type_name, fields, scrutinee_value, artifact_line, env)?
@@ -202,9 +189,9 @@ fn evaluate_oracle_branch(
             // be a `lexicon` — by pulling out the listed keys. Keys not
             // listed are not matched against, so partial patterns like
             // `{ "name": n }` are valid; an absent key falls through.
-            if let AST::OracleLexiconPattern {
+            if let Pattern::Lexicon {
                 entries,
-                line_info: lexicon_line,
+                span: lexicon_line,
             } = pattern_elem
             {
                 if !match_lexicon_pattern(entries, scrutinee_value, lexicon_line, env)? {
@@ -214,7 +201,15 @@ fn evaluate_oracle_branch(
                 continue;
             }
 
-            let pattern_result = evaluate(pattern_elem, env)?;
+            let Pattern::Expr(pattern_expr) = pattern_elem else {
+                // Only a trailing rest segment reaches here, and it is
+                // meaningless outside a scroll pattern.
+                return Err(EvalError::InvalidOperation(
+                    "Rest segment is only valid inside a scroll pattern".to_string(),
+                    *line_info,
+                ));
+            };
+            let pattern_result = evaluate_expr(pattern_expr, env)?;
 
             match (scrutinee_value, pattern_result) {
                 (Value::Arcana(cond_n), EvalResult::Data(Value::Arcana(pat_n))) => {
@@ -252,8 +247,14 @@ fn evaluate_oracle_branch(
         matched
     } else {
         let mut all_true = true;
-        for pattern_expr in pattern {
-            match evaluate(pattern_expr, env)? {
+        for pattern_elem in pattern {
+            let Pattern::Expr(pattern_expr) = pattern_elem else {
+                return Err(EvalError::InvalidOperation(
+                    "Oracle if-else pattern must be an expression".to_string(),
+                    *line_info,
+                ));
+            };
+            match evaluate_expr(pattern_expr, env)? {
                 EvalResult::Data(Value::Omen(true)) => continue,
                 EvalResult::Data(Value::Omen(false)) => {
                     all_true = false;
@@ -276,7 +277,7 @@ fn evaluate_oracle_branch(
     let matched = if matched {
         match guard {
             None => true,
-            Some(guard_expr) => match evaluate(guard_expr, env)? {
+            Some(guard_expr) => match evaluate_expr(guard_expr, env)? {
                 EvalResult::Data(Value::Omen(b)) => b,
                 other => {
                     return Err(EvalError::InvalidOperation(
@@ -339,7 +340,7 @@ fn type_of_scrutinee(value: &Value) -> Type {
 /// element. Mid-list rests like `[a, .., last]` are rejected here so the
 /// matching logic stays linear.
 fn match_scroll_pattern(
-    elements: &[AST],
+    elements: &[Pattern],
     scrutinee_value: &Value,
     line_info: &Option<Span>,
     env: &mut RuntimeEnv,
@@ -361,7 +362,7 @@ fn match_scroll_pattern(
 
     let mut rest_index: Option<usize> = None;
     for (idx, element) in elements.iter().enumerate() {
-        if matches!(element, AST::OracleScrollRest { .. }) {
+        if matches!(element, Pattern::Rest { .. }) {
             if rest_index.is_some() {
                 return Err(EvalError::InvalidOperation(
                     "Scroll pattern may contain at most one rest segment".to_string(),
@@ -397,8 +398,8 @@ fn match_scroll_pattern(
     for (idx, element) in elements.iter().take(prefix_len).enumerate() {
         let elem_value = &scroll_values[idx];
         match element {
-            AST::OracleDontCareItem(_) => continue,
-            AST::Var(name, var_line) => {
+            Pattern::DontCare(_) => continue,
+            Pattern::Expr(Expr::Var(name, var_line)) => {
                 env.set_var(
                     name.clone(),
                     elem_value.clone(),
@@ -407,33 +408,38 @@ fn match_scroll_pattern(
                     *var_line,
                 );
             }
-            AST::OracleScrollPattern {
+            Pattern::Scroll {
                 elements: nested_elements,
-                line_info: nested_line,
+                span: nested_line,
             } => {
                 if !match_scroll_pattern(nested_elements, elem_value, nested_line, env)? {
                     return Ok(false);
                 }
             }
-            AST::OracleArtifactPattern {
+            Pattern::Artifact {
                 type_name,
                 fields,
-                line_info: artifact_line,
+                span: artifact_line,
             } => {
                 if !match_artifact_pattern(type_name, fields, elem_value, artifact_line, env)? {
                     return Ok(false);
                 }
             }
-            AST::OracleLexiconPattern {
+            Pattern::Lexicon {
                 entries,
-                line_info: lexicon_line,
+                span: lexicon_line,
             } => {
                 if !match_lexicon_pattern(entries, elem_value, lexicon_line, env)? {
                     return Ok(false);
                 }
             }
-            other => {
-                let pattern_result = evaluate(other, env)?;
+            Pattern::Rest { .. } => {
+                // Validated above: at most one rest, trailing only. A rest
+                // inside the prefix loop is unreachable.
+                unreachable!("rest segment handled after the prefix loop")
+            }
+            Pattern::Expr(other) => {
+                let pattern_result = evaluate_expr(other, env)?;
                 if !values_match_for_pattern(elem_value, &pattern_result, line_info)? {
                     return Ok(false);
                 }
@@ -442,9 +448,9 @@ fn match_scroll_pattern(
     }
 
     if let Some(idx) = rest_index
-        && let AST::OracleScrollRest {
+        && let Pattern::Rest {
             name: Some(name),
-            line_info: rest_line,
+            span: rest_line,
         } = &elements[idx]
     {
         let tail: Vec<Value> = scroll_values.iter().skip(prefix_len).cloned().collect();
@@ -488,7 +494,7 @@ fn match_scroll_pattern(
 /// distinction proves valuable.
 fn match_artifact_pattern(
     type_name: &str,
-    fields: &[(String, AST)],
+    fields: &[(String, Pattern)],
     scrutinee_value: &Value,
     line_info: &Option<Span>,
     env: &mut RuntimeEnv,
@@ -541,23 +547,29 @@ fn match_artifact_pattern(
         let field_value = read_artifact_field(env, &handle, field_name, line_info)?;
 
         match sub_pattern {
-            AST::OracleDontCareItem(_) => continue,
-            AST::Var(name, var_line) => {
+            Pattern::DontCare(_) => continue,
+            Pattern::Rest { .. } => {
+                return Err(EvalError::InvalidOperation(
+                    "Rest segment is only valid inside a scroll pattern".to_string(),
+                    *line_info,
+                ));
+            }
+            Pattern::Expr(Expr::Var(name, var_line)) => {
                 let bound_type = type_of_scrutinee(&field_value);
                 env.set_var(name.clone(), field_value, bound_type, false, *var_line);
             }
-            AST::OracleScrollPattern {
+            Pattern::Scroll {
                 elements,
-                line_info: scroll_line,
+                span: scroll_line,
             } => {
                 if !match_scroll_pattern(elements, &field_value, scroll_line, env)? {
                     return Ok(false);
                 }
             }
-            AST::OracleArtifactPattern {
+            Pattern::Artifact {
                 type_name: nested_type,
                 fields: nested_fields,
-                line_info: nested_line,
+                span: nested_line,
             } => {
                 if !match_artifact_pattern(
                     nested_type,
@@ -569,15 +581,15 @@ fn match_artifact_pattern(
                     return Ok(false);
                 }
             }
-            AST::OracleLexiconPattern {
+            Pattern::Lexicon {
                 entries: nested_entries,
-                line_info: nested_line,
+                span: nested_line,
             } => {
                 if !match_lexicon_pattern(nested_entries, &field_value, nested_line, env)? {
                     return Ok(false);
                 }
             }
-            other => {
+            Pattern::Expr(other) => {
                 // For literal-compare on an artifact field we want a deep,
                 // type-aware equality so nested scrolls / lexicons / artifacts
                 // compare by structure (matching the existing `==` semantics
@@ -585,7 +597,7 @@ fn match_artifact_pattern(
                 // `values_match_for_pattern` would only handle scalars and
                 // emit a misleading "Scroll pattern element" error for any
                 // non-scalar field.
-                let pattern_result = evaluate(other, env)?;
+                let pattern_result = evaluate_expr(other, env)?;
                 let pattern_value = match pattern_result {
                     EvalResult::Data(value) => value,
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
@@ -624,7 +636,7 @@ fn match_artifact_pattern(
 /// `Tag {}` matches any artifact of type `Tag`. Keys not mentioned in the
 /// pattern are intentionally unrestricted.
 fn match_lexicon_pattern(
-    entries: &[(String, AST)],
+    entries: &[(String, Pattern)],
     scrutinee_value: &Value,
     line_info: &Option<Span>,
     env: &mut RuntimeEnv,
@@ -652,23 +664,29 @@ fn match_lexicon_pattern(
         };
 
         match sub_pattern {
-            AST::OracleDontCareItem(_) => continue,
-            AST::Var(name, var_line) => {
+            Pattern::DontCare(_) => continue,
+            Pattern::Rest { .. } => {
+                return Err(EvalError::InvalidOperation(
+                    "Rest segment is only valid inside a scroll pattern".to_string(),
+                    *line_info,
+                ));
+            }
+            Pattern::Expr(Expr::Var(name, var_line)) => {
                 let bound_type = type_of_scrutinee(&entry_value);
                 env.set_var(name.clone(), entry_value, bound_type, false, *var_line);
             }
-            AST::OracleScrollPattern {
+            Pattern::Scroll {
                 elements,
-                line_info: scroll_line,
+                span: scroll_line,
             } => {
                 if !match_scroll_pattern(elements, &entry_value, scroll_line, env)? {
                     return Ok(false);
                 }
             }
-            AST::OracleArtifactPattern {
+            Pattern::Artifact {
                 type_name: nested_type,
                 fields: nested_fields,
-                line_info: nested_line,
+                span: nested_line,
             } => {
                 if !match_artifact_pattern(
                     nested_type,
@@ -680,19 +698,19 @@ fn match_lexicon_pattern(
                     return Ok(false);
                 }
             }
-            AST::OracleLexiconPattern {
+            Pattern::Lexicon {
                 entries: nested_entries,
-                line_info: nested_line,
+                span: nested_line,
             } => {
                 if !match_lexicon_pattern(nested_entries, &entry_value, nested_line, env)? {
                     return Ok(false);
                 }
             }
-            other => {
+            Pattern::Expr(other) => {
                 // Same deep-equality strategy as `match_artifact_pattern`'s
                 // literal-compare path so non-scalar entry values compare
                 // structurally and match the runtime `==` semantics.
-                let pattern_result = evaluate(other, env)?;
+                let pattern_result = evaluate_expr(other, env)?;
                 let pattern_value = match pattern_result {
                     EvalResult::Data(value) => value,
                     EvalResult::Revealed(_) | EvalResult::Resume(_) | EvalResult::Eject(_) => {
@@ -749,25 +767,25 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let conditional = ConditionalAssignment {
             variable: "sigil".into(),
-            expression: Box::new(AST::Arcana(1, line())),
-            line_info: line(),
+            expression: Box::new(Expr::Arcana(1, line())),
+            span: line(),
         };
 
-        let branch = AST::OracleBranch {
-            pattern: vec![AST::Arcana(1, line())],
+        let branch = OracleBranch {
+            pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
             guard: None,
-            body: Box::new(AST::Reveal(Box::new(AST::Arcana(42, line())), line())),
-            line_info: line(),
+            body: Stmt::Reveal(Expr::Arcana(42, line()), line()),
+            span: line(),
         };
 
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![conditional],
             branches: vec![branch],
-            line_info: line(),
+            span: line(),
         };
 
-        let result = evaluate(&oracle, &mut env).expect("oracle should succeed");
+        let result = evaluate_expr(&oracle, &mut env).expect("oracle should succeed");
         match result {
             EvalResult::Data(Value::Arcana(value)) => assert_eq!(value, 42),
             other => panic!("unexpected oracle result {:?}", other),
@@ -780,31 +798,34 @@ mod tests {
         let conditionals = vec![
             ConditionalAssignment {
                 variable: "flux".into(),
-                expression: Box::new(AST::Aether(1.5, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Aether(1.5, line())),
+                span: line(),
             },
             ConditionalAssignment {
                 variable: "word".into(),
-                expression: Box::new(AST::Rune("moon".into(), line())),
-                line_info: line(),
+                expression: Box::new(Expr::Rune("moon".into(), line())),
+                span: line(),
             },
         ];
 
-        let branch = AST::OracleBranch {
-            pattern: vec![AST::Aether(1.5, line()), AST::Rune("moon".into(), line())],
+        let branch = OracleBranch {
+            pattern: vec![
+                Pattern::Expr(Expr::Aether(1.5, line())),
+                Pattern::Expr(Expr::Rune("moon".into(), line())),
+            ],
             guard: None,
-            body: Box::new(AST::Arcana(7, line())),
-            line_info: line(),
+            body: Stmt::Expr(Expr::Arcana(7, line()), line()),
+            span: line(),
         };
 
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals,
             branches: vec![branch],
-            line_info: line(),
+            span: line(),
         };
 
-        let result = evaluate(&oracle, &mut env).expect("oracle should match scalars");
+        let result = evaluate_expr(&oracle, &mut env).expect("oracle should match scalars");
         match result {
             EvalResult::Data(Value::Arcana(value)) => assert_eq!(value, 7),
             other => panic!("unexpected oracle result {:?}", other),
@@ -814,21 +835,22 @@ mod tests {
     #[test]
     fn oracle_if_else_pattern_requires_omen_values() {
         let mut env = RuntimeEnv::new();
-        let pattern_branch = AST::OracleBranch {
-            pattern: vec![AST::Arcana(1, line())],
+        let pattern_branch = OracleBranch {
+            pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
             guard: None,
-            body: Box::new(AST::Arcana(0, line())),
-            line_info: line(),
+            body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+            span: line(),
         };
 
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: false,
             conditionals: vec![],
             branches: vec![pattern_branch],
-            line_info: line(),
+            span: line(),
         };
 
-        let err = evaluate(&oracle, &mut env).expect_err("if-else mode patterns must yield omens");
+        let err =
+            evaluate_expr(&oracle, &mut env).expect_err("if-else mode patterns must yield omens");
         match err {
             EvalError::InvalidOperation(message, _) => {
                 assert!(
@@ -846,25 +868,29 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let conditional = ConditionalAssignment {
             variable: "sigil".into(),
-            expression: Box::new(AST::Arcana(1, line())),
-            line_info: line(),
+            expression: Box::new(Expr::Arcana(1, line())),
+            span: line(),
         };
 
-        let branch = AST::OracleBranch {
-            pattern: vec![AST::Arcana(1, line()), AST::Arcana(2, line())],
+        let branch = OracleBranch {
+            pattern: vec![
+                Pattern::Expr(Expr::Arcana(1, line())),
+                Pattern::Expr(Expr::Arcana(2, line())),
+            ],
             guard: None,
-            body: Box::new(AST::Arcana(0, line())),
-            line_info: line(),
+            body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+            span: line(),
         };
 
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![conditional],
             branches: vec![branch],
-            line_info: line(),
+            span: line(),
         };
 
-        let err = evaluate(&oracle, &mut env).expect_err("pattern length mismatch should fail");
+        let err =
+            evaluate_expr(&oracle, &mut env).expect_err("pattern length mismatch should fail");
         match err {
             EvalError::InvalidOperation(message, _) => {
                 assert!(message.contains("pattern length"), "{}", message)
@@ -878,25 +904,25 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let conditional = ConditionalAssignment {
             variable: "arc".into(),
-            expression: Box::new(AST::Arcana(99, line())),
-            line_info: line(),
+            expression: Box::new(Expr::Arcana(99, line())),
+            span: line(),
         };
 
-        let branch = AST::OracleBranch {
-            pattern: vec![AST::OracleDontCareItem(line())],
+        let branch = OracleBranch {
+            pattern: vec![Pattern::DontCare(line())],
             guard: None,
-            body: Box::new(AST::Arcana(5, line())),
-            line_info: line(),
+            body: Stmt::Expr(Expr::Arcana(5, line()), line()),
+            span: line(),
         };
 
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![conditional],
-            branches: vec![AST::Comment("ignored".into(), line()), branch],
-            line_info: line(),
+            branches: vec![branch],
+            span: line(),
         };
 
-        let result = evaluate(&oracle, &mut env).expect("dont care branch should match");
+        let result = evaluate_expr(&oracle, &mut env).expect("dont care branch should match");
         match result {
             EvalResult::Data(Value::Arcana(value)) => assert_eq!(value, 5),
             other => panic!("unexpected oracle result {:?}", other),
@@ -915,78 +941,81 @@ mod tests {
         //    accepted Arcana / Aether / Rune / Omen list).
         let mut env = RuntimeEnv::new();
         assert_eq!(env.scope_depth(), 1);
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Abyss(line())),
-                line_info: line(),
+                expression: Box::new(Expr::Abyss(line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("scrutinee type error");
+        evaluate_expr(&oracle, &mut env).expect_err("scrutinee type error");
         assert_eq!(env.scope_depth(), 1, "scrutinee error leaked a scope");
 
         // 2. Pattern length mismatch (1 scrutinee vs 2-element pattern).
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line()), AST::Arcana(2, line())],
+            branches: vec![OracleBranch {
+                pattern: vec![
+                    Pattern::Expr(Expr::Arcana(1, line())),
+                    Pattern::Expr(Expr::Arcana(2, line())),
+                ],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("pattern length error");
+        evaluate_expr(&oracle, &mut env).expect_err("pattern length error");
         assert_eq!(env.scope_depth(), 1, "pattern length error leaked a scope");
 
         // 3. Pattern type mismatch (Arcana scrutinee vs Rune pattern).
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Rune("x".into(), line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Rune("x".into(), line()))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("pattern type error");
+        evaluate_expr(&oracle, &mut env).expect_err("pattern type error");
         assert_eq!(env.scope_depth(), 1, "pattern type error leaked a scope");
 
         // 4. If-else mode pattern that does not yield an omen.
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: false,
             conditionals: vec![],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("if-else mode pattern type error");
+        evaluate_expr(&oracle, &mut env).expect_err("if-else mode pattern type error");
         assert_eq!(
             env.scope_depth(),
             1,
@@ -995,42 +1024,42 @@ mod tests {
 
         // 5. Ward expression evaluates to a non-omen.
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
-                guard: Some(Box::new(AST::Arcana(42, line()))),
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
+                guard: Some(Expr::Arcana(42, line())),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("ward type error");
+        evaluate_expr(&oracle, &mut env).expect_err("ward type error");
         assert_eq!(env.scope_depth(), 1, "ward type error leaked a scope");
 
         // 6. Body raises an error after the pattern matched (undefined var).
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
                 guard: None,
-                body: Box::new(AST::Var("missing".into(), line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Var("missing".into(), line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("body undefined-variable error");
+        evaluate_expr(&oracle, &mut env).expect_err("body undefined-variable error");
         assert_eq!(env.scope_depth(), 1, "body error leaked a scope");
     }
 
@@ -1047,22 +1076,22 @@ mod tests {
         // A. Scrutinee expression itself fails — exercises
         //    `evaluate(&conditional.expression, env)?`.
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Var("missing".into(), line())),
-                line_info: line(),
+                expression: Box::new(Expr::Var("missing".into(), line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("scrutinee var lookup error");
+        evaluate_expr(&oracle, &mut env).expect_err("scrutinee var lookup error");
         assert_eq!(
             env.scope_depth(),
             1,
@@ -1071,34 +1100,34 @@ mod tests {
 
         // B. Match-mode pattern expression fails — exercises
         //    `evaluate(pattern, env)?` inside the pattern loop. We use
-        //    `AST::Add(Var("missing"), Arcana(1))` here rather than a bare
-        //    `AST::Var("missing", _)` because, after PR2's binding-pattern
+        //    `Expr::Add(Var("missing"), Arcana(1))` here rather than a bare
+        //    `Expr::Var("missing", _)` because, after PR2's binding-pattern
         //    work, a bare identifier in match-mode pattern position is
         //    intercepted as a fresh binding and never reaches `evaluate`.
         //    Wrapping the missing identifier inside an `Add` keeps the
         //    pattern an expression so the inner `evaluate` actually runs and
         //    can raise `UndefinedVariable`.
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Add(
-                    Box::new(AST::Var("missing".into(), line())),
-                    Box::new(AST::Arcana(1, line())),
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Add(
+                    Box::new(Expr::Var("missing".into(), line())),
+                    Box::new(Expr::Arcana(1, line())),
                     line(),
-                )],
+                ))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("match-mode pattern var lookup error");
+        evaluate_expr(&oracle, &mut env).expect_err("match-mode pattern var lookup error");
         assert_eq!(
             env.scope_depth(),
             1,
@@ -1108,18 +1137,18 @@ mod tests {
         // C. If-else-mode pattern expression fails — exercises
         //    `evaluate(pattern_expr, env)?` inside the all-true loop.
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: false,
             conditionals: vec![],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Var("missing".into(), line())],
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Var("missing".into(), line()))],
                 guard: None,
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("if-else-mode pattern var lookup error");
+        evaluate_expr(&oracle, &mut env).expect_err("if-else-mode pattern var lookup error");
         assert_eq!(
             env.scope_depth(),
             1,
@@ -1130,22 +1159,22 @@ mod tests {
         //    `evaluate(guard_expr.as_ref(), env)?` (the original bug site
         //    from PR #414, now folded into the central pop_scope).
         let mut env = RuntimeEnv::new();
-        let oracle = AST::Oracle {
+        let oracle = Expr::Oracle {
             is_match: true,
             conditionals: vec![ConditionalAssignment {
                 variable: "v".into(),
-                expression: Box::new(AST::Arcana(1, line())),
-                line_info: line(),
+                expression: Box::new(Expr::Arcana(1, line())),
+                span: line(),
             }],
-            branches: vec![AST::OracleBranch {
-                pattern: vec![AST::Arcana(1, line())],
-                guard: Some(Box::new(AST::Var("missing".into(), line()))),
-                body: Box::new(AST::Arcana(0, line())),
-                line_info: line(),
+            branches: vec![OracleBranch {
+                pattern: vec![Pattern::Expr(Expr::Arcana(1, line()))],
+                guard: Some(Expr::Var("missing".into(), line())),
+                body: Stmt::Expr(Expr::Arcana(0, line()), line()),
+                span: line(),
             }],
-            line_info: line(),
+            span: line(),
         };
-        evaluate(&oracle, &mut env).expect_err("ward var lookup error");
+        evaluate_expr(&oracle, &mut env).expect_err("ward var lookup error");
         assert_eq!(env.scope_depth(), 1, "ward `?` propagation leaked a scope");
     }
 }

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -1,5 +1,5 @@
 use crate::env::{ArtifactMethod, Callable, EngravedFunction, RuntimeEnv, Value};
-use abyss_core::ast::{AST, AssignmentOp, Span, Type};
+use abyss_core::ast::{AssignmentOp, Span, Stmt, Type};
 use std::rc::Rc;
 
 use super::artifacts::{
@@ -7,67 +7,30 @@ use super::artifacts::{
     expect_artifact_handle, lookup_schema_from_handle, missing_field_error,
 };
 use super::collections::{collect_index_chain, expect_arcana_index, expect_rune_key};
-use super::expressions::try_evaluate_expression;
-use super::patterns::evaluate_oracle;
+use super::expressions::evaluate_expr;
 use super::result::{EvalError, EvalResult};
 use super::values::{
     convert_to_typed_value, describe_value, eval_result_to_value_checked, extract_aether,
     extract_arcana, extract_omen, extract_rune,
 };
 
-/// Evaluates an abstract syntax tree (AST) node in the given environment.
+/// Evaluates a statement in the given environment.
 ///
-/// # Arguments
-///
-/// * `ast` - The AST node to be evaluated.
-/// * `env` - The environment containing variable and function bindings.
-///
-/// # Returns
-///
-/// The result of the evaluation, or an `EvalError` if an error occurs.
-pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError> {
-    if let Some(result) = try_evaluate_expression(ast, env)? {
-        return Ok(result);
-    }
-
-    match ast {
-        AST::Statement(node, _line_info) => evaluate(node, env),
-        AST::Omen(..)
-        | AST::Arcana(..)
-        | AST::Aether(..)
-        | AST::Rune(..)
-        | AST::Abyss(..)
-        | AST::ListLiteral { .. }
-        | AST::MapLiteral { .. }
-        | AST::Add(..)
-        | AST::Sub(..)
-        | AST::Mul(..)
-        | AST::Div(..)
-        | AST::Mod(..)
-        | AST::PowArcana(..)
-        | AST::PowAether(..)
-        | AST::Equal(..)
-        | AST::NotEqual(..)
-        | AST::LessThan(..)
-        | AST::LessThanOrEqual(..)
-        | AST::GreaterThan(..)
-        | AST::GreaterThanOrEqual(..)
-        | AST::LogicalAnd(..)
-        | AST::LogicalOr(..)
-        | AST::LogicalNot(..)
-        | AST::Var(..)
-        | AST::IndexAccess { .. }
-        | AST::FuncCall { .. }
-        | AST::MethodCall { .. } => unreachable!("expression nodes handled earlier"),
-        AST::VarAssign {
+/// Bare expressions in statement position arrive as [`Stmt::Expr`] and
+/// delegate to [`evaluate_expr`]; there is no longer a shared node type
+/// between the two, so each evaluator states its input in its signature.
+pub fn evaluate(stmt: &Stmt, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError> {
+    match stmt {
+        Stmt::Expr(expr, _span) => evaluate_expr(expr, env),
+        Stmt::VarAssign {
             name,
             value,
             var_type,
             is_morph,
-            line_info,
+            span: line_info,
         } => {
             ensure_type_known(var_type, env, line_info)?;
-            let evaluated_value = evaluate(value, env)?;
+            let evaluated_value = evaluate_expr(value, env)?;
             let stored_value = convert_to_typed_value(evaluated_value, var_type, line_info)?;
             env.set_var(
                 name.clone(),
@@ -78,13 +41,13 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             );
             Ok(EvalResult::abyss())
         }
-        AST::Assignment {
+        Stmt::Assignment {
             name,
             value,
             op,
-            line_info,
+            span: line_info,
         } => {
-            let evaluated_value = evaluate(value, env)?;
+            let evaluated_value = evaluate_expr(value, env)?;
             if let Some(var_info) = env.get_var_mut(name) {
                 if !var_info.is_morph {
                     return Err(EvalError::ImmutableAssignment(name.clone(), *line_info));
@@ -227,11 +190,11 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 Err(env.undefined_variable_error(name, *line_info))
             }
         }
-        AST::IndexAssignment {
+        Stmt::IndexAssignment {
             target,
             index,
             value,
-            line_info,
+            span: line_info,
         } => {
             let (base_name, nested_indices) = collect_index_chain(target).ok_or_else(|| {
                 EvalError::InvalidOperation(
@@ -242,11 +205,11 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
 
             let mut evaluated_indices = Vec::new();
             for idx_ast in nested_indices {
-                evaluated_indices.push(evaluate(idx_ast, env)?);
+                evaluated_indices.push(evaluate_expr(idx_ast, env)?);
             }
 
-            let final_index_value = evaluate(index, env)?;
-            let new_value = eval_result_to_value_checked(evaluate(value, env)?, *line_info)?;
+            let final_index_value = evaluate_expr(index, env)?;
+            let new_value = eval_result_to_value_checked(evaluate_expr(value, env)?, *line_info)?;
 
             let var_info = match env.get_var_mut(&base_name) {
                 Some(var_info) => var_info,
@@ -291,11 +254,11 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
 
             Ok(EvalResult::abyss())
         }
-        AST::FieldAssignment {
+        Stmt::FieldAssignment {
             target,
             field,
             value,
-            line_info,
+            span: line_info,
         } => {
             let (base_name, access_chain) = collect_field_chain(target).ok_or_else(|| {
                 EvalError::InvalidOperation(
@@ -304,7 +267,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 )
             })?;
 
-            let evaluated_value = evaluate(value, env)?;
+            let evaluated_value = evaluate_expr(value, env)?;
 
             let var_info = match env.get_var_mut(&base_name) {
                 Some(var_info) => var_info,
@@ -357,26 +320,11 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
 
             Ok(EvalResult::abyss())
         }
-        AST::Oracle {
-            is_match,
-            conditionals,
-            branches,
-            line_info,
-        } => {
-            // Push the oracle's local scope, run the body, and unconditionally
-            // pop on the way out — including error paths — so a failing
-            // scrutinee, pattern, ward, or body cannot leak a scope back into
-            // the REPL. The helper itself uses `?` freely.
-            env.push_scope();
-            let result = evaluate_oracle(*is_match, conditionals, branches, line_info, env);
-            env.pop_scope();
-            result
-        }
-        AST::Reveal(expr, _line_info) => {
-            let result = evaluate(expr, env)?;
+        Stmt::Reveal(expr, _span) => {
+            let result = evaluate_expr(expr, env)?;
             Ok(EvalResult::Revealed(Box::new(result)))
         }
-        AST::Block(statements, _line_info) => {
+        Stmt::Block(statements, _span) => {
             let mut last_result = EvalResult::abyss();
             for statement in statements {
                 let result = evaluate(statement, env)?;
@@ -391,11 +339,10 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             }
             Ok(last_result)
         }
-        AST::OracleDontCareItem(_line_info) => Ok(EvalResult::data(Value::Omen(true))),
-        AST::Orbit {
+        Stmt::Orbit {
             params,
             body,
-            line_info,
+            span: line_info,
         } => {
             if params.is_empty() {
                 loop {
@@ -413,16 +360,11 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                 }
 
                 Ok(EvalResult::abyss())
-            } else if let AST::OrbitParam {
-                name,
-                start,
-                end,
-                op,
-                ..
-            } = &params[0]
-            {
-                let start_value = evaluate(start, env)?;
-                let end_value = evaluate(end, env)?;
+            } else {
+                let param = &params[0];
+                let (name, start, end, op) = (&param.name, &param.start, &param.end, &param.op);
+                let start_value = evaluate_expr(start, env)?;
+                let end_value = evaluate_expr(end, env)?;
 
                 let start_num = extract_arcana(&start_value, line_info)?;
                 let end_num = extract_arcana(&end_value, line_info)?;
@@ -445,10 +387,10 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                         evaluate(body.as_ref(), env)?
                     } else {
                         evaluate(
-                            &AST::Orbit {
+                            &Stmt::Orbit {
                                 params: remaining_params,
                                 body: body.clone(),
-                                line_info: *line_info,
+                                span: *line_info,
                             },
                             env,
                         )?
@@ -483,33 +425,21 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
                     env.pop_scope();
                 }
                 Ok(EvalResult::abyss())
-            } else {
-                Err(EvalError::InvalidOperation(
-                    "Expected OrbitParam in Orbit".to_string(),
-                    *line_info,
-                ))
             }
         }
-        AST::Resume(identifier, _line_info) => Ok(EvalResult::Resume(identifier.clone())),
-        AST::Eject(identifier, _line_info) => Ok(EvalResult::Eject(identifier.clone())),
-        AST::Engrave {
+        Stmt::Resume(identifier, _span) => Ok(EvalResult::Resume(identifier.clone())),
+        Stmt::Eject(identifier, _span) => Ok(EvalResult::Eject(identifier.clone())),
+        Stmt::Engrave {
             name,
             params,
             return_type,
             body,
             method_target,
-            line_info,
+            span: line_info,
         } => {
             ensure_type_known(return_type, env, line_info)?;
             for param in params {
-                if let AST::EngraveParam {
-                    param_type,
-                    line_info: param_info,
-                    ..
-                } = param
-                {
-                    ensure_type_known(param_type, env, param_info)?;
-                }
+                ensure_type_known(&param.param_type, env, &param.span)?;
             }
             let function_name = if let Some(target) = method_target {
                 format!("{}::{}", target.artifact, name)
@@ -534,10 +464,10 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             }
             Ok(EvalResult::abyss())
         }
-        AST::ArtifactDef {
+        Stmt::ArtifactDef {
             name,
             fields,
-            line_info,
+            span: line_info,
         } => {
             if env.artifact_defined_in_current_scope(name) {
                 return Err(EvalError::InvalidOperation(
@@ -556,11 +486,7 @@ pub fn evaluate(ast: &AST, env: &mut RuntimeEnv) -> Result<EvalResult, EvalError
             );
             Ok(EvalResult::abyss())
         }
-        AST::Comment(_, _) => Ok(EvalResult::abyss()),
-        _ => Err(EvalError::InvalidOperation(
-            format!("Unsupported operation: {:?}", ast),
-            None,
-        )),
+        Stmt::Comment(_, _) => Ok(EvalResult::abyss()),
     }
 }
 
@@ -597,6 +523,7 @@ fn clone_indexed_child(
 mod tests {
     use super::*;
     use crate::eval::test_support::{artifact_handle, lexicon, register_artifact, rune, scroll};
+    use abyss_core::ast::Expr;
 
     fn line() -> Option<Span> {
         Some(Span::new(1, 1))
@@ -607,11 +534,11 @@ mod tests {
         let mut env = RuntimeEnv::new();
         env.set_var("sigil".into(), Value::Arcana(2), Type::Arcana, true, line());
 
-        let assignment = AST::Assignment {
+        let assignment = Stmt::Assignment {
             name: "sigil".into(),
-            value: Box::new(AST::Arcana(5, line())),
+            value: Expr::Arcana(5, line()),
             op: AssignmentOp::AddAssign,
-            line_info: line(),
+            span: line(),
         };
 
         evaluate(&assignment, &mut env).expect("assignment should succeed");
@@ -633,11 +560,11 @@ mod tests {
             line(),
         );
 
-        let assignment = AST::Assignment {
+        let assignment = Stmt::Assignment {
             name: "sigil".into(),
-            value: Box::new(AST::Arcana(5, line())),
+            value: Expr::Arcana(5, line()),
             op: AssignmentOp::Assign,
-            line_info: line(),
+            span: line(),
         };
 
         let err = evaluate(&assignment, &mut env).expect_err("immutable reassign should fail");
@@ -658,11 +585,11 @@ mod tests {
             line(),
         );
 
-        let index_assignment = AST::IndexAssignment {
-            target: Box::new(AST::Var("scroll".into(), line())),
-            index: Box::new(AST::Arcana(0, line())),
-            value: Box::new(AST::Arcana(99, line())),
-            line_info: line(),
+        let index_assignment = Stmt::IndexAssignment {
+            target: Expr::Var("scroll".into(), line()),
+            index: Expr::Arcana(0, line()),
+            value: Expr::Arcana(99, line()),
+            span: line(),
         };
 
         let err = evaluate(&index_assignment, &mut env).expect_err("immutable index assignment");
@@ -681,11 +608,11 @@ mod tests {
             line(),
         );
 
-        let field_assignment = AST::FieldAssignment {
-            target: Box::new(AST::Var("relic".into(), line())),
+        let field_assignment = Stmt::FieldAssignment {
+            target: Expr::Var("relic".into(), line()),
             field: "power".into(),
-            value: Box::new(AST::Arcana(2, line())),
-            line_info: line(),
+            value: Expr::Arcana(2, line()),
+            span: line(),
         };
 
         let err = evaluate(&field_assignment, &mut env).expect_err("immutable field assignment");
@@ -703,11 +630,11 @@ mod tests {
             line(),
         );
 
-        let index_assignment = AST::IndexAssignment {
-            target: Box::new(AST::Var("scroll".into(), line())),
-            index: Box::new(AST::Arcana(1, line())),
-            value: Box::new(AST::Arcana(99, line())),
-            line_info: line(),
+        let index_assignment = Stmt::IndexAssignment {
+            target: Expr::Var("scroll".into(), line()),
+            index: Expr::Arcana(1, line()),
+            value: Expr::Arcana(99, line()),
+            span: line(),
         };
 
         evaluate(&index_assignment, &mut env).expect("index assignment succeeds");
@@ -726,11 +653,11 @@ mod tests {
     #[test]
     fn field_assignment_requires_artifact_target() {
         let mut env = RuntimeEnv::new();
-        let assignment = AST::FieldAssignment {
-            target: Box::new(AST::Arcana(1, line())),
+        let assignment = Stmt::FieldAssignment {
+            target: Expr::Arcana(1, line()),
             field: "power".into(),
-            value: Box::new(AST::Arcana(2, line())),
-            line_info: line(),
+            value: Expr::Arcana(2, line()),
+            span: line(),
         };
 
         let err = evaluate(&assignment, &mut env).expect_err("non artifact target should fail");
@@ -743,11 +670,11 @@ mod tests {
     #[test]
     fn field_assignment_reports_missing_variable() {
         let mut env = RuntimeEnv::new();
-        let assignment = AST::FieldAssignment {
-            target: Box::new(AST::Var("missing".into(), line())),
+        let assignment = Stmt::FieldAssignment {
+            target: Expr::Var("missing".into(), line()),
             field: "power".into(),
-            value: Box::new(AST::Arcana(1, line())),
-            line_info: line(),
+            value: Expr::Arcana(1, line()),
+            span: line(),
         };
 
         let err = evaluate(&assignment, &mut env).expect_err("missing variable should error");
@@ -776,16 +703,16 @@ mod tests {
             line(),
         );
 
-        let target = AST::FieldAccess {
-            target: Box::new(AST::Var("sigil".into(), line())),
+        let target = Expr::FieldAccess {
+            target: Box::new(Expr::Var("sigil".into(), line())),
             field: "core".into(),
-            line_info: line(),
+            span: line(),
         };
-        let assignment = AST::FieldAssignment {
-            target: Box::new(target),
+        let assignment = Stmt::FieldAssignment {
+            target,
             field: "power".into(),
-            value: Box::new(AST::Arcana(10, line())),
-            line_info: line(),
+            value: Expr::Arcana(10, line()),
+            span: line(),
         };
 
         let err = evaluate(&assignment, &mut env).expect_err("non artifact segment should error");
@@ -821,16 +748,16 @@ mod tests {
             line(),
         );
 
-        let target = AST::FieldAccess {
-            target: Box::new(AST::Var("sigil".into(), line())),
+        let target = Expr::FieldAccess {
+            target: Box::new(Expr::Var("sigil".into(), line())),
             field: "core".into(),
-            line_info: line(),
+            span: line(),
         };
-        let assignment = AST::FieldAssignment {
-            target: Box::new(target),
+        let assignment = Stmt::FieldAssignment {
+            target,
             field: "power".into(),
-            value: Box::new(AST::Arcana(10, line())),
-            line_info: line(),
+            value: Expr::Arcana(10, line()),
+            span: line(),
         };
 
         evaluate(&assignment, &mut env).expect("field assignment succeeds");
@@ -883,10 +810,10 @@ mod tests {
     #[test]
     fn artifact_definition_creates_glyph_variable() {
         let mut env = RuntimeEnv::new();
-        let artifact = AST::ArtifactDef {
+        let artifact = Stmt::ArtifactDef {
             name: "Relic".into(),
             fields: Vec::new(),
-            line_info: line(),
+            span: line(),
         };
 
         evaluate(&artifact, &mut env).expect("artifact definition succeeds");

--- a/crates/abyss-interpreter/src/stdlib/methods/lexicon.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/lexicon.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{Expr, Span, Type};
 
 use super::{call_arg_to_value, ensure_mutable_receiver, method_table_for};
 
@@ -18,7 +18,7 @@ pub(super) fn register_methods(registry: &mut BuiltinMethodRegistry) {
 
 fn lexicon_tally(
     _env: &mut RuntimeEnv,
-    _receiver_ast: &AST,
+    _receiver_ast: &Expr,
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -38,7 +38,7 @@ fn lexicon_tally(
 
 fn lexicon_define(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -78,7 +78,7 @@ fn lexicon_define(
 
 fn lexicon_expunge(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -120,7 +120,7 @@ fn lexicon_expunge(
 
 fn lexicon_glossary(
     _env: &mut RuntimeEnv,
-    _receiver_ast: &AST,
+    _receiver_ast: &Expr,
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -173,7 +173,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let result = lexicon_tally(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             dummy_lexicon(),
             dummy_args(1),
@@ -190,7 +190,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let _result = lexicon_define(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             Some("lex"), // Mutable receiver needs a name
             dummy_lexicon(),
             dummy_args(1), // Needs 2
@@ -216,7 +216,7 @@ mod tests {
         // Now call with wrong args
         let result = lexicon_define(
             &mut env,
-            &AST::Var("lex".to_string(), None),
+            &Expr::Var("lex".to_string(), None),
             Some("lex"),
             dummy_lexicon(),
             dummy_args(1),
@@ -242,7 +242,7 @@ mod tests {
 
         let result = lexicon_expunge(
             &mut env,
-            &AST::Var("lex".to_string(), None),
+            &Expr::Var("lex".to_string(), None),
             Some("lex"),
             dummy_lexicon(),
             dummy_args(0), // Needs 1
@@ -260,7 +260,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let result = lexicon_glossary(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             dummy_lexicon(),
             dummy_args(1),

--- a/crates/abyss-interpreter/src/stdlib/methods/materia.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/materia.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{Expr, Span, Type};
 
 use super::{expect_glyph_argument, method_table_for};
 
@@ -13,7 +13,7 @@ pub(super) fn register_methods(registry: &mut BuiltinMethodRegistry) {
 
 fn materia_trans_method(
     _env: &mut RuntimeEnv,
-    _receiver_ast: &AST,
+    _receiver_ast: &Expr,
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -108,7 +108,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let result = materia_trans_method(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             Value::Abyss,
             vec![], // Needs 1
@@ -126,8 +126,14 @@ mod tests {
         // Pass a non-glyph (e.g. integer) as target type
         let args = dummy_args(Value::Arcana(1));
 
-        let result =
-            materia_trans_method(&mut env, &AST::Abyss(None), None, Value::Abyss, args, &None);
+        let result = materia_trans_method(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            Value::Abyss,
+            args,
+            &None,
+        );
 
         assert!(matches!(
             result,
@@ -140,8 +146,14 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let args = dummy_args(Value::Rune(Rc::new("unknown".to_string())));
 
-        let result =
-            materia_trans_method(&mut env, &AST::Abyss(None), None, Value::Abyss, args, &None);
+        let result = materia_trans_method(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            Value::Abyss,
+            args,
+            &None,
+        );
 
         assert!(matches!(
             result,

--- a/crates/abyss-interpreter/src/stdlib/methods/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/mod.rs
@@ -8,7 +8,7 @@ use crate::eval::artifacts::collect_field_chain;
 use crate::eval::values::describe_value;
 use crate::eval::values::eval_result_to_value_checked;
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{Expr, Span, Type};
 use std::collections::HashMap;
 
 pub fn get_all_builtin_methods() -> BuiltinMethodRegistry {
@@ -21,7 +21,7 @@ pub fn get_all_builtin_methods() -> BuiltinMethodRegistry {
 
 pub fn dispatch_builtin_method(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     method_name: &str,
@@ -102,7 +102,7 @@ pub(super) fn method_table_for(
 
 pub(super) fn ensure_mutable_receiver(
     env: &RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     collection_kind: &str,
     method_name: &str,
@@ -198,7 +198,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let result = dispatch_builtin_method(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             Value::Abyss,
             "unknown_method",
@@ -220,7 +220,7 @@ mod tests {
         let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
         let err = dispatch_builtin_method(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             scroll_value,
             "scrieb",
@@ -246,7 +246,7 @@ mod tests {
         let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
         let err = dispatch_builtin_method(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             scroll_value,
             "tarns",
@@ -269,7 +269,7 @@ mod tests {
         let scroll_value = Value::Scroll(std::rc::Rc::new(std::cell::RefCell::new(vec![])));
         let err = dispatch_builtin_method(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             scroll_value,
             "completely_unrelated_method_name",

--- a/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
 use crate::eval::{EvalError, EvalResult};
-use abyss_core::ast::{AST, Span, Type};
+use abyss_core::ast::{Expr, Span, Type};
 
 use super::{call_arg_to_value, ensure_mutable_receiver, method_table_for};
 
@@ -16,7 +16,7 @@ pub(super) fn register_methods(registry: &mut BuiltinMethodRegistry) {
 
 fn scroll_tally(
     _env: &mut RuntimeEnv,
-    _receiver_ast: &AST,
+    _receiver_ast: &Expr,
     _receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -34,7 +34,7 @@ fn scroll_tally(
 
 fn scroll_scribe(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -68,7 +68,7 @@ fn scroll_scribe(
 
 fn scroll_extract(
     env: &mut RuntimeEnv,
-    receiver_ast: &AST,
+    receiver_ast: &Expr,
     receiver_var_name: Option<&str>,
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -132,7 +132,7 @@ mod tests {
         let mut env = RuntimeEnv::new();
         let result = scroll_tally(
             &mut env,
-            &AST::Abyss(None),
+            &Expr::Abyss(None),
             None,
             dummy_scroll(),
             dummy_args(1),
@@ -151,7 +151,7 @@ mod tests {
 
         let result = scroll_scribe(
             &mut env,
-            &AST::Var("list".to_string(), None),
+            &Expr::Var("list".to_string(), None),
             Some("list"),
             dummy_scroll(),
             dummy_args(0), // Needs 1
@@ -171,7 +171,7 @@ mod tests {
 
         let result = scroll_extract(
             &mut env,
-            &AST::Var("list".to_string(), None),
+            &Expr::Var("list".to_string(), None),
             Some("list"),
             dummy_scroll(),
             dummy_args(1), // Needs 0
@@ -191,7 +191,7 @@ mod tests {
 
         let result = scroll_extract(
             &mut env,
-            &AST::Var("list".to_string(), None),
+            &Expr::Var("list".to_string(), None),
             Some("list"),
             dummy_scroll(),
             dummy_args(0),

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -57,9 +57,9 @@ Promote runtime failures from "interpreter prints a diagnostic and either aborts
 
 User-defined sum types (true enums with arbitrary variants, payloads, and generics) remain in *Later*; they require generics, which the `Option<T>` / `Result<T, E>` shape would otherwise demand.
 
-### v0.8.0 — Span-tracking Refactor
+### v0.8.0 — Span-tracking Refactor *(shipped early, in the v0.6.0 cycle)*
 
-Replace the current single-point `LineInfo` (`{ line, column }`) attached to AST nodes and `EvalError` with `start..end` byte spans. This is what the `#[non_exhaustive]` marker on `EvalError` shipped in v0.4.1 was reserved for. Pure infrastructure with no user-visible language change, but a hard prerequisite for the LSP work that follows.
+~~Replace the current single-point `LineInfo` (`{ line, column }`) attached to AST nodes and `EvalError` with `start..end` byte spans.~~ **Done ahead of schedule** ([#510](https://github.com/liebe-magi/abyss-lang/issues/510)): AST nodes and `EvalError` now carry byte spans (runtime diagnostics underline the full offending range), and the single `AST` enum has been split into `Expr` / `Stmt` / `Pattern`. This is what the `#[non_exhaustive]` marker on `EvalError` shipped in v0.4.1 was reserved for. Pure infrastructure with no user-visible language change — pulled forward because every prerequisite refactor had already landed, clearing the runway for the LSP work below.
 
 ### v0.8.1+ — LSP MVP
 


### PR DESCRIPTION
## Summary

Completes the core of #510 (sub-tasks 2–4, following the span threading in #520).

**The single `AST` enum is split into `Expr` / `Stmt` / `Pattern`.**

### abyss-core

- `ast.rs`: three purpose-built enums — `Expr` (literals, operators, calls/accesses, `Oracle`), `Stmt` (assignments, `forge`/`engrave`/`orbit`/`reveal`/flow, `Block`), `Pattern` (`DontCare`, `Scroll`/`Rest`, `Artifact`, `Lexicon`, and the `Expr` literal-compare/binding fallback). `OracleBranch`, `OrbitParam`, and `EngraveParam` become plain structs instead of enum variants. Fields are named `span` throughout.
- The `AST::Statement` wrapper is gone: `parse` returns `Vec<Stmt>` and each statement carries its own span.
- Grammar: statement parsers produce `Stmt`, the expression chain produces `Expr`, oracle-arm parsers produce `Pattern`/`OracleBranch`. `Oracle` is confirmed an *expression* (usable in value position), matching the existing grammar.
- Formatter: `format_ast` is replaced by `format_stmt` / `format_expr` / `format_pattern`. One deliberate behaviour fix surfaced by the type split: single-statement oracle arm bodies are now semicolon-terminated on round-trip (`=> reveal x;`) and block bodies brace-terminated — matching what the parser actually accepts (the old formatter emitted `=> reveal x`, which does not re-parse).

### abyss-interpreter

- `evaluate(&Stmt)` + `evaluate_expr(&Expr)` with honest signatures: the 27-arm `unreachable!()` guard and the `Option`-returning `try_evaluate_expression` probe are deleted; pattern matching consumes the `Pattern` enum directly (`patterns.rs` no longer routes pattern nodes through the statement evaluator).
- `EngravedFunction` stores `Vec<EngraveParam>` / `Box<Stmt>`; the "Expected EngraveParam / Expected OrbitParam" defensive error paths are now unrepresentable.
- Comments can no longer appear inside oracle branch lists (they were unreachable from the parser anyway); `Stmt::Comment` is retained for hand-built trees with a doc note.

### Compatibility

- **No language-level change**: every existing script parses, runs, and formats identically (all 23 workspace test binaries pass unmodified in behaviour; `examples/*.aby` round-trip via `invoke`/`align` verified).
- Breaking for `abyss-core` / `abyss-interpreter` API consumers (semver-major, same 0.6.0 cycle as #513/#517/#520). CHANGELOG updated.
- Roadmap page updated: v0.8 "Span-tracking Refactor" marked shipped early in the v0.6.0 cycle.

## Remaining #510 items

- Coordinated semver-major release notes at the next `0.x.0` bump (release-time task).
- Control-flow separation in `EvalResult` was evaluated again and remains deferred (documented on #505): oracle bodies mean expressions can still yield `Revealed`/`Resume`/`Eject`, so the split is not free even after this change.

## Verification

- `cargo test --workspace` — all 23 test binaries pass, zero warnings
- `cargo clippy --workspace --all-targets` — clean
- CLI smoke: `invoke examples/pattern.aby` (all five pattern features) correct; `align examples/oracle.aby` round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
