### PR TITLE
feat(stdlib): add scroll sort, unique, sum, min, and max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ### Added
 
+- **`scroll` ordering and aggregation methods** ([#534](https://github.com/liebe-magi/abyss-lang/issues/534)) — `sort()` and `unique()` return new scrolls (the receiver is untouched, so no `morph` needed); `sum()`, `min()`, and `max()` aggregate homogeneous scrolls of `arcana` / `aether` (/ `rune` for ordering). Empty-scroll aggregation errors for now and moves to `augury` returns in the v0.7.x fallible-API revision.
 - **`rune` methods** ([#533](https://github.com/liebe-magi/abyss-lang/issues/533)) — the first item of the v0.6.x Standard Library Essentials cycle. `upper()`, `lower()`, `trim()`, `tally()` (Unicode character count), `contains(needle)`, `replace(from, to)`, and `split(separator)`. All return new values; `replace` and `split` reject empty search/separator runes with a clear error.
 
 ### Fixed

--- a/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
@@ -12,6 +12,251 @@ pub(super) fn register_methods(registry: &mut BuiltinMethodRegistry) {
     table.insert("tally".to_string(), scroll_tally);
     table.insert("scribe".to_string(), scroll_scribe);
     table.insert("extract".to_string(), scroll_extract);
+    table.insert("sort".to_string(), scroll_sort);
+    table.insert("unique".to_string(), scroll_unique);
+    table.insert("sum".to_string(), scroll_sum);
+    table.insert("min".to_string(), scroll_min);
+    table.insert("max".to_string(), scroll_max);
+}
+
+/// The element kinds the ordering/aggregation methods understand. A scroll
+/// must be homogeneous in one of these for `sort` / `sum` / `min` / `max`.
+#[derive(Clone, Copy, PartialEq)]
+enum ScalarKind {
+    Arcana,
+    Aether,
+    Rune,
+}
+
+fn scalar_kind(value: &Value) -> Option<ScalarKind> {
+    match value {
+        Value::Arcana(_) => Some(ScalarKind::Arcana),
+        Value::Aether(_) => Some(ScalarKind::Aether),
+        Value::Rune(_) => Some(ScalarKind::Rune),
+        _ => None,
+    }
+}
+
+/// Validate that every element shares one orderable kind; error otherwise.
+fn homogeneous_kind(
+    items: &[Value],
+    method: &str,
+    line_info: &Option<Span>,
+) -> Result<ScalarKind, EvalError> {
+    let mut kind: Option<ScalarKind> = None;
+    for item in items {
+        let item_kind = scalar_kind(item).ok_or_else(|| {
+            EvalError::InvalidOperation(
+                format!(
+                    "{}() requires a scroll of arcana, aether, or rune values",
+                    method
+                ),
+                *line_info,
+            )
+        })?;
+        match kind {
+            None => kind = Some(item_kind),
+            Some(existing) if existing == item_kind => {}
+            Some(_) => {
+                return Err(EvalError::InvalidOperation(
+                    format!(
+                        "{}() requires all scroll elements to share one type",
+                        method
+                    ),
+                    *line_info,
+                ));
+            }
+        }
+    }
+    kind.ok_or_else(|| {
+        EvalError::InvalidOperation(
+            format!("{}() cannot operate on an empty scroll", method),
+            *line_info,
+        )
+    })
+}
+
+fn compare_scalars(kind: ScalarKind, a: &Value, b: &Value) -> std::cmp::Ordering {
+    match (kind, a, b) {
+        (ScalarKind::Arcana, Value::Arcana(x), Value::Arcana(y)) => x.cmp(y),
+        (ScalarKind::Aether, Value::Aether(x), Value::Aether(y)) => x.total_cmp(y),
+        (ScalarKind::Rune, Value::Rune(x), Value::Rune(y)) => x.as_ref().cmp(y.as_ref()),
+        _ => unreachable!("homogeneity validated before comparing"),
+    }
+}
+
+/// Returns a new sorted scroll (ascending); the receiver is untouched, so
+/// no `morph` receiver is required.
+fn scroll_sort(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let items = expect_scroll(receiver_value);
+    if !args.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            "sort() does not take any arguments".to_string(),
+            *line_info,
+        ));
+    }
+    let mut sorted: Vec<Value> = items.borrow().clone();
+    if sorted.is_empty() {
+        return Ok(EvalResult::data(Value::Scroll(Rc::new(RefCell::new(
+            sorted,
+        )))));
+    }
+    let kind = homogeneous_kind(&sorted, "sort", line_info)?;
+    sorted.sort_by(|a, b| compare_scalars(kind, a, b));
+    Ok(EvalResult::data(Value::Scroll(Rc::new(RefCell::new(
+        sorted,
+    )))))
+}
+
+/// Returns a new scroll keeping the first occurrence of each scalar value
+/// (arcana / aether / rune / omen); the receiver is untouched.
+fn scroll_unique(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let items = expect_scroll(receiver_value);
+    if !args.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            "unique() does not take any arguments".to_string(),
+            *line_info,
+        ));
+    }
+    let source: Vec<Value> = items.borrow().clone();
+    let mut seen: Vec<Value> = Vec::new();
+    for item in source {
+        let is_scalar = matches!(
+            item,
+            Value::Arcana(_) | Value::Aether(_) | Value::Rune(_) | Value::Omen(_)
+        );
+        if !is_scalar {
+            return Err(EvalError::InvalidOperation(
+                "unique() requires a scroll of scalar values (arcana, aether, rune, omen)"
+                    .to_string(),
+                *line_info,
+            ));
+        }
+        let duplicate = seen.iter().any(|existing| match (existing, &item) {
+            (Value::Arcana(x), Value::Arcana(y)) => x == y,
+            (Value::Aether(x), Value::Aether(y)) => x.total_cmp(y).is_eq(),
+            (Value::Rune(x), Value::Rune(y)) => x.as_ref() == y.as_ref(),
+            (Value::Omen(x), Value::Omen(y)) => x == y,
+            _ => false,
+        });
+        if !duplicate {
+            seen.push(item);
+        }
+    }
+    Ok(EvalResult::data(Value::Scroll(Rc::new(RefCell::new(seen)))))
+}
+
+/// Sums a homogeneous numeric scroll. Empty scrolls error for now; the
+/// v0.7.x fallible-API revision moves the aggregation methods to `augury`
+/// returns (see the roadmap).
+fn scroll_sum(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let items = expect_scroll(receiver_value);
+    if !args.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            "sum() does not take any arguments".to_string(),
+            *line_info,
+        ));
+    }
+    let values: Vec<Value> = items.borrow().clone();
+    let kind = homogeneous_kind(&values, "sum", line_info)?;
+    match kind {
+        ScalarKind::Arcana => {
+            let mut total: i64 = 0;
+            for value in &values {
+                if let Value::Arcana(n) = value {
+                    total += n;
+                }
+            }
+            Ok(EvalResult::data(Value::Arcana(total)))
+        }
+        ScalarKind::Aether => {
+            let mut total: f64 = 0.0;
+            for value in &values {
+                if let Value::Aether(n) = value {
+                    total += n;
+                }
+            }
+            Ok(EvalResult::data(Value::Aether(total)))
+        }
+        ScalarKind::Rune => Err(EvalError::InvalidOperation(
+            "sum() requires a scroll of arcana or aether values".to_string(),
+            *line_info,
+        )),
+    }
+}
+
+fn scroll_extremum(
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    method: &str,
+    want_max: bool,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let items = expect_scroll(receiver_value);
+    if !args.is_empty() {
+        return Err(EvalError::InvalidOperation(
+            format!("{}() does not take any arguments", method),
+            *line_info,
+        ));
+    }
+    let values: Vec<Value> = items.borrow().clone();
+    let kind = homogeneous_kind(&values, method, line_info)?;
+    let mut best = values[0].clone();
+    for value in &values[1..] {
+        let ordering = compare_scalars(kind, value, &best);
+        let better = if want_max {
+            ordering.is_gt()
+        } else {
+            ordering.is_lt()
+        };
+        if better {
+            best = value.clone();
+        }
+    }
+    Ok(EvalResult::data(best))
+}
+
+fn scroll_min(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    scroll_extremum(receiver_value, args, "min", false, line_info)
+}
+
+fn scroll_max(
+    _env: &mut RuntimeEnv,
+    _receiver_ast: &Expr,
+    _receiver_var_name: Option<&str>,
+    receiver_value: Value,
+    args: Vec<CallArg>,
+    line_info: &Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    scroll_extremum(receiver_value, args, "max", true, line_info)
 }
 
 fn scroll_tally(

--- a/crates/abyss-interpreter/tests/test_collections.rs
+++ b/crates/abyss-interpreter/tests/test_collections.rs
@@ -193,3 +193,95 @@ fn define_requires_rune_key() {
         },
     }
 }
+
+#[test]
+fn scroll_sort_unique_sum_min_max() {
+    let input = r#"
+forge xs: scroll = [3, 1, 2, 3, 1];
+xs.sort();
+xs.unique();
+xs.sum();
+xs.min();
+xs.max();
+forge names: scroll = ["hex", "boon", "abyss"];
+names.sort();
+"#;
+    let results = test_base(input).expect("scroll methods should evaluate");
+    assert_eq!(results.len(), 8);
+
+    let as_arcana_vec = |result: &EvalResult| -> Vec<i64> {
+        match result {
+            EvalResult::Data(Value::Scroll(items)) => items
+                .borrow()
+                .iter()
+                .map(|v| match v {
+                    Value::Arcana(n) => *n,
+                    other => panic!("expected arcana element, got {:?}", other),
+                })
+                .collect(),
+            other => panic!("expected scroll, got {:?}", other),
+        }
+    };
+
+    assert_eq!(as_arcana_vec(&results[1]), vec![1, 1, 2, 3, 3]);
+    assert_eq!(as_arcana_vec(&results[2]), vec![3, 1, 2]);
+    assert!(matches!(&results[3], EvalResult::Data(Value::Arcana(10))));
+    assert!(matches!(&results[4], EvalResult::Data(Value::Arcana(1))));
+    assert!(matches!(&results[5], EvalResult::Data(Value::Arcana(3))));
+    match &results[7] {
+        EvalResult::Data(Value::Scroll(items)) => {
+            let names: Vec<String> = items
+                .borrow()
+                .iter()
+                .map(|v| match v {
+                    Value::Rune(s) => s.as_ref().clone(),
+                    other => panic!("expected rune element, got {:?}", other),
+                })
+                .collect();
+            assert_eq!(names, vec!["abyss", "boon", "hex"]);
+        }
+        other => panic!("expected scroll, got {:?}", other),
+    }
+}
+
+#[test]
+fn scroll_sort_leaves_receiver_untouched() {
+    let input = r#"
+forge xs: scroll = [2, 1];
+xs.sort();
+xs[0];
+"#;
+    let results = test_base(input).expect("sort should not mutate");
+    assert!(matches!(&results[2], EvalResult::Data(Value::Arcana(2))));
+}
+
+#[test]
+fn scroll_aggregates_reject_empty_and_mixed() {
+    let empty = r#"
+forge xs: scroll = [];
+xs.min();
+"#;
+    match test_base(empty) {
+        Ok(_) => panic!("expected empty-scroll error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("empty scroll"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+
+    let mixed = r#"
+forge xs: scroll = [1, "two"];
+xs.sum();
+"#;
+    match test_base(mixed) {
+        Ok(_) => panic!("expected mixed-type error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("share one type"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+}

--- a/docs/src/content/docs/reference/collections.mdx
+++ b/docs/src/content/docs/reference/collections.mdx
@@ -26,6 +26,30 @@ Methods keep APIs uniform with artifact calls.
 - `scroll.tally()` → length as `arcana`.
 - `scroll.scribe(value)` → append to a morph scroll.
 - `scroll.extract()` → pop the last entry from a morph scroll.
+- `scroll.sort()` → new ascending scroll (homogeneous `arcana`, `aether`, or `rune` elements); the receiver is untouched.
+- `scroll.unique()` → new scroll keeping the first occurrence of each scalar value.
+- `scroll.sum()` → total of a numeric scroll (`arcana` or `aether`).
+- `scroll.min()` / `scroll.max()` → smallest / largest element.
+
+`sum`, `min`, and `max` raise an error on an empty scroll for now; they move to `augury` returns in the v0.7.x fallible-API revision (see the roadmap).
+
+```aby
+forge rolls: scroll = [3, 1, 2, 3, 1];
+
+unveil(rolls.sort());
+unveil(rolls.unique());
+unveil(rolls.sum().transmute(rune));
+unveil(rolls.min().transmute(rune));
+unveil(rolls.max().transmute(rune));
+```
+
+```
+[1, 1, 2, 3, 3]
+[3, 1, 2]
+10
+1
+3
+```
 - `lexicon.tally()` → number of rune entries.
 - `lexicon.define("key", value)` → insert/update.
 - `lexicon.expunge("key")` → remove an entry.


### PR DESCRIPTION
## Summary

Resolves #534 — second item of the v0.6.x **Standard Library Essentials** cycle (stacked on #537, now merged).

| Method | Returns | Notes |
|---|---|---|
| `sort()` | new `scroll` | ascending; homogeneous `arcana` / `aether` / `rune`; receiver untouched |
| `unique()` | new `scroll` | first occurrence of each scalar value |
| `sum()` | `arcana` / `aether` | numeric scrolls only |
| `min()` / `max()` | element | ordering shared with `sort` |

Design notes:

- **No mutation**: `sort` / `unique` return new scrolls, so they work on immutable receivers (no `morph` machinery involved) — receiver immutability is pinned by a test.
- **Shared homogeneity validation** with uniform wording (`sum() requires all scroll elements to share one type`, `min() cannot operate on an empty scroll`).
- **Empty-scroll aggregation errors for now** — moves to `augury` returns in the v0.7.x fallible-API revision, as recorded in the roadmap and docs.

Docs: `reference/collections.mdx` gains the five bullets and a snippet executed end-to-end before inclusion.

## Verification

- Integration tests: arcana + rune sorting, first-occurrence `unique`, aggregation values, receiver immutability, empty and mixed-type error paths
- `cargo test --workspace` — all 23 binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)