### PR TITLE
feat(stdlib): add math rituals abs, sqrt, floor, and ceil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ### Added
 
+- **Math rituals** ([#535](https://github.com/liebe-magi/abyss-lang/issues/535)) — sandbox-safe global functions `abs` (type-preserving for `arcana` / `aether`), `sqrt` (non-negative `aether`; negative input errors until the v0.7.0 `fate` return), and `floor` / `ceil` (`aether` → `arcana`). Pure functions, identical on CLI and Playground.
 - **`scroll` ordering and aggregation methods** ([#534](https://github.com/liebe-magi/abyss-lang/issues/534)) — `sort()` and `unique()` return new scrolls (the receiver is untouched, so no `morph` needed); `sum()`, `min()`, and `max()` aggregate homogeneous scrolls of `arcana` / `aether` (/ `rune` for ordering). Empty-scroll aggregation errors for now and moves to `augury` returns in the v0.7.x fallible-API revision.
 - **`rune` methods** ([#533](https://github.com/liebe-magi/abyss-lang/issues/533)) — the first item of the v0.6.x Standard Library Essentials cycle. `upper()`, `lower()`, `trim()`, `tally()` (Unicode character count), `contains(needle)`, `replace(from, to)`, and `split(separator)`. All return new values; `replace` and `split` reject empty search/separator runes with a clear error.
 

--- a/crates/abyss-interpreter/src/stdlib/functions/math.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/math.rs
@@ -1,0 +1,183 @@
+//! Sandbox-safe math rituals: pure functions with no I/O, so they behave
+//! identically on the CLI and in the Wasm playground.
+
+use crate::env::{CallArg, RuntimeEnv, Value};
+use crate::eval::values::describe_value;
+use crate::eval::{EvalError, EvalResult};
+use abyss_core::ast::Span;
+
+/// `abs(x)` — magnitude of an `arcana` or `aether`, preserving the type.
+pub fn native_abs(
+    _env: &mut RuntimeEnv,
+    args: Vec<CallArg>,
+    line_info: Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    match take_one_numeric(args, "abs", &line_info)? {
+        Value::Arcana(n) => Ok(EvalResult::data(Value::Arcana(n.abs()))),
+        Value::Aether(n) => Ok(EvalResult::data(Value::Aether(n.abs()))),
+        _ => unreachable!("take_one_numeric only returns numeric values"),
+    }
+}
+
+/// `sqrt(x)` — square root of a non-negative `aether`. Negative input is
+/// an error for now; the v0.7.0 error-handling cycle moves this to a
+/// `fate` return.
+pub fn native_sqrt(
+    _env: &mut RuntimeEnv,
+    args: Vec<CallArg>,
+    line_info: Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let value = take_one_aether(args, "sqrt", &line_info)?;
+    if value < 0.0 {
+        return Err(EvalError::InvalidOperation(
+            "sqrt() requires a non-negative aether".to_string(),
+            line_info,
+        ));
+    }
+    Ok(EvalResult::data(Value::Aether(value.sqrt())))
+}
+
+/// `floor(x)` — largest `arcana` not greater than the `aether` input.
+pub fn native_floor(
+    _env: &mut RuntimeEnv,
+    args: Vec<CallArg>,
+    line_info: Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let value = take_one_aether(args, "floor", &line_info)?;
+    Ok(EvalResult::data(Value::Arcana(value.floor() as i64)))
+}
+
+/// `ceil(x)` — smallest `arcana` not less than the `aether` input.
+pub fn native_ceil(
+    _env: &mut RuntimeEnv,
+    args: Vec<CallArg>,
+    line_info: Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let value = take_one_aether(args, "ceil", &line_info)?;
+    Ok(EvalResult::data(Value::Arcana(value.ceil() as i64)))
+}
+
+fn take_one_value(
+    args: Vec<CallArg>,
+    name: &str,
+    line_info: &Option<Span>,
+) -> Result<Value, EvalError> {
+    if args.len() != 1 {
+        return Err(EvalError::InvalidOperation(
+            format!("{}() expects exactly one argument", name),
+            *line_info,
+        ));
+    }
+    let arg = args.into_iter().next().expect("argument exists");
+    match arg.value {
+        EvalResult::Data(value) => Ok(value),
+        other => Err(EvalError::InvalidOperation(
+            format!("{}() received a non-value argument: {:?}", name, other),
+            *line_info,
+        )),
+    }
+}
+
+fn take_one_numeric(
+    args: Vec<CallArg>,
+    name: &str,
+    line_info: &Option<Span>,
+) -> Result<Value, EvalError> {
+    match take_one_value(args, name, line_info)? {
+        value @ (Value::Arcana(_) | Value::Aether(_)) => Ok(value),
+        other => Err(EvalError::InvalidOperation(
+            format!(
+                "{}() expects an arcana or aether value, found {}",
+                name,
+                describe_value(&other)
+            ),
+            *line_info,
+        )),
+    }
+}
+
+fn take_one_aether(
+    args: Vec<CallArg>,
+    name: &str,
+    line_info: &Option<Span>,
+) -> Result<f64, EvalError> {
+    match take_one_value(args, name, line_info)? {
+        Value::Aether(n) => Ok(n),
+        other => Err(EvalError::InvalidOperation(
+            format!(
+                "{}() expects an aether value, found {} (transmute first)",
+                name,
+                describe_value(&other)
+            ),
+            *line_info,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arg(value: Value) -> Vec<CallArg> {
+        vec![CallArg {
+            value: EvalResult::data(value),
+            var_name: None,
+        }]
+    }
+
+    #[test]
+    fn abs_preserves_numeric_type() {
+        let mut env = RuntimeEnv::new();
+        assert!(matches!(
+            native_abs(&mut env, arg(Value::Arcana(-7)), None),
+            Ok(EvalResult::Data(Value::Arcana(7)))
+        ));
+        match native_abs(&mut env, arg(Value::Aether(-2.5)), None) {
+            Ok(EvalResult::Data(Value::Aether(n))) => assert_eq!(n, 2.5),
+            other => panic!("expected aether, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sqrt_rejects_negative_and_non_aether() {
+        let mut env = RuntimeEnv::new();
+        assert!(matches!(
+            native_sqrt(&mut env, arg(Value::Aether(-1.0)), None),
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("non-negative")
+        ));
+        assert!(matches!(
+            native_sqrt(&mut env, arg(Value::Arcana(4)), None),
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("expects an aether value, found arcana")
+        ));
+        match native_sqrt(&mut env, arg(Value::Aether(9.0)), None) {
+            Ok(EvalResult::Data(Value::Aether(n))) => assert_eq!(n, 3.0),
+            other => panic!("expected aether, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn floor_and_ceil_return_arcana() {
+        let mut env = RuntimeEnv::new();
+        assert!(matches!(
+            native_floor(&mut env, arg(Value::Aether(2.9)), None),
+            Ok(EvalResult::Data(Value::Arcana(2)))
+        ));
+        assert!(matches!(
+            native_ceil(&mut env, arg(Value::Aether(2.1)), None),
+            Ok(EvalResult::Data(Value::Arcana(3)))
+        ));
+        assert!(matches!(
+            native_floor(&mut env, arg(Value::Aether(-2.1)), None),
+            Ok(EvalResult::Data(Value::Arcana(-3)))
+        ));
+    }
+
+    #[test]
+    fn arity_is_enforced() {
+        let mut env = RuntimeEnv::new();
+        assert!(matches!(
+            native_abs(&mut env, vec![], None),
+            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("exactly one argument")
+        ));
+    }
+}

--- a/crates/abyss-interpreter/src/stdlib/functions/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/mod.rs
@@ -1,4 +1,5 @@
 pub mod io;
+pub mod math;
 
 use std::collections::HashMap;
 
@@ -22,6 +23,21 @@ pub fn get_all_global_functions() -> HashMap<String, Callable> {
             func: io::native_summon,
         }),
     );
+
+    for (name, func) in [
+        ("abs", math::native_abs as crate::env::BuiltinFunc),
+        ("sqrt", math::native_sqrt),
+        ("floor", math::native_floor),
+        ("ceil", math::native_ceil),
+    ] {
+        functions.insert(
+            name.to_string(),
+            Callable::Builtin(BuiltinFunction {
+                name: name.to_string(),
+                func,
+            }),
+        );
+    }
 
     functions
 }

--- a/crates/abyss-interpreter/tests/test_calc.rs
+++ b/crates/abyss-interpreter/tests/test_calc.rs
@@ -1108,3 +1108,39 @@ fn test_aether_pow_assign() {
         Err(e) => panic!("Error: {:?}", e),
     }
 }
+
+#[test]
+fn math_rituals_evaluate() {
+    let input = r#"
+abs(-7);
+abs(-2.5);
+sqrt(9.0);
+floor(2.9);
+ceil(2.1);
+"#;
+    let results = test_base(input).expect("math rituals should evaluate");
+    assert!(matches!(&results[0], EvalResult::Data(Value::Arcana(7))));
+    match &results[1] {
+        EvalResult::Data(Value::Aether(n)) => assert_eq!(*n, 2.5),
+        other => panic!("expected aether, got {:?}", other),
+    }
+    match &results[2] {
+        EvalResult::Data(Value::Aether(n)) => assert_eq!(*n, 3.0),
+        other => panic!("expected aether, got {:?}", other),
+    }
+    assert!(matches!(&results[3], EvalResult::Data(Value::Arcana(2))));
+    assert!(matches!(&results[4], EvalResult::Data(Value::Arcana(3))));
+}
+
+#[test]
+fn sqrt_of_negative_errors() {
+    match test_base("sqrt(-1.0);") {
+        Ok(_) => panic!("expected sqrt error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("non-negative"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+}

--- a/docs/src/content/docs/reference/basic-syntax.mdx
+++ b/docs/src/content/docs/reference/basic-syntax.mdx
@@ -14,6 +14,30 @@ AbySS leans into symbolic, magic-inspired keywords without sacrificing readabili
 */
 ```
 
+## Math Rituals
+
+Pure, sandbox-safe helpers available everywhere — including the Playground:
+
+- `abs(x)` → magnitude of an `arcana` or `aether`, preserving the type.
+- `sqrt(x)` → square root of a non-negative `aether` (negative input errors for now; a `fate` return arrives with v0.7.0 error handling).
+- `floor(x)` / `ceil(x)` → nearest `arcana` at or below / above an `aether`.
+
+```aby
+unveil(abs(-7).transmute(rune));
+unveil(abs(-2.5).transmute(rune));
+unveil(sqrt(9.0).transmute(rune));
+unveil(floor(2.9).transmute(rune));
+unveil(ceil(2.1).transmute(rune));
+```
+
+```
+7
+2.5
+3
+2
+3
+```
+
 ## Style Notes
 
 - Keywords such as `forge`, `oracle`, and `orbit` are intentionally thematic but remain deterministic.


### PR DESCRIPTION
## Summary

Resolves #535 — third and final item of the v0.6.x **Standard Library Essentials** cycle (stacked on #538, now merged).

Sandbox-safe global functions registered alongside `unveil` / `summon` (pure, so identical on CLI and Playground):

| Ritual | Signature | Notes |
|---|---|---|
| `abs(x)` | `arcana`→`arcana`, `aether`→`aether` | type-preserving |
| `sqrt(x)` | `aether`→`aether` | non-negative required; negative input errors until the v0.7.0 `fate` return; `arcana` input gets a `transmute first` hint |
| `floor(x)` / `ceil(x)` | `aether`→`arcana` | |

Docs: **Math Rituals** section in `reference/basic-syntax.mdx` with an end-to-end-verified snippet.

## Verification

- Unit tests per function (type preservation, negative `sqrt`, strict `aether` typing, arity)
- Integration tests in `test_calc.rs`
- `cargo test --workspace` — all 23 binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)