### PR TITLE
fix(extension): highlight transmute instead of trans in the TextMate grammar

### DIFF
--- a/editors/code/syntaxes/abyss.tmLanguage.json
+++ b/editors/code/syntaxes/abyss.tmLanguage.json
@@ -76,7 +76,7 @@
 			"patterns": [
 				{
 					"name": "support.function.abyss",
-					"match": "\\b(unveil|summon|trans)\\b"
+					"match": "\\b(unveil|summon|transmute)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
## Summary

Follow-up to #528: the `trans` → `transmute` rename covered the keyword-completion list and snippets but missed the TextMate grammar's support-function highlight group (`unveil|summon|trans`). This fixes the group to `unveil|summon|transmute`, so the removed method loses its colour and the new one gains it.

Impact of the miss on the published 0.6.0 extension is cosmetic only (highlighting; completion and snippets were already correct). Ships with the next lockstep release rather than an emergency Marketplace republish.

## Verification

- JSON validated; grammar group now reads `\\b(unveil|summon|transmute)\\b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)