### PR TITLE
feat(lang): add fate and augury types with built-in variant artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ AbySS is a magic-themed scripting language with its own interpreter, formatter, 
 
 ## Domain Vocabulary
 
-Language types map to magical concepts: `arcana` (integer), `aether` (float), `rune` (string), `omen` (boolean with `boon`/`hex`), `abyss` (unit), `scroll`/`lexicon` (collections), `materia` (untyped slot), and `glyph` (type token passed to conversion APIs).
+Language types map to magical concepts: `arcana` (integer), `aether` (float), `rune` (string), `omen` (boolean with `boon`/`hex`), `abyss` (unit), `scroll`/`lexicon` (collections), `materia` (untyped slot), `glyph` (type token passed to conversion APIs), and the error-handling unions `fate` (over the built-in `bless`/`curse` artifacts) and `augury` (over `manifest`/`naught`).
 
 Control flow keywords: `oracle` (conditionals / patterns), `orbit` (loops with `revolve`/`eject`), `engrave` (function definition), `summon` (input), `unveil` (output). Statements terminate with semicolons; block structure relies on braces, so formatter and REPL brace counting must stay accurate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Added
+
+- **`fate` and `augury` types with built-in variant artifacts** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 1/3) — the themed `Result` / `Option`: `fate` admits the pre-seeded `bless { value }` / `curse { reason }` artifacts and `augury` admits `manifest { value }` / `naught {}`. Construction uses ordinary artifact literals, destructuring uses ordinary artifact patterns, and `forge` annotations, `engrave` parameters, and `engrave` return types all accept the union types with call-time enforcement. The six names are reserved in every scope. Payload fields are `materia` until generics land.
+
 ## [0.6.1] - 2026-07-06
 
 The first Standard Library Essentials point release. `rune` goes from zero methods to the everyday seven, `scroll` learns to sort and aggregate, sandbox-safe math rituals arrive, and a nasty parser bug dies: strings containing `//` (every URL) previously failed to parse. Fully compatibility-preserving — no language or API changes beyond the additions.

--- a/crates/abyss-core/src/ast.rs
+++ b/crates/abyss-core/src/ast.rs
@@ -227,6 +227,12 @@ pub enum Type {
     Lexicon,
     Materia,
     Glyph,
+    /// Union type over the built-in `bless` / `curse` artifacts (the
+    /// themed `Result`). Payloads are `materia` until generics land.
+    Fate,
+    /// Union type over the built-in `manifest` / `naught` artifacts
+    /// (the themed `Option`).
+    Augury,
     Artifact(String),
 }
 

--- a/crates/abyss-core/src/format.rs
+++ b/crates/abyss-core/src/format.rs
@@ -102,6 +102,8 @@ fn type_keyword(var_type: &Type) -> String {
         Type::Lexicon => "lexicon".to_string(),
         Type::Materia => "materia".to_string(),
         Type::Glyph => "glyph".to_string(),
+        Type::Fate => "fate".to_string(),
+        Type::Augury => "augury".to_string(),
         Type::Artifact(name) => name.clone(),
     }
 }

--- a/crates/abyss-core/src/parser/grammar/statements.rs
+++ b/crates/abyss-core/src/parser/grammar/statements.rs
@@ -626,6 +626,8 @@ pub(super) fn type_keyword_name(ty: &Type) -> String {
         Type::Lexicon => "lexicon",
         Type::Materia => "materia",
         Type::Glyph => "glyph",
+        Type::Fate => "fate",
+        Type::Augury => "augury",
         Type::Artifact(name) => name,
     }
     .to_string()

--- a/crates/abyss-core/src/parser/tokens.rs
+++ b/crates/abyss-core/src/parser/tokens.rs
@@ -215,6 +215,8 @@ pub fn lexer<'src>() -> impl Parser<'src, &'src str, Vec<SpannedToken>, LexerExt
         "lexicon" => Token::Type(Type::Lexicon),
         "materia" => Token::Type(Type::Materia),
         "glyph" => Token::Type(Type::Glyph),
+        "fate" => Token::Type(Type::Fate),
+        "augury" => Token::Type(Type::Augury),
         "boon" => Token::OmenLiteral(true),
         "hex" => Token::OmenLiteral(false),
         _ => Token::Identifier(ident.to_string()),

--- a/crates/abyss-interpreter/src/env.rs
+++ b/crates/abyss-interpreter/src/env.rs
@@ -269,7 +269,30 @@ impl RuntimeEnv {
         }
     }
 
+    /// Names claimed by the error-handling built-ins. User artifacts may
+    /// not use them in any scope, so `bless { … }` always means the seeded
+    /// variant and patterns can never be shadowed into silence.
+    pub const RESERVED_ARTIFACT_NAMES: [&'static str; 6] =
+        ["fate", "augury", "bless", "curse", "manifest", "naught"];
+
+    /// Registers a built-in artifact schema, bypassing the reserved-name
+    /// guard. Only the stdlib seeding path uses this.
+    pub(crate) fn define_builtin_artifact(&mut self, schema: ArtifactSchema) {
+        if let Some(scope) = self.artifact_scopes.first_mut() {
+            scope.insert(schema.name.clone(), schema);
+        }
+    }
+
     pub fn define_artifact(&mut self, schema: ArtifactSchema) -> Result<(), EvalError> {
+        if Self::RESERVED_ARTIFACT_NAMES.contains(&schema.name.as_str()) {
+            return Err(EvalError::InvalidOperation(
+                format!(
+                    "Artifact name {} is reserved by the error-handling built-ins",
+                    schema.name
+                ),
+                schema.line_info,
+            ));
+        }
         if let Some(scope) = self.artifact_scopes.last_mut() {
             if scope.contains_key(&schema.name) {
                 return Err(EvalError::InvalidOperation(

--- a/crates/abyss-interpreter/src/eval/expressions.rs
+++ b/crates/abyss-interpreter/src/eval/expressions.rs
@@ -655,6 +655,27 @@ fn evaluate_engraved_function(
         (Type::Scroll, Value::Scroll(values)) => Ok(EvalResult::data(Value::Scroll(values))),
         (Type::Lexicon, Value::Lexicon(entries)) => Ok(EvalResult::data(Value::Lexicon(entries))),
         (Type::Materia, value) => Ok(EvalResult::data(value)),
+        (ty @ (Type::Fate | Type::Augury), Value::Artifact(handle)) => {
+            let allowed: [&str; 2] = if ty == Type::Fate {
+                ["bless", "curse"]
+            } else {
+                ["manifest", "naught"]
+            };
+            let type_name = handle.borrow().type_name.clone();
+            if allowed.contains(&type_name.as_str()) {
+                Ok(EvalResult::artifact(handle))
+            } else {
+                Err(EvalError::TypeError(
+                    format!(
+                        "Type mismatch for return value of function {} (expected {}, got artifact {})",
+                        function.name,
+                        if ty == Type::Fate { "fate" } else { "augury" },
+                        type_name
+                    ),
+                    function.line_info,
+                ))
+            }
+        }
         (Type::Artifact(expected), Value::Artifact(handle)) => {
             let type_name = handle.borrow().type_name.clone();
             if type_name == expected {

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -78,6 +78,8 @@ fn type_label(ty: &Type) -> &str {
         Type::Lexicon => "lexicon",
         Type::Glyph => "glyph",
         Type::Materia => "materia",
+        Type::Fate => "fate",
+        Type::Augury => "augury",
         Type::Artifact(name) => name,
     }
 }

--- a/crates/abyss-interpreter/src/eval/statements.rs
+++ b/crates/abyss-interpreter/src/eval/statements.rs
@@ -165,6 +165,19 @@ pub fn evaluate(stmt: &Stmt, env: &mut RuntimeEnv) -> Result<EvalResult, EvalErr
                         *value_slot =
                             convert_to_typed_value(evaluated_value, &Type::Lexicon, line_info)?;
                     }
+                    (value_slot, ty @ (Type::Fate | Type::Augury)) => {
+                        if !matches!(op, AssignmentOp::Assign) {
+                            return Err(EvalError::InvalidOperation(
+                                format!(
+                                    "{} variables only support =",
+                                    if *ty == Type::Fate { "Fate" } else { "Augury" }
+                                ),
+                                *line_info,
+                            ));
+                        }
+                        let ty = ty.clone();
+                        *value_slot = convert_to_typed_value(evaluated_value, &ty, line_info)?;
+                    }
                     (value_slot, Type::Materia) => {
                         if !matches!(op, AssignmentOp::Assign) {
                             return Err(EvalError::InvalidOperation(
@@ -469,6 +482,15 @@ pub fn evaluate(stmt: &Stmt, env: &mut RuntimeEnv) -> Result<EvalResult, EvalErr
             fields,
             span: line_info,
         } => {
+            if RuntimeEnv::RESERVED_ARTIFACT_NAMES.contains(&name.as_str()) {
+                return Err(EvalError::InvalidOperation(
+                    format!(
+                        "Artifact name {} is reserved by the error-handling built-ins",
+                        name
+                    ),
+                    *line_info,
+                ));
+            }
             if env.artifact_defined_in_current_scope(name) {
                 return Err(EvalError::InvalidOperation(
                     format!("Artifact {} is already defined", name),

--- a/crates/abyss-interpreter/src/eval/values.rs
+++ b/crates/abyss-interpreter/src/eval/values.rs
@@ -85,6 +85,21 @@ pub(crate) fn convert_to_typed_value(
             Value::Glyph(_) => Ok(value),
             _ => Err(EvalError::ExpectedType(Type::Glyph, *line_info)),
         },
+        Type::Fate | Type::Augury => {
+            let allowed: [&str; 2] = if *expected == Type::Fate {
+                ["bless", "curse"]
+            } else {
+                ["manifest", "naught"]
+            };
+            match value {
+                Value::Artifact(handle)
+                    if allowed.contains(&handle.borrow().type_name.as_str()) =>
+                {
+                    Ok(Value::Artifact(clone_artifact_handle(&handle)))
+                }
+                _ => Err(EvalError::ExpectedType(expected.clone(), *line_info)),
+            }
+        }
         Type::Artifact(expected) => match value {
             Value::Artifact(handle) => {
                 let borrowed = handle.borrow();

--- a/crates/abyss-interpreter/src/stdlib/functions/io.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/io.rs
@@ -124,6 +124,8 @@ fn glyph_label(var_type: &Type) -> String {
         Type::Lexicon => "lexicon".to_string(),
         Type::Materia => "materia".to_string(),
         Type::Glyph => "glyph".to_string(),
+        Type::Fate => "fate".to_string(),
+        Type::Augury => "augury".to_string(),
         Type::Artifact(name) => name.clone(),
     }
 }

--- a/crates/abyss-interpreter/src/stdlib/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/mod.rs
@@ -28,6 +28,45 @@ fn seed_builtin_glyphs(env: &mut RuntimeEnv) {
     }
 }
 
+/// Seed the error-handling variant artifacts (`bless` / `curse` for
+/// `fate`, `manifest` / `naught` for `augury`) plus their glyph
+/// variables, mirroring what an `artifact` definition would create.
+/// Payload fields are `materia` until generics land.
+fn seed_error_handling_artifacts(env: &mut RuntimeEnv) {
+    use crate::artifact::{ArtifactFieldSchema, ArtifactSchema};
+    use std::collections::HashMap;
+
+    let variants: [(&str, Option<&str>); 4] = [
+        ("bless", Some("value")),
+        ("curse", Some("reason")),
+        ("manifest", Some("value")),
+        ("naught", None),
+    ];
+    for (name, field) in variants {
+        let fields = field
+            .map(|f| {
+                vec![ArtifactFieldSchema {
+                    name: f.to_string(),
+                    field_type: Type::Materia,
+                }]
+            })
+            .unwrap_or_default();
+        env.define_builtin_artifact(ArtifactSchema {
+            name: name.to_string(),
+            fields,
+            methods: HashMap::new(),
+            line_info: None,
+        });
+        env.set_var(
+            name.to_string(),
+            Value::Glyph(Type::Artifact(name.to_string())),
+            Type::Glyph,
+            false,
+            None,
+        );
+    }
+}
+
 pub fn create_global_environment() -> RuntimeEnv {
     let mut env = RuntimeEnv::new();
     let functions = functions::get_all_global_functions();
@@ -35,6 +74,7 @@ pub fn create_global_environment() -> RuntimeEnv {
     let methods = methods::get_all_builtin_methods();
     env.set_builtin_methods(methods);
     seed_builtin_glyphs(&mut env);
+    seed_error_handling_artifacts(&mut env);
     env
 }
 

--- a/crates/abyss-interpreter/tests/test_fate.rs
+++ b/crates/abyss-interpreter/tests/test_fate.rs
@@ -1,0 +1,160 @@
+mod common;
+
+use abyss_interpreter::env::Value;
+use abyss_interpreter::eval::{EvalError, EvalResult};
+use common::test_base;
+
+fn expect_artifact_name(result: &EvalResult, expected: &str) {
+    match result {
+        EvalResult::Data(Value::Artifact(handle)) => {
+            assert_eq!(handle.borrow().type_name, expected);
+        }
+        other => panic!("expected {} artifact, got {:?}", expected, other),
+    }
+}
+
+#[test]
+fn fate_variants_construct_and_annotate() {
+    let input = r#"
+forge ok: fate = bless { value: 42 };
+forge bad: fate = curse { reason: "misfired" };
+ok;
+bad;
+"#;
+    let results = test_base(input).expect("fate construction should evaluate");
+    expect_artifact_name(&results[2], "bless");
+    expect_artifact_name(&results[3], "curse");
+}
+
+#[test]
+fn augury_variants_construct_and_annotate() {
+    let input = r#"
+forge found: augury = manifest { value: "sigil" };
+forge missing: augury = naught {};
+found;
+missing;
+"#;
+    let results = test_base(input).expect("augury construction should evaluate");
+    expect_artifact_name(&results[2], "manifest");
+    expect_artifact_name(&results[3], "naught");
+}
+
+#[test]
+fn fate_destructures_with_artifact_patterns() {
+    let input = r#"
+forge result: fate = bless { value: 7 };
+oracle (result) {
+    bless { value } => value;
+    curse { reason } => 0;
+};
+"#;
+    let results = test_base(input).expect("fate pattern match should evaluate");
+    match &results[1] {
+        EvalResult::Data(Value::Arcana(7)) => {}
+        other => panic!("expected unwrapped 7, got {:?}", other),
+    }
+}
+
+#[test]
+fn fate_annotation_rejects_other_values() {
+    let input = r#"forge r: fate = 42;"#;
+    match test_base(input) {
+        Ok(_) => panic!("expected type error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::ExpectedType(ty, _)) => {
+                assert_eq!(format!("{:?}", ty), "Fate");
+            }
+            other => panic!("expected ExpectedType, got {:?}", other),
+        },
+    }
+}
+
+#[test]
+fn fate_annotation_rejects_augury_variants() {
+    let input = r#"forge r: fate = naught {};"#;
+    match test_base(input) {
+        Ok(_) => panic!("expected type error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::ExpectedType(_, _)) => {}
+            other => panic!("expected ExpectedType, got {:?}", other),
+        },
+    }
+}
+
+#[test]
+fn engrave_fate_return_enforced() {
+    let ok = r#"
+engrave parse_level(raw: arcana) -> fate {
+    oracle {
+        (raw >= 0) => reveal bless { value: raw };
+        _ => reveal curse { reason: "negative" };
+    };
+};
+parse_level(5);
+parse_level(0 - 1);
+"#;
+    let results = test_base(ok).expect("fate-returning function should work");
+    expect_artifact_name(&results[1], "bless");
+    expect_artifact_name(&results[2], "curse");
+
+    let bad = r#"
+artifact Player { name: rune; };
+engrave broken() -> fate {
+    reveal Player { name: "Ardyn" };
+};
+broken();
+"#;
+    match test_base(bad) {
+        Ok(_) => panic!("expected return-type error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::TypeError(msg, _)) => {
+                assert!(
+                    msg.contains("expected fate, got artifact Player"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected type error, got {:?}", other),
+        },
+    }
+}
+
+#[test]
+fn morph_fate_reassignment_works() {
+    let input = r#"
+forge morph r: fate = bless { value: 1 };
+r = curse { reason: "flipped" };
+r;
+"#;
+    let results = test_base(input).expect("fate reassignment should work");
+    expect_artifact_name(&results[2], "curse");
+}
+
+#[test]
+fn reserved_variant_names_cannot_be_redefined() {
+    let input = r#"artifact bless { value: arcana; };"#;
+    match test_base(input) {
+        Ok(_) => panic!("expected reserved-name error"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("reserved"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+
+    let inner = r#"
+engrave shadow() -> abyss {
+    artifact naught { ghost: arcana; };
+};
+shadow();
+"#;
+    match test_base(inner) {
+        Ok(_) => panic!("expected reserved-name error in inner scope"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::InvalidOperation(msg, _)) => {
+                assert!(msg.contains("reserved"), "msg: {msg}");
+            }
+            other => panic!("expected invalid operation, got {:?}", other),
+        },
+    }
+}


### PR DESCRIPTION
## Summary

PR 1/3 of the v0.7.0 error-handling cycle (design: #548, owner-approved).

- **`Type::Fate` / `Type::Augury`** — union types over pre-seeded variant artifacts: `bless { value }` / `curse { reason }` and `manifest { value }` / `naught {}` (payloads `materia` until generics).
- **Zero new literal/pattern machinery**: construction is an ordinary artifact literal, destructuring an ordinary artifact pattern — as promised on the roadmap.
- Typing surface: `forge r: fate = bless { value: 42 };`, `engrave f(...) -> fate` (return values checked: only the matching variant pair is accepted), parameters, and `morph` reassignment.
- **Reserved names** (decision 1 on #548): the six names are rejected in *any* scope, with the reserved-name check running before the duplicate-definition guard so the message states the real reason.
- `AGENTS.md` domain vocabulary updated.

Example (executed end-to-end):

```aby
engrave safe_div(a: arcana, b: arcana) -> fate {
    oracle {
        (b == 0) => reveal curse { reason: "division by zero" };
        _ => reveal bless { value: a / b };
    };
};

oracle (safe_div(10, 2)) {
    bless { value } => unveil(value);
    curse { reason } => unveil(reason);
};
```

Next: PR 2 adds the `?` propagation operator; PR 3 revises the fallible stdlib APIs and adds the docs page.

## Verification

- New `tests/test_fate.rs`: construction/annotation for both unions, pattern destructuring, wrong-value and cross-union rejections, return-type enforcement (positive + negative), `morph` reassignment, reserved-name rejection at top level and in inner scopes
- `cargo test --workspace` — all 24 test binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)