### PR TITLE
fix(parser): make the comment scanner string-literal aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Fixed
+
+- **Comment scrubber corrupted string literals containing `//` or `/*`** ([#532](https://github.com/liebe-magi/abyss-lang/issues/532)) — the pre-lex comment scanner treated comment openers inside rune literals as comments, so any string containing them (every URL, for instance) failed to parse. The scanner is now string-aware, honouring the lexer's escape rules, and a single shared region scan backs both the scrubber and the formatter's comment collector so their views cannot diverge. Bonus fix: comments are now blanked byte-wise, so multi-byte characters in comments no longer shift the spans of everything after them.
+
 ## [0.6.0] - 2026-07-03
 
 The Web Playground release, riding on the biggest internal overhaul since the workspace split. AbySS now runs directly in the browser at [abyss-lang.dev/playground](https://abyss-lang.dev/playground) via a new Wasm adapter, while under the hood the compiler grew up: every AST node and runtime error carries a byte span (diagnostics underline the full offending range), the AST is split into `Expr` / `Stmt` / `Pattern`, `EvalError` gained structured variants, and `abyss align` finally preserves comments. Two off-theme names were hard-switched while the user base is small: `resume` → `revolve` and `trans` → `transmute`. Language semantics are otherwise unchanged — scripts that used neither renamed word run identically.

--- a/crates/abyss-core/src/parser/helpers.rs
+++ b/crates/abyss-core/src/parser/helpers.rs
@@ -14,54 +14,101 @@ pub struct SourceComment {
     pub text: String,
 }
 
-/// Collect every comment in `source` with its byte span, in source order.
+/// Scan `source` for the byte regions occupied by comments, in order.
 ///
-/// Uses the same scan as [`scrub_comments_preserve_layout`], so the spans
-/// line up exactly with the regions the scrubber blanks out before lexing.
-pub fn collect_comments(source: &str) -> Vec<SourceComment> {
-    let mut comments = Vec::new();
+/// The scanner is rune-literal aware: `//` and `/*` inside a string are
+/// text, not comment openers, and the lexer's escape rules are honoured
+/// so `"\""` does not end the literal early. A line comment spans from
+/// `//` to just before the newline (or EOF); a block comment spans from
+/// `/*` through the closing `*/` (or EOF when unterminated). Region
+/// boundaries always fall on `char` boundaries.
+///
+/// This single scanner backs both [`scrub_comments_preserve_layout`] and
+/// [`collect_comments`], so their views of the source can never diverge.
+fn comment_regions(source: &str) -> Vec<(usize, usize)> {
+    let mut regions = Vec::new();
     let mut chars = source.char_indices().peekable();
+    let mut in_string = false;
 
     while let Some((idx, ch)) = chars.next() {
-        if ch == '/'
-            && let Some(&(_, next)) = chars.peek()
-        {
-            if next == '/' {
-                chars.next(); // consume second '/'
-                let mut end = source.len();
-                while let Some(&(c_idx, c)) = chars.peek() {
-                    if c == '\n' {
-                        end = c_idx;
-                        break;
-                    }
+        if in_string {
+            match ch {
+                // Skip the escaped character so `\"` stays inside the
+                // literal — mirroring the lexer's escape handling.
+                '\\' => {
                     chars.next();
                 }
-                comments.push(SourceComment {
-                    span: Span::new(idx, end),
-                    text: source[idx..end].trim_end().to_string(),
-                });
-                continue;
-            } else if next == '*' {
-                chars.next(); // consume '*'
-                let mut end = source.len();
-                let mut prev = '\0';
-                for (c_idx, c) in chars.by_ref() {
-                    if prev == '*' && c == '/' {
-                        end = c_idx + c.len_utf8();
-                        break;
-                    }
-                    prev = c;
-                }
-                comments.push(SourceComment {
-                    span: Span::new(idx, end),
-                    text: source[idx..end].to_string(),
-                });
-                continue;
+                '"' => in_string = false,
+                _ => {}
             }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '/' => {
+                let Some(&(_, next)) = chars.peek() else {
+                    continue;
+                };
+                if next == '/' {
+                    chars.next(); // consume second '/'
+                    let mut end = source.len();
+                    while let Some(&(c_idx, c)) = chars.peek() {
+                        if c == '\n' {
+                            end = c_idx;
+                            break;
+                        }
+                        chars.next();
+                    }
+                    regions.push((idx, end));
+                } else if next == '*' {
+                    chars.next(); // consume '*'
+                    let mut end = source.len();
+                    let mut prev = '\0';
+                    for (c_idx, c) in chars.by_ref() {
+                        if prev == '*' && c == '/' {
+                            end = c_idx + c.len_utf8();
+                            break;
+                        }
+                        prev = c;
+                    }
+                    regions.push((idx, end));
+                }
+            }
+            _ => {}
         }
     }
 
-    comments
+    regions
+}
+
+/// Collect every comment in `source` with its byte span, in source order.
+pub fn collect_comments(source: &str) -> Vec<SourceComment> {
+    comment_regions(source)
+        .into_iter()
+        .map(|(start, end)| SourceComment {
+            span: Span::new(start, end),
+            text: source[start..end].trim_end().to_string(),
+        })
+        .collect()
+}
+
+/// Replace comments with whitespace of equal **byte** length so token spans
+/// align exactly with the original source. Blanking is byte-wise (newlines
+/// inside block comments are kept) — a multi-byte character in a comment
+/// becomes that many spaces, so subsequent offsets never shift.
+pub fn scrub_comments_preserve_layout(source: &str) -> String {
+    let mut bytes = source.as_bytes().to_vec();
+    for (start, end) in comment_regions(source) {
+        for byte in &mut bytes[start..end] {
+            if *byte != b'\n' {
+                *byte = b' ';
+            }
+        }
+    }
+    // Regions start/end on char boundaries and every blanked byte becomes
+    // ASCII space, so the result is valid UTF-8 by construction.
+    String::from_utf8(bytes).expect("blanking comments preserves UTF-8 validity")
 }
 
 /// Produces a parser that skips AbySS whitespace.
@@ -69,58 +116,63 @@ pub fn abyss_whitespace<'src>() -> impl Parser<'src, &'src str, (), LexerExtra<'
     text::whitespace::<_, LexerExtra<'src>>().to(())
 }
 
-/// Replace comments with whitespace of equal length so token spans align with the original source.
-pub fn scrub_comments_preserve_layout(source: &str) -> String {
-    let mut result = String::with_capacity(source.len());
-    let mut chars = source.chars().peekable();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    while let Some(ch) = chars.next() {
-        if ch == '/'
-            && let Some(&next) = chars.peek()
-        {
-            if next == '/' {
-                // Single-line comment: consume until newline, keep newline intact.
-                result.push(' '); // replace first '/'
-                chars.next(); // consume second '/'
-                result.push(' ');
+    #[test]
+    fn slashes_inside_rune_literals_are_not_comments() {
+        let source = r#"forge url: rune = "http://example.com"; // real comment"#;
+        let scrubbed = scrub_comments_preserve_layout(source);
+        assert!(scrubbed.contains(r#""http://example.com""#));
+        assert!(!scrubbed.contains("real comment"));
 
-                while let Some(&c) = chars.peek() {
-                    chars.next();
-                    if c == '\n' {
-                        result.push('\n');
-                        break;
-                    }
-                    result.push(' ');
-                }
-
-                continue;
-            } else if next == '*' {
-                // Block comment: consume until closing */ while preserving newlines.
-                result.push(' '); // first '/'
-                chars.next(); // consume '*'
-                result.push(' ');
-
-                let mut prev = '\0';
-                for c in chars.by_ref() {
-                    if c == '\n' {
-                        result.push('\n');
-                    } else {
-                        result.push(' ');
-                    }
-
-                    if prev == '*' && c == '/' {
-                        break;
-                    }
-
-                    prev = c;
-                }
-
-                continue;
-            }
-        }
-
-        result.push(ch);
+        let comments = collect_comments(source);
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].text, "// real comment");
     }
 
-    result
+    #[test]
+    fn block_comment_opener_inside_string_is_text() {
+        let source = r#"unveil("/* not a comment */");"#;
+        assert_eq!(scrub_comments_preserve_layout(source), source);
+        assert!(collect_comments(source).is_empty());
+    }
+
+    #[test]
+    fn escaped_quote_does_not_end_the_literal() {
+        let source = r#"forge s: rune = "say \"hi\" // still text";"#;
+        assert_eq!(scrub_comments_preserve_layout(source), source);
+        assert!(collect_comments(source).is_empty());
+    }
+
+    #[test]
+    fn quote_inside_comment_does_not_open_a_string() {
+        let source = "// a \"quoted\" note\nforge x: arcana = 1; // b\n";
+        let comments = collect_comments(source);
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].text, "// a \"quoted\" note");
+        assert_eq!(comments[1].text, "// b");
+        let scrubbed = scrub_comments_preserve_layout(source);
+        assert!(scrubbed.contains("forge x: arcana = 1;"));
+        assert!(!scrubbed.contains("note"));
+    }
+
+    #[test]
+    fn multibyte_comment_blanking_preserves_byte_offsets() {
+        let source = "// コメント\nforge x: arcana = 1;\n";
+        let scrubbed = scrub_comments_preserve_layout(source);
+        assert_eq!(scrubbed.len(), source.len(), "byte length must not shift");
+        let forge_at = source.find("forge").unwrap();
+        assert_eq!(scrubbed.find("forge").unwrap(), forge_at);
+    }
+
+    #[test]
+    fn unterminated_block_comment_runs_to_eof() {
+        let source = "forge x: arcana = 1; /* dangling";
+        let comments = collect_comments(source);
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].text, "/* dangling");
+        assert!(scrub_comments_preserve_layout(source).starts_with("forge x: arcana = 1;"));
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #532.

The pre-lex comment scrubber (and, since #523, the formatter's comment collector) treated `//` and `/*` inside rune literals as comment openers, corrupting any string containing them — **every URL failed to parse**:

```
forge url: rune = "a//b";   // → Unexpected token `identifier `a``
```

### Fix

- One shared `comment_regions` scanner backs both `scrub_comments_preserve_layout` and `collect_comments`, so their views of the source can never diverge. It tracks rune-literal state and honours the lexer's escape rules (`\"` does not end the literal).
- **Bonus fix**: comments are now blanked **byte-wise** (multi-byte character → that many spaces). Previously each comment *character* became one space, so a multi-byte comment (e.g. Japanese) shifted the byte spans of everything after it — which since the span refactor would have misplaced diagnostics and re-attached comments.

### Verification

- Six new unit tests: slashes/openers inside strings, escaped quotes, quotes inside comments, multibyte blanking preserves byte offsets, unterminated block comment.
- CLI smoke: URL-containing scripts `invoke` and `align` round-trip correctly, including a multibyte comment + trailing comment case.
- `cargo test --workspace` — all 23 test binaries pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)