### PR TITLE
feat(format): preserve comments in abyss align output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Added
+
+- **`abyss align` preserves comments** ([#521](https://github.com/liebe-magi/abyss-lang/issues/521)) — the formatter re-emits line and block comments next to the statements they accompanied: full-line comments stay above their statement (including inside `engrave` / `orbit` blocks), a comment trailing a statement on the same line is re-attached to the formatted line, and end-of-file comments are kept. Previously every comment was silently dropped. Powered by the new byte spans: comments are collected with their spans (`parser::collect_comments`) and interleaved by position (`format::format_program`). Comments in positions the formatter cannot represent (inside an expression, between oracle arms) move to the nearest preceding statement boundary.
+
 ### Changed
 
 - **The single `AST` enum is split into `Expr` / `Stmt` / `Pattern`** ([#510](https://github.com/liebe-magi/abyss-lang/issues/510)) — expressions, statements, and oracle match-arm patterns are now distinct types, with `OracleBranch` / `OrbitParam` / `EngraveParam` as plain structs. The evaluator gains honest signatures (`evaluate(&Stmt)` / expression evaluation without the old `Option`-returning probe), the 27-arm `unreachable!()` guard is gone, and `parse` returns `Vec<Stmt>`. `format_ast` is replaced by `format_stmt` / `format_expr` / `format_pattern`. Breaking for `abyss-core` / `abyss-interpreter` consumers; no language-level change — every existing script parses and runs identically.

--- a/crates/abyss-cli/src/commands.rs
+++ b/crates/abyss-cli/src/commands.rs
@@ -3,8 +3,8 @@
 //! the REPL.
 
 use abyss_core::{
-    format::format_stmt,
-    parser::{ParserDiagnostic, emit_diagnostics, parse},
+    format::format_program,
+    parser::{ParserDiagnostic, collect_comments, emit_diagnostics, parse},
 };
 use abyss_interpreter::{
     eval::{display_error_with_source, evaluate},
@@ -54,7 +54,6 @@ pub fn execute_format(script: &str) {
         return;
     }
 
-    for ast in outcome.ast {
-        println!("{}", format_stmt(&ast, 0));
-    }
+    let comments = collect_comments(script);
+    print!("{}", format_program(script, &outcome.ast, &comments));
 }

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -1,4 +1,95 @@
 use crate::ast::{AssignmentOp, Expr, Pattern, Stmt, Type};
+use crate::parser::SourceComment;
+
+/// Walks the comment list in source order while statements are being
+/// formatted, so each comment is emitted exactly once, next to the
+/// statement it preceded (or trailed) in the original source.
+struct CommentCursor<'a> {
+    comments: &'a [SourceComment],
+    source: &'a str,
+    next: usize,
+}
+
+impl<'a> CommentCursor<'a> {
+    /// Emit (indented, one per line) every not-yet-consumed comment that
+    /// starts before `pos`.
+    fn flush_before(&mut self, pos: usize, indent_level: usize, out: &mut String) {
+        let indent = "    ".repeat(indent_level);
+        while self.next < self.comments.len() && self.comments[self.next].span.start() < pos {
+            for line in self.comments[self.next].text.lines() {
+                out.push_str(&indent);
+                out.push_str(line.trim_end());
+                out.push('\n');
+            }
+            self.next += 1;
+        }
+    }
+
+    /// If the next comment sits on the same source line as `stmt_end`
+    /// (no newline between them), consume it and return its text so the
+    /// caller can append it to the formatted statement line.
+    fn take_trailing(&mut self, stmt_end: usize) -> Option<String> {
+        let comment = self.comments.get(self.next)?;
+        let start = comment.span.start();
+        if start < stmt_end || self.source.get(stmt_end..start)?.contains('\n') {
+            return None;
+        }
+        self.next += 1;
+        Some(comment.text.clone())
+    }
+}
+
+/// Format a whole parsed program, re-emitting the comments collected by
+/// [`crate::parser::collect_comments`] next to the statements they
+/// accompanied: full-line comments stay above their statement (including
+/// inside blocks), a comment trailing a statement on the same line is
+/// re-attached to the formatted line, and comments after the last
+/// statement land at the end.
+///
+/// Comments embedded somewhere the formatter cannot represent (inside an
+/// expression, between oracle arms) are moved up to the closest preceding
+/// statement boundary.
+pub fn format_program(source: &str, stmts: &[Stmt], comments: &[SourceComment]) -> String {
+    let mut cursor = CommentCursor {
+        comments,
+        source,
+        next: 0,
+    };
+    let mut out = String::new();
+    for stmt in stmts {
+        if let Some(span) = stmt_span(stmt) {
+            cursor.flush_before(span.start(), 0, &mut out);
+        }
+        out.push_str(&format_stmt_inner(stmt, 0, &mut Some(&mut cursor)));
+        if let Some(span) = stmt_span(stmt)
+            && let Some(trailing) = cursor.take_trailing(span.end() + 1)
+        {
+            out.push(' ');
+            out.push_str(&trailing);
+        }
+        out.push('\n');
+    }
+    cursor.flush_before(usize::MAX, 0, &mut out);
+    out
+}
+
+fn stmt_span(stmt: &Stmt) -> Option<crate::span::Span> {
+    match stmt {
+        Stmt::Expr(_, span)
+        | Stmt::Reveal(_, span)
+        | Stmt::Block(_, span)
+        | Stmt::Comment(_, span)
+        | Stmt::Resume(_, span)
+        | Stmt::Eject(_, span)
+        | Stmt::VarAssign { span, .. }
+        | Stmt::Assignment { span, .. }
+        | Stmt::IndexAssignment { span, .. }
+        | Stmt::FieldAssignment { span, .. }
+        | Stmt::Orbit { span, .. }
+        | Stmt::Engrave { span, .. }
+        | Stmt::ArtifactDef { span, .. } => *span,
+    }
+}
 
 fn type_keyword(var_type: &Type) -> String {
     match var_type {
@@ -19,14 +110,34 @@ fn type_keyword(var_type: &Type) -> String {
 /// the statement body, and the trailing semicolon. This is the entry
 /// point the CLI's `align` subcommand and the REPL echo use.
 pub fn format_stmt(stmt: &Stmt, indent_level: usize) -> String {
+    format_stmt_inner(stmt, indent_level, &mut None)
+}
+
+fn format_stmt_inner(
+    stmt: &Stmt,
+    indent_level: usize,
+    comments: &mut Option<&mut CommentCursor>,
+) -> String {
     let indent = "    ".repeat(indent_level);
-    format!("{}{};", indent, format_stmt_body(stmt, indent_level))
+    format!(
+        "{}{};",
+        indent,
+        format_stmt_body_inner(stmt, indent_level, comments)
+    )
 }
 
 /// Formats the body of a statement without indentation or the trailing
 /// semicolon — the shape used inside oracle arm bodies and by
 /// [`format_stmt`].
 fn format_stmt_body(stmt: &Stmt, indent_level: usize) -> String {
+    format_stmt_body_inner(stmt, indent_level, &mut None)
+}
+
+fn format_stmt_body_inner(
+    stmt: &Stmt,
+    indent_level: usize,
+    comments: &mut Option<&mut CommentCursor>,
+) -> String {
     let indent = "    ".repeat(indent_level);
 
     match stmt {
@@ -69,10 +180,24 @@ fn format_stmt_body(stmt: &Stmt, indent_level: usize) -> String {
                 _ => format!("reveal {}", trimmed_val),
             }
         }
-        Stmt::Block(statements, _) => {
+        Stmt::Block(statements, block_span) => {
             let mut result = format!("{}{{\n", indent);
             for statement in statements {
-                result.push_str(&format!("{}\n", format_stmt(statement, indent_level + 1)));
+                if let (Some(cursor), Some(span)) = (comments.as_deref_mut(), stmt_span(statement))
+                {
+                    cursor.flush_before(span.start(), indent_level + 1, &mut result);
+                }
+                result.push_str(&format_stmt_inner(statement, indent_level + 1, comments));
+                if let (Some(cursor), Some(span)) = (comments.as_deref_mut(), stmt_span(statement))
+                    && let Some(trailing) = cursor.take_trailing(span.end() + 1)
+                {
+                    result.push(' ');
+                    result.push_str(&trailing);
+                }
+                result.push('\n');
+            }
+            if let (Some(cursor), Some(span)) = (comments.as_deref_mut(), block_span) {
+                cursor.flush_before(span.end(), indent_level + 1, &mut result);
             }
             result.push_str(&format!("{}}}", indent));
             result
@@ -91,7 +216,9 @@ fn format_stmt_body(stmt: &Stmt, indent_level: usize) -> String {
                     .join(", ");
                 result.push_str(&format!(" ({})", params_str));
             }
-            result.push_str(format_stmt_body(body.as_ref(), indent_level).trim());
+            result.push_str(
+                format_stmt_body_inner(body.as_ref(), indent_level, comments).trim_start(),
+            );
             result
         }
         Stmt::Resume(value, _) => match value {
@@ -149,14 +276,14 @@ fn format_stmt_body(stmt: &Stmt, indent_level: usize) -> String {
                     "engrave {}({}) {}",
                     qualified_name,
                     params_str,
-                    format_stmt_body(body, indent_level)
+                    format_stmt_body_inner(body, indent_level, comments)
                 ),
                 Some(ret) => format!(
                     "engrave {}({}) -> {} {}",
                     qualified_name,
                     params_str,
                     ret,
-                    format_stmt_body(body, indent_level)
+                    format_stmt_body_inner(body, indent_level, comments)
                 ),
             }
         }

--- a/crates/abyss-core/src/parser/helpers.rs
+++ b/crates/abyss-core/src/parser/helpers.rs
@@ -1,6 +1,68 @@
 use chumsky::{error::Rich, extra, prelude::*, span::SimpleSpan as ChumskySpan, text};
 
+use crate::span::Span;
+
 type LexerExtra<'src> = extra::Err<Rich<'src, char, ChumskySpan<usize>>>;
+
+/// A comment lifted out of the original source, with the byte span it
+/// occupied. Produced by [`collect_comments`]; consumed by the formatter's
+/// comment-preserving `format_program` to re-emit comments alongside the
+/// statements they belonged to.
+#[derive(Debug, Clone)]
+pub struct SourceComment {
+    pub span: Span,
+    pub text: String,
+}
+
+/// Collect every comment in `source` with its byte span, in source order.
+///
+/// Uses the same scan as [`scrub_comments_preserve_layout`], so the spans
+/// line up exactly with the regions the scrubber blanks out before lexing.
+pub fn collect_comments(source: &str) -> Vec<SourceComment> {
+    let mut comments = Vec::new();
+    let mut chars = source.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if ch == '/'
+            && let Some(&(_, next)) = chars.peek()
+        {
+            if next == '/' {
+                chars.next(); // consume second '/'
+                let mut end = source.len();
+                while let Some(&(c_idx, c)) = chars.peek() {
+                    if c == '\n' {
+                        end = c_idx;
+                        break;
+                    }
+                    chars.next();
+                }
+                comments.push(SourceComment {
+                    span: Span::new(idx, end),
+                    text: source[idx..end].trim_end().to_string(),
+                });
+                continue;
+            } else if next == '*' {
+                chars.next(); // consume '*'
+                let mut end = source.len();
+                let mut prev = '\0';
+                for (c_idx, c) in chars.by_ref() {
+                    if prev == '*' && c == '/' {
+                        end = c_idx + c.len_utf8();
+                        break;
+                    }
+                    prev = c;
+                }
+                comments.push(SourceComment {
+                    span: Span::new(idx, end),
+                    text: source[idx..end].to_string(),
+                });
+                continue;
+            }
+        }
+    }
+
+    comments
+}
 
 /// Produces a parser that skips AbySS whitespace.
 pub fn abyss_whitespace<'src>() -> impl Parser<'src, &'src str, (), LexerExtra<'src>> + Clone {

--- a/crates/abyss-core/src/parser/mod.rs
+++ b/crates/abyss-core/src/parser/mod.rs
@@ -1,5 +1,7 @@
 pub use crate::span::SimpleSpan;
-pub use helpers::{abyss_whitespace, scrub_comments_preserve_layout};
+pub use helpers::{
+    SourceComment, abyss_whitespace, collect_comments, scrub_comments_preserve_layout,
+};
 pub use tokens::{SpannedToken, Token, lexer};
 mod diagnostics;
 mod grammar;

--- a/crates/abyss-core/tests/test_format.rs
+++ b/crates/abyss-core/tests/test_format.rs
@@ -2,7 +2,8 @@ use abyss_core::ast::{
     ArtifactField, ArtifactMethodTarget, AssignmentOp, ConditionalAssignment, EngraveParam, Expr,
     OracleBranch, OrbitParam, Pattern, Stmt, Type,
 };
-use abyss_core::format::{format_expr, format_pattern, format_stmt};
+use abyss_core::format::{format_expr, format_pattern, format_program, format_stmt};
+use abyss_core::parser::{collect_comments, parse};
 
 fn arcana(value: i64) -> Box<Expr> {
     Box::new(Expr::Arcana(value, None))
@@ -532,4 +533,71 @@ fn format_type_keyword_variants() {
         let expected_text = format!("forge {}param{}: {} = 1;", prefix, index, expected);
         assert_eq!(format_stmt(&stmt, 0), expected_text);
     }
+}
+
+fn format_source(source: &str) -> String {
+    let outcome = parse(source);
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "parser emitted diagnostics: {:?}",
+        outcome.diagnostics
+    );
+    format_program(source, &outcome.ast, &collect_comments(source))
+}
+
+#[test]
+fn format_program_preserves_comments() {
+    let source = concat!(
+        "// pick a sigil\n",
+        "forge x:arcana=1; // initial value\n",
+        "/* block comment\n   spanning lines */\n",
+        "engrave double(n:arcana)->arcana {\n",
+        "// twice the input\n",
+        "reveal n*2; // fast path\n",
+        "};\n",
+        "unveil(double(x));\n",
+        "// done\n",
+    );
+    let expected = concat!(
+        "// pick a sigil\n",
+        "forge x: arcana = 1; // initial value\n",
+        "/* block comment\n",
+        "   spanning lines */\n",
+        "engrave double(n: arcana) -> arcana {\n",
+        "    // twice the input\n",
+        "    reveal n * 2; // fast path\n",
+        "};\n",
+        "unveil(double(x));\n",
+        "// done\n",
+    );
+    assert_eq!(format_source(source), expected);
+}
+
+#[test]
+fn format_program_with_comments_is_idempotent() {
+    let source = concat!(
+        "// leading\n",
+        "forge x: arcana = 1; // trailing\n",
+        "orbit (i = 0..2){\n",
+        "    // loop body note\n",
+        "    unveil(i);\n",
+        "};\n",
+        "// end\n",
+    );
+    let once = format_source(source);
+    let twice = format_source(&once);
+    assert_eq!(once, twice, "formatting must be idempotent");
+}
+
+#[test]
+fn format_program_without_comments_matches_per_statement_output() {
+    let source = "forge x: arcana = 1;\nunveil(x);\n";
+    let outcome = parse(source);
+    assert!(outcome.diagnostics.is_empty());
+    let joined: String = outcome
+        .ast
+        .iter()
+        .map(|stmt| format!("{}\n", format_stmt(stmt, 0)))
+        .collect();
+    assert_eq!(format_program(source, &outcome.ast, &[]), joined);
 }


### PR DESCRIPTION
## Summary

Resolves #521.

`abyss align` now preserves comments instead of silently dropping them.

- **`parser::collect_comments`** walks the source with the same scan as the pre-lex comment scrubber and returns each comment as a `SourceComment { span, text }`, so positions line up exactly with the regions the scrubber blanks.
- **`format::format_program(source, stmts, comments)`** interleaves comments with formatted statements by byte position:
  - full-line comments are emitted above the statement they preceded — including inside `engrave` / `orbit` block bodies, via a comment cursor threaded through the block formatter;
  - a comment trailing a statement on the same source line is re-attached to the formatted line;
  - comments after the last statement are kept at the end;
  - comments in positions the formatter cannot represent (inside an expression, between oracle arms) move to the nearest preceding statement boundary — the standard formatter compromise.
- The CLI `align` subcommand switches to `format_program`; `format_stmt` / `format_expr` are unchanged for comment-less callers (REPL echo still uses `format_stmt`).

Example round-trip:

```
// pick a sigil
forge x: arcana = 1; // initial value
engrave double(n: arcana) -> arcana {
    // twice the input
    reveal n * 2; // fast path
};
// done
```

(verified end-to-end via `cargo run -p abyss-lang -- align`; second pass is byte-identical.)

## Verification

- `cargo test --workspace` — all 23 test binaries pass, zero warnings; three new `test_format.rs` cases pin comment placement, idempotence, and that comment-less formatting matches per-statement output
- `cargo clippy --workspace --all-targets` — clean
- CLI smoke: `align` on a commented script preserves every comment; running `align` on its own output is byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
