### PR TITLE
chore(release): bump workspace and extension to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-06
+
+The first Standard Library Essentials point release. `rune` goes from zero methods to the everyday seven, `scroll` learns to sort and aggregate, sandbox-safe math rituals arrive, and a nasty parser bug dies: strings containing `//` (every URL) previously failed to parse. Fully compatibility-preserving — no language or API changes beyond the additions.
+
 ### Added
 
 - **Math rituals** ([#535](https://github.com/liebe-magi/abyss-lang/issues/535)) — sandbox-safe global functions `abs` (type-preserving for `arcana` / `aether`), `sqrt` (non-negative `aether`; negative input errors until the v0.7.0 `fate` return), and `floor` / `ceil` (`aether` → `arcana`). Pure functions, identical on CLI and Playground.
@@ -15,6 +19,8 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 ### Fixed
 
 - **Comment scrubber corrupted string literals containing `//` or `/*`** ([#532](https://github.com/liebe-magi/abyss-lang/issues/532)) — the pre-lex comment scanner treated comment openers inside rune literals as comments, so any string containing them (every URL, for instance) failed to parse. The scanner is now string-aware, honouring the lexer's escape rules, and a single shared region scan backs both the scrubber and the formatter's comment collector so their views cannot diverge. Bonus fix: comments are now blanked byte-wise, so multi-byte characters in comments no longer shift the spans of everything after them.
+
+For the full diff, see the [GitHub compare v0.6.0...v0.6.1](https://github.com/liebe-magi/abyss-lang/compare/v0.6.0...v0.6.1).
 
 ## [0.6.0] - 2026-07-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-interpreter"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "abyss-core",
  "ariadne",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-lang"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 license = "MIT"
@@ -16,8 +16,8 @@ repository = "https://github.com/liebe-magi/abyss-lang"
 homepage = "https://abyss-lang.dev"
 
 [workspace.dependencies]
-abyss-core = { path = "crates/abyss-core", version = "0.6.0" }
-abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.6.0" }
+abyss-core = { path = "crates/abyss-core", version = "0.6.1" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.6.1" }
 ariadne = "0.6"
 chumsky = "0.13"
 ordered-float = "5"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [v0.6.1] - 2026-07-06
+
+### Fixed
+
+- The support-function highlight group now colours `transmute` instead of the removed `trans` (follow-up to the 0.6.0 rename; completion and snippets were already correct).
+
+### Changed
+
+- Bumped the extension version to 0.6.1 to stay in lockstep with the `abyss-lang` crate. The 0.6.1 cycle adds stdlib methods (`rune` / `scroll` / math rituals); per the established convention the completion list covers keywords rather than method names, so no grammar changes beyond the fix above.
+
 ## [v0.6.0] - 2026-07-03
 
 ### Changed

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-codex-familiar",
   "displayName": "AbySS Codex Familiar",
   "description": "Custom syntax highlighting for the AbySS programming language.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "liebe-magi",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release prep for **v0.6.1** — the first Standard Library Essentials point release (compatibility-preserving).

- Root `Cargo.toml` + workspace dep pins + `editors/code/package.json` → `0.6.1` (`check_version_sync.py` passing); `Cargo.lock` regenerated.
- `CHANGELOG.md`: `[Unreleased]` → `[0.6.1] - 2026-07-06` with narrative and compare link.
- Extension changelog: v0.6.1 entry — this version also ships the `transmute` highlight fix from PR #531 to the Marketplace.

## Verification

- `cargo test --workspace` — all 23 binaries pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)