### PR TITLE
feat(stdlib): add rune methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Added
+
+- **`rune` methods** ([#533](https://github.com/liebe-magi/abyss-lang/issues/533)) — the first item of the v0.6.x Standard Library Essentials cycle. `upper()`, `lower()`, `trim()`, `tally()` (Unicode character count), `contains(needle)`, `replace(from, to)`, and `split(separator)`. All return new values; `replace` and `split` reject empty search/separator runes with a clear error.
+
 ### Fixed
 
 - **Comment scrubber corrupted string literals containing `//` or `/*`** ([#532](https://github.com/liebe-magi/abyss-lang/issues/532)) — the pre-lex comment scanner treated comment openers inside rune literals as comments, so any string containing them (every URL, for instance) failed to parse. The scanner is now string-aware, honouring the lexer's escape rules, and a single shared region scan backs both the scrubber and the formatter's comment collector so their views cannot diverge. Bonus fix: comments are now blanked byte-wise, so multi-byte characters in comments no longer shift the spans of everything after them.

--- a/crates/abyss-interpreter/src/stdlib/methods/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/mod.rs
@@ -1,5 +1,6 @@
 mod lexicon;
 mod materia;
+mod rune;
 mod scroll;
 
 use crate::diagnostics::did_you_mean_hint;
@@ -14,6 +15,7 @@ use std::collections::HashMap;
 pub fn get_all_builtin_methods() -> BuiltinMethodRegistry {
     let mut registry = BuiltinMethodRegistry::new();
     materia::register_methods(&mut registry);
+    rune::register_methods(&mut registry);
     scroll::register_methods(&mut registry);
     lexicon::register_methods(&mut registry);
     registry

--- a/crates/abyss-interpreter/src/stdlib/methods/rune.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/rune.rs
@@ -1,0 +1,345 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::env::{BuiltinMethodRegistry, CallArg, RuntimeEnv, Value};
+use crate::eval::{EvalError, EvalResult};
+use abyss_core::ast::{Expr, Span, Type};
+
+use super::{call_arg_to_value, method_table_for};
+
+pub(super) fn register_methods(registry: &mut BuiltinMethodRegistry) {
+    let table = method_table_for(registry, Type::Rune);
+    table.insert("upper".to_string(), rune_upper);
+    table.insert("lower".to_string(), rune_lower);
+    table.insert("trim".to_string(), rune_trim);
+    table.insert("tally".to_string(), rune_tally);
+    table.insert("contains".to_string(), rune_contains);
+    table.insert("replace".to_string(), rune_replace);
+    table.insert("split".to_string(), rune_split);
+}
+
+fn rune_upper(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    ensure_no_args(&args, "upper", line_info)?;
+    Ok(EvalResult::data(Value::Rune(Rc::new(text.to_uppercase()))))
+}
+
+fn rune_lower(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    ensure_no_args(&args, "lower", line_info)?;
+    Ok(EvalResult::data(Value::Rune(Rc::new(text.to_lowercase()))))
+}
+
+fn rune_trim(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    ensure_no_args(&args, "trim", line_info)?;
+    Ok(EvalResult::data(Value::Rune(Rc::new(
+        text.trim().to_string(),
+    ))))
+}
+
+/// Character count (Unicode scalar values), mirroring `scroll.tally()`'s
+/// element count rather than a byte length.
+fn rune_tally(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    ensure_no_args(&args, "tally", line_info)?;
+    Ok(EvalResult::data(Value::Arcana(text.chars().count() as i64)))
+}
+
+fn rune_contains(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    let [needle] = take_rune_args::<1>(args, "contains", line_info)?;
+    Ok(EvalResult::data(Value::Omen(
+        text.contains(needle.as_str()),
+    )))
+}
+
+fn rune_replace(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    let [from, to] = take_rune_args::<2>(args, "replace", line_info)?;
+    if from.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            "replace() requires a non-empty search rune".to_string(),
+            *line_info,
+        ));
+    }
+    Ok(EvalResult::data(Value::Rune(Rc::new(
+        text.replace(from.as_str(), to.as_str()),
+    ))))
+}
+
+fn rune_split(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let text = expect_rune(receiver_value);
+    let [separator] = take_rune_args::<1>(args, "split", line_info)?;
+    if separator.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            "split() requires a non-empty separator rune".to_string(),
+            *line_info,
+        ));
+    }
+    let pieces: Vec<Value> = text
+        .split(separator.as_str())
+        .map(|piece| Value::Rune(Rc::new(piece.to_string())))
+        .collect();
+    Ok(EvalResult::data(Value::Scroll(Rc::new(RefCell::new(
+        pieces,
+    )))))
+}
+
+fn expect_rune(value: Value) -> Rc<String> {
+    if let Value::Rune(text) = value {
+        text
+    } else {
+        panic!("rune builtin dispatched with non-rune value");
+    }
+}
+
+fn ensure_no_args(
+    args: &[CallArg],
+    method: &str,
+    line_info: &Option<Span>,
+) -> Result<(), EvalError> {
+    if args.is_empty() {
+        Ok(())
+    } else {
+        Err(EvalError::InvalidOperation(
+            format!("{}() does not take any arguments", method),
+            *line_info,
+        ))
+    }
+}
+
+/// Extract exactly `N` rune arguments, with the shared wording for arity
+/// and type errors.
+fn take_rune_args<const N: usize>(
+    args: Vec<CallArg>,
+    method: &str,
+    line_info: &Option<Span>,
+) -> Result<[Rc<String>; N], EvalError> {
+    if args.len() != N {
+        let plural = if N == 1 { "argument" } else { "arguments" };
+        return Err(EvalError::InvalidOperation(
+            format!("{}() expects exactly {} rune {}", method, N, plural),
+            *line_info,
+        ));
+    }
+    let mut runes = Vec::with_capacity(N);
+    for arg in args {
+        let label = format!("{}()", method);
+        match call_arg_to_value(arg, &label, line_info)? {
+            Value::Rune(text) => runes.push(text),
+            other => {
+                return Err(EvalError::InvalidOperation(
+                    format!(
+                        "{}() expects rune arguments, found {}",
+                        method,
+                        crate::eval::values::describe_value(&other)
+                    ),
+                    *line_info,
+                ));
+            }
+        }
+    }
+    Ok(runes
+        .try_into()
+        .unwrap_or_else(|_| unreachable!("length checked above")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rune_value(text: &str) -> Value {
+        Value::Rune(Rc::new(text.to_string()))
+    }
+
+    fn rune_arg(text: &str) -> CallArg {
+        CallArg {
+            value: EvalResult::data(rune_value(text)),
+            var_name: None,
+        }
+    }
+
+    fn unwrap_rune(result: Result<EvalResult, EvalError>) -> String {
+        match result.expect("method should succeed") {
+            EvalResult::Data(Value::Rune(text)) => text.as_ref().clone(),
+            other => panic!("expected rune result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn upper_lower_trim_transform_the_receiver() {
+        let mut env = RuntimeEnv::new();
+        let recv = &Expr::Abyss(None);
+        assert_eq!(
+            unwrap_rune(rune_upper(
+                &mut env,
+                recv,
+                None,
+                rune_value("abyss"),
+                vec![],
+                &None
+            )),
+            "ABYSS"
+        );
+        assert_eq!(
+            unwrap_rune(rune_lower(
+                &mut env,
+                recv,
+                None,
+                rune_value("ABYSS"),
+                vec![],
+                &None
+            )),
+            "abyss"
+        );
+        assert_eq!(
+            unwrap_rune(rune_trim(
+                &mut env,
+                recv,
+                None,
+                rune_value("  rune  "),
+                vec![],
+                &None
+            )),
+            "rune"
+        );
+    }
+
+    #[test]
+    fn tally_counts_characters_not_bytes() {
+        let mut env = RuntimeEnv::new();
+        let result = rune_tally(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            rune_value("呪文"),
+            vec![],
+            &None,
+        );
+        assert!(matches!(result, Ok(EvalResult::Data(Value::Arcana(2)))));
+    }
+
+    #[test]
+    fn contains_returns_omen() {
+        let mut env = RuntimeEnv::new();
+        let result = rune_contains(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            rune_value("dark incantation"),
+            vec![rune_arg("cant")],
+            &None,
+        );
+        assert!(matches!(result, Ok(EvalResult::Data(Value::Omen(true)))));
+    }
+
+    #[test]
+    fn replace_rejects_empty_search() {
+        let mut env = RuntimeEnv::new();
+        let result = rune_replace(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            rune_value("aaa"),
+            vec![rune_arg(""), rune_arg("b")],
+            &None,
+        );
+        assert!(matches!(
+            result,
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("non-empty search")
+        ));
+    }
+
+    #[test]
+    fn split_produces_scroll_of_runes() {
+        let mut env = RuntimeEnv::new();
+        let result = rune_split(
+            &mut env,
+            &Expr::Abyss(None),
+            None,
+            rune_value("a,b,c"),
+            vec![rune_arg(",")],
+            &None,
+        )
+        .expect("split should succeed");
+        match result {
+            EvalResult::Data(Value::Scroll(items)) => {
+                let items = items.borrow();
+                assert_eq!(items.len(), 3);
+                assert!(matches!(&items[1], Value::Rune(t) if t.as_ref() == "b"));
+            }
+            other => panic!("expected scroll, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn arity_and_type_errors_share_wording() {
+        let mut env = RuntimeEnv::new();
+        let recv = &Expr::Abyss(None);
+        let result = rune_contains(&mut env, recv, None, rune_value("x"), vec![], &None);
+        assert!(matches!(
+            result,
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("expects exactly 1 rune argument")
+        ));
+
+        let bad_type = CallArg {
+            value: EvalResult::data(Value::Arcana(1)),
+            var_name: None,
+        };
+        let result = rune_contains(&mut env, recv, None, rune_value("x"), vec![bad_type], &None);
+        assert!(matches!(
+            result,
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("expects rune arguments, found arcana")
+        ));
+    }
+}

--- a/crates/abyss-interpreter/tests/test_rune.rs
+++ b/crates/abyss-interpreter/tests/test_rune.rs
@@ -178,3 +178,82 @@ fn test_unveil_no_args_error() {
         Ok(_) => panic!("Expected an error for unveil() with no arguments"),
     }
 }
+
+#[test]
+fn rune_methods_transform_and_query() {
+    let input = r#"
+forge spell: rune = "  Dark Incantation  ";
+forge clean: rune = spell.trim();
+clean.upper();
+clean.lower();
+clean.tally();
+clean.contains("Incant");
+clean.replace("Dark", "Bright");
+"#;
+    let results = test_base(input).expect("rune methods should evaluate");
+    assert_eq!(results.len(), 7);
+    match &results[2] {
+        EvalResult::Data(Value::Rune(s)) => assert_eq!(s.as_ref(), "DARK INCANTATION"),
+        other => panic!("expected upper() rune, got {:?}", other),
+    }
+    match &results[3] {
+        EvalResult::Data(Value::Rune(s)) => assert_eq!(s.as_ref(), "dark incantation"),
+        other => panic!("expected lower() rune, got {:?}", other),
+    }
+    match &results[4] {
+        EvalResult::Data(Value::Arcana(n)) => assert_eq!(*n, 16),
+        other => panic!("expected tally() arcana, got {:?}", other),
+    }
+    match &results[5] {
+        EvalResult::Data(Value::Omen(true)) => {}
+        other => panic!("expected contains() boon, got {:?}", other),
+    }
+    match &results[6] {
+        EvalResult::Data(Value::Rune(s)) => assert_eq!(s.as_ref(), "Bright Incantation"),
+        other => panic!("expected replace() rune, got {:?}", other),
+    }
+}
+
+#[test]
+fn rune_split_yields_scroll_of_runes() {
+    let input = r#"
+forge csv: rune = "boon,hex,abyss";
+forge parts: scroll = csv.split(",");
+parts.tally();
+parts[1];
+"#;
+    let results = test_base(input).expect("split should evaluate");
+    assert_eq!(results.len(), 4);
+    match &results[2] {
+        EvalResult::Data(Value::Arcana(3)) => {}
+        other => panic!("expected 3 parts, got {:?}", other),
+    }
+    match &results[3] {
+        EvalResult::Data(Value::Rune(s)) => assert_eq!(s.as_ref(), "hex"),
+        other => panic!("expected rune part, got {:?}", other),
+    }
+}
+
+#[test]
+fn rune_tally_counts_unicode_characters() {
+    let input = r#""呪文詠唱".tally();"#;
+    let results = test_base(input).expect("tally should evaluate");
+    match &results[0] {
+        EvalResult::Data(Value::Arcana(4)) => {}
+        other => panic!("expected 4 characters, got {:?}", other),
+    }
+}
+
+#[test]
+fn rune_split_rejects_empty_separator() {
+    let input = r#""abc".split("");"#;
+    match test_base(input) {
+        Ok(_) => panic!("expected split error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("non-empty separator"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+}

--- a/docs/src/content/docs/reference/types.mdx
+++ b/docs/src/content/docs/reference/types.mdx
@@ -32,4 +32,38 @@ forge ledger: lexicon = {"sun": 1, "moon": 2};
 forge essence: materia = 99;
 ```
 
+## Rune Methods
+
+Runes carry their own rituals for everyday text work. All of them return new values — runes are never mutated in place.
+
+- `rune.upper()` / `rune.lower()` → case-shifted copy.
+- `rune.trim()` → copy with surrounding whitespace removed.
+- `rune.tally()` → character count as `arcana` (Unicode characters, mirroring `scroll.tally()`'s element count).
+- `rune.contains(needle)` → `omen`.
+- `rune.replace(from, to)` → copy with every `from` replaced (the search rune must be non-empty).
+- `rune.split(separator)` → `scroll` of runes (the separator must be non-empty).
+
+```aby
+forge chant: rune = "  Fiat Lux  ";
+forge clean: rune = chant.trim();
+
+unveil(clean.upper());
+unveil(clean.lower());
+unveil(clean.tally().transmute(rune));
+unveil(clean.contains("Lux"));
+unveil(clean.replace("Lux", "Nox"));
+
+forge parts: scroll = "boon,hex,abyss".split(",");
+unveil(parts[1]);
+```
+
+```
+FIAT LUX
+fiat lux
+8
+boon
+Fiat Nox
+hex
+```
+
 Each rune name hints at its intent: `glyph` tokens are passed into conversions, `artifact` declarations craft reusable records, and `materia` absorbs values whose final shape is still unknown.


### PR DESCRIPTION
## Summary

Resolves #533 — the first item of the v0.6.x **Standard Library Essentials** cycle. `rune` previously had **zero** methods; this adds the everyday seven via a new `Type::Rune` table:

| Method | Returns | Notes |
|---|---|---|
| `upper()` / `lower()` | `rune` | case-shifted copy |
| `trim()` | `rune` | surrounding whitespace removed |
| `tally()` | `arcana` | Unicode character count, mirroring `scroll.tally()`'s element count |
| `contains(needle)` | `omen` | |
| `replace(from, to)` | `rune` | non-empty `from` enforced |
| `split(separator)` | `scroll` of runes | non-empty separator enforced |

All methods return new values (runes are never mutated in place), so none require a `morph` receiver. Shared arity/type-error helpers keep the wording uniform (`contains() expects exactly 1 rune argument`, `… expects rune arguments, found arcana`).

Docs: new **Rune Methods** section in `reference/types.mdx`; per AGENTS.md the snippet was executed end-to-end before inclusion (which caught and removed an `omen.transmute(rune)` call — unsupported today).

## Verification

- Unit tests per method (including Unicode `tally`, empty-search/separator rejections, arity/type wording)
- Integration tests in `test_rune.rs` (method chaining, `split`→`scroll` indexing, Unicode count, error path)
- `cargo test --workspace` — all 23 binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)