### PR TITLE
docs(roadmap): codify the theming boundary for stdlib names

### DIFF
--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -22,6 +22,7 @@ AbySS's reserved words are the language's signature. New keywords are chosen by 
 2. Five-to-seven characters, comfortable to type.
 3. Real English words without programming-language baggage.
 4. One concept, one word — no collisions or near-collisions (this is why the Option type is *not* called `echo`: shell users read `echo` as "print").
+5. Theming is for **keywords, types, and concept-defining APIs** (`forge`, `fate`, `scribe`). Everyday utility helpers keep their familiar names (`min`, `max`, `sqrt`, `upper`) — discoverability beats flavour where no metaphor adds meaning. This is a deliberate split, decided with the v0.6.x stdlib names.
 
 ## Delivered
 


### PR DESCRIPTION
## Summary

One-line addition to the vocabulary principles, making explicit the split that was decided implicitly with the v0.6.x stdlib names: **theming is for keywords, types, and concept-defining APIs; everyday utility helpers keep familiar names** (`min`, `max`, `sqrt`, `upper`) for discoverability.

Recorded so the boundary doesn't get relitigated each stdlib cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)