### PR TITLE
chore(release): bump workspace and extension to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-03
+
+The Web Playground release, riding on the biggest internal overhaul since the workspace split. AbySS now runs directly in the browser at [abyss-lang.dev/playground](https://abyss-lang.dev/playground) via a new Wasm adapter, while under the hood the compiler grew up: every AST node and runtime error carries a byte span (diagnostics underline the full offending range), the AST is split into `Expr` / `Stmt` / `Pattern`, `EvalError` gained structured variants, and `abyss align` finally preserves comments. Two off-theme names were hard-switched while the user base is small: `resume` → `revolve` and `trans` → `transmute`. Language semantics are otherwise unchanged — scripts that used neither renamed word run identically.
+
+### Added
+
+- **Web Playground** — `crates/abyss-wasm` exposes `evaluate(source)` over `wasm-bindgen`, and the docs site embeds an editor seeded with the `examples/` programs. Parser and runtime diagnostics render with the same ariadne formatting the CLI shows.
+
 ### Changed (breaking — language)
 
 - **`resume` → `revolve`** ([#525](https://github.com/liebe-magi/abyss-lang/issues/525)) — the loop-continue keyword inside `orbit` is renamed to the themed `revolve` ("another revolution of the orbit", pairing with `eject`'s orbital ejection). Hard switch with no alias: `resume` no longer parses. Migration is a find-and-replace; done now while the user base is small, ahead of a proper deprecation/warning channel planned with the LSP diagnostics work.
@@ -23,6 +31,8 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 ### Removed
 
 - **`abyss_core::semantic` module (`SymbolTable` / `SymbolInfo`)** ([#503](https://github.com/liebe-magi/abyss-lang/issues/503)) — the static-analysis scaffold had zero consumers anywhere in the workspace since its introduction. The roadmap's LSP milestone (v0.8.1) is preceded by the v0.8 span-tracking refactor, and a symbol table without span data would have been rewritten there anyway; git history preserves the removed code. Breaking for `abyss-core` per Cargo 0.x semver, so this ships with the next `0.x.0` bump.
+
+For the full diff including Renovate-driven dependency updates, see the [GitHub compare v0.5.0...v0.6.0](https://github.com/liebe-magi/abyss-lang/compare/v0.5.0...v0.6.0).
 
 ## [0.5.0] - 2026-05-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-interpreter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "abyss-core",
  "ariadne",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-lang"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 license = "MIT"
@@ -16,8 +16,8 @@ repository = "https://github.com/liebe-magi/abyss-lang"
 homepage = "https://abyss-lang.dev"
 
 [workspace.dependencies]
-abyss-core = { path = "crates/abyss-core", version = "0.5.0" }
-abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.5.0" }
+abyss-core = { path = "crates/abyss-core", version = "0.6.0" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.6.0" }
 ariadne = "0.6"
 chumsky = "0.13"
 ordered-float = "5"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [v0.6.0] - 2026-07-03
+
+### Changed
+
+- **Breaking keyword rename followed from the language**: `resume` → `revolve`. The TextMate grammar's `keyword.control` group, the snippets, and the static keyword-completion provider all track the new name; `resume` is no longer highlighted or completed because it no longer parses.
+- The completion list's method vocabulary follows the `trans` → `transmute` stdlib rename.
+- Bumped the extension version to 0.6.0 to stay in lockstep with the `abyss-lang` crate. The 0.6.0 cycle is the Web Playground plus an internal compiler overhaul (spans, AST split, comment-preserving `align`); apart from the two renames above, the grammar surface is unchanged.
+
 ## [v0.5.0] - 2026-05-06
 
 ### Added

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-codex-familiar",
   "displayName": "AbySS Codex Familiar",
   "description": "Custom syntax highlighting for the AbySS programming language.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "liebe-magi",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release prep for **v0.6.0** (the Web Playground & internal-overhaul release):

- Root `Cargo.toml`: `[workspace.package].version` and the `abyss-core` / `abyss-interpreter` workspace-dependency pins → `0.6.0`; `Cargo.lock` regenerated.
- `editors/code/package.json` → `0.6.0` (lockstep enforced by `scripts/check_version_sync.py` — passing).
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.6.0] - 2026-07-03` with the release narrative and compare link; fresh empty `[Unreleased]` kept.
- `editors/code/CHANGELOG.md`: v0.6.0 entry covering the `revolve` / `transmute` grammar updates.

After this merges, the `develop` → `main` promotion PR triggers `release.yml` (tag, GitHub release, crates.io publishes, per-target binaries, Marketplace publish).

## Verification

- `python3 scripts/check_version_sync.py` — versions match
- `cargo test --workspace` — all 23 test binaries pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)