### PR TITLE
feat(stdlib)!: fallible APIs return fate and augury

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Changed (breaking — stdlib)
+
+- **Fallible stdlib APIs return `fate` / `augury`** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 3/3) — `scroll.min()` / `scroll.max()` now return `manifest { value }` or `naught {}` instead of a bare element / an empty-scroll error, and `sqrt(x)` returns `bless { value }` or `curse { reason }` instead of erroring on negative input — so `sqrt(x)?` is the everyday form. The convention: data-dependent failure returns a union; programming errors (wrong types, arity) keep raising diagnostics. `sum()` still errors on empty scrolls pending generics.
+
 ### Added
 
 - **`?` propagation operator** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 2/3) — postfix `expr?` unwraps a `bless` / `manifest` payload, or propagates the `curse` / `naught` out of the enclosing `engrave` as its return value (checked against the declared return type; cross-union propagation is rejected, no implicit conversion). A propagation that reaches the top level renders as an `Uncaught curse: …` / `Uncaught naught` diagnostic underlining the `?` expression, and `abyss invoke` now exits non-zero on any script failure. Scope depth is restored exactly at the catch point even when the propagation unwound out of nested `orbit` / `oracle` scopes.

--- a/crates/abyss-interpreter/src/stdlib/functions/math.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/math.rs
@@ -19,22 +19,32 @@ pub fn native_abs(
     }
 }
 
-/// `sqrt(x)` — square root of a non-negative `aether`. Negative input is
-/// an error for now; the v0.7.0 error-handling cycle moves this to a
-/// `fate` return.
+/// `sqrt(x)` — square root as a `fate`: `bless {{ value }}` for a
+/// non-negative `aether`, `curse {{ reason }}` for a negative one, so
+/// call sites write `sqrt(x)?` (v0.7.0 fallible-API convention,
+/// design: #548). A non-`aether` argument remains a hard error —
+/// that's a programming mistake, not data-dependent failure.
 pub fn native_sqrt(
     _env: &mut RuntimeEnv,
     args: Vec<CallArg>,
     line_info: Option<Span>,
 ) -> Result<EvalResult, EvalError> {
+    use std::rc::Rc;
+
     let value = take_one_aether(args, "sqrt", &line_info)?;
     if value < 0.0 {
-        return Err(EvalError::InvalidOperation(
-            "sqrt() requires a non-negative aether".to_string(),
-            line_info,
-        ));
+        return Ok(EvalResult::data(crate::stdlib::make_variant(
+            "curse",
+            Some((
+                "reason",
+                Value::Rune(Rc::new("sqrt() requires a non-negative aether".to_string())),
+            )),
+        )));
     }
-    Ok(EvalResult::data(Value::Aether(value.sqrt())))
+    Ok(EvalResult::data(crate::stdlib::make_variant(
+        "bless",
+        Some(("value", Value::Aether(value.sqrt()))),
+    )))
 }
 
 /// `floor(x)` — largest `arcana` not greater than the `aether` input.
@@ -139,19 +149,27 @@ mod tests {
     }
 
     #[test]
-    fn sqrt_rejects_negative_and_non_aether() {
+    fn sqrt_returns_fate_variants() {
         let mut env = RuntimeEnv::new();
-        assert!(matches!(
-            native_sqrt(&mut env, arg(Value::Aether(-1.0)), None),
-            Err(EvalError::InvalidOperation(msg, _)) if msg.contains("non-negative")
-        ));
+        match native_sqrt(&mut env, arg(Value::Aether(-1.0)), None) {
+            Ok(EvalResult::Data(Value::Artifact(handle))) => {
+                assert_eq!(handle.borrow().type_name, "curse");
+            }
+            other => panic!("expected curse, got {:?}", other),
+        }
         assert!(matches!(
             native_sqrt(&mut env, arg(Value::Arcana(4)), None),
             Err(EvalError::InvalidOperation(msg, _)) if msg.contains("expects an aether value, found arcana")
         ));
         match native_sqrt(&mut env, arg(Value::Aether(9.0)), None) {
-            Ok(EvalResult::Data(Value::Aether(n))) => assert_eq!(n, 3.0),
-            other => panic!("expected aether, got {:?}", other),
+            Ok(EvalResult::Data(Value::Artifact(handle))) => {
+                let borrowed = handle.borrow();
+                assert_eq!(borrowed.type_name, "bless");
+                assert!(
+                    matches!(borrowed.fields.get("value"), Some(Value::Aether(n)) if *n == 3.0)
+                );
+            }
+            other => panic!("expected bless, got {:?}", other),
         }
     }
 

--- a/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
+++ b/crates/abyss-interpreter/src/stdlib/methods/scroll.rs
@@ -206,6 +206,10 @@ fn scroll_sum(
     }
 }
 
+/// `min` / `max` return an `augury`: `manifest {{ value }}` with the
+/// extremum, or `naught {{}}` for an empty scroll — the v0.7.0
+/// fallible-API convention (design: #548). Mixed-type scrolls remain a
+/// hard error (programming error, not data-dependent absence).
 fn scroll_extremum(
     receiver_value: Value,
     args: Vec<CallArg>,
@@ -221,6 +225,11 @@ fn scroll_extremum(
         ));
     }
     let values: Vec<Value> = items.borrow().clone();
+    if values.is_empty() {
+        return Ok(EvalResult::data(crate::stdlib::make_variant(
+            "naught", None,
+        )));
+    }
     let kind = homogeneous_kind(&values, method, line_info)?;
     let mut best = values[0].clone();
     for value in &values[1..] {
@@ -234,7 +243,10 @@ fn scroll_extremum(
             best = value.clone();
         }
     }
-    Ok(EvalResult::data(best))
+    Ok(EvalResult::data(crate::stdlib::make_variant(
+        "manifest",
+        Some(("value", best)),
+    )))
 }
 
 fn scroll_min(

--- a/crates/abyss-interpreter/src/stdlib/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/mod.rs
@@ -67,6 +67,27 @@ fn seed_error_handling_artifacts(env: &mut RuntimeEnv) {
     }
 }
 
+/// Construct one of the error-handling variant artifacts from Rust —
+/// the stdlib's counterpart of writing `bless {{ value: … }}` in AbySS.
+pub(crate) fn make_variant(name: &str, field: Option<(&str, Value)>) -> Value {
+    use crate::artifact::ArtifactValue;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    let mut fields = HashMap::new();
+    let mut field_order = Vec::new();
+    if let Some((field_name, value)) = field {
+        field_order.push(field_name.to_string());
+        fields.insert(field_name.to_string(), value);
+    }
+    Value::Artifact(Rc::new(RefCell::new(ArtifactValue {
+        type_name: name.to_string(),
+        fields,
+        field_order,
+    })))
+}
+
 pub fn create_global_environment() -> RuntimeEnv {
     let mut env = RuntimeEnv::new();
     let functions = functions::get_all_global_functions();

--- a/crates/abyss-interpreter/tests/test_calc.rs
+++ b/crates/abyss-interpreter/tests/test_calc.rs
@@ -1125,22 +1125,42 @@ ceil(2.1);
         other => panic!("expected aether, got {:?}", other),
     }
     match &results[2] {
-        EvalResult::Data(Value::Aether(n)) => assert_eq!(*n, 3.0),
-        other => panic!("expected aether, got {:?}", other),
+        EvalResult::Data(Value::Artifact(handle)) => {
+            let borrowed = handle.borrow();
+            assert_eq!(borrowed.type_name, "bless");
+            assert!(matches!(borrowed.fields.get("value"), Some(Value::Aether(n)) if *n == 3.0));
+        }
+        other => panic!("expected bless, got {:?}", other),
     }
     assert!(matches!(&results[3], EvalResult::Data(Value::Arcana(2))));
     assert!(matches!(&results[4], EvalResult::Data(Value::Arcana(3))));
 }
 
 #[test]
-fn sqrt_of_negative_errors() {
-    match test_base("sqrt(-1.0);") {
-        Ok(_) => panic!("expected sqrt error"),
-        Err(err) => match err.downcast_ref::<EvalError>() {
-            Some(EvalError::InvalidOperation(msg, _)) => {
-                assert!(msg.contains("non-negative"), "msg: {msg}");
-            }
-            other => panic!("expected invalid operation, got {:?}", other),
-        },
+fn sqrt_of_negative_returns_curse() {
+    let results = test_base("sqrt(-1.0);").expect("sqrt should return a fate");
+    match &results[0] {
+        EvalResult::Data(Value::Artifact(handle)) => {
+            assert_eq!(handle.borrow().type_name, "curse");
+        }
+        other => panic!("expected curse, got {:?}", other),
+    }
+}
+
+#[test]
+fn sqrt_composes_with_question_operator() {
+    let input = r#"
+engrave hypot(a: aether, b: aether) -> fate {
+    reveal bless { value: sqrt(a * a + b * b)? };
+};
+oracle (hypot(3.0, 4.0)) {
+    bless { value } => value;
+    curse { reason } => 0.0;
+};
+"#;
+    let results = test_base(input).expect("hypot should evaluate");
+    match results.last().unwrap() {
+        EvalResult::Data(Value::Aether(n)) => assert_eq!(*n, 5.0),
+        other => panic!("expected 5.0, got {:?}", other),
     }
 }

--- a/crates/abyss-interpreter/tests/test_collections.rs
+++ b/crates/abyss-interpreter/tests/test_collections.rs
@@ -226,8 +226,18 @@ names.sort();
     assert_eq!(as_arcana_vec(&results[1]), vec![1, 1, 2, 3, 3]);
     assert_eq!(as_arcana_vec(&results[2]), vec![3, 1, 2]);
     assert!(matches!(&results[3], EvalResult::Data(Value::Arcana(10))));
-    assert!(matches!(&results[4], EvalResult::Data(Value::Arcana(1))));
-    assert!(matches!(&results[5], EvalResult::Data(Value::Arcana(3))));
+    let expect_manifest = |result: &EvalResult, expected: i64| match result {
+        EvalResult::Data(Value::Artifact(handle)) => {
+            let borrowed = handle.borrow();
+            assert_eq!(borrowed.type_name, "manifest");
+            assert!(
+                matches!(borrowed.fields.get("value"), Some(Value::Arcana(n)) if *n == expected)
+            );
+        }
+        other => panic!("expected manifest, got {:?}", other),
+    };
+    expect_manifest(&results[4], 1);
+    expect_manifest(&results[5], 3);
     match &results[7] {
         EvalResult::Data(Value::Scroll(items)) => {
             let names: Vec<String> = items
@@ -261,14 +271,12 @@ fn scroll_aggregates_reject_empty_and_mixed() {
 forge xs: scroll = [];
 xs.min();
 "#;
-    match test_base(empty) {
-        Ok(_) => panic!("expected empty-scroll error"),
-        Err(err) => match err.downcast_ref::<EvalError>() {
-            Some(EvalError::InvalidOperation(msg, _)) => {
-                assert!(msg.contains("empty scroll"), "msg: {msg}");
-            }
-            other => panic!("expected invalid operation, got {:?}", other),
-        },
+    let results = test_base(empty).expect("empty min should return naught");
+    match results.last().unwrap() {
+        EvalResult::Data(Value::Artifact(handle)) => {
+            assert_eq!(handle.borrow().type_name, "naught");
+        }
+        other => panic!("expected naught, got {:?}", other),
     }
 
     let mixed = r#"

--- a/crates/abyss-interpreter/tests/test_examples.rs
+++ b/crates/abyss-interpreter/tests/test_examples.rs
@@ -34,6 +34,12 @@ fn artifact_example_executes() {
 }
 
 #[test]
+fn fate_example_executes() {
+    let source = load_example("fate.aby");
+    test_base(&source).expect("fate example failed to execute");
+}
+
+#[test]
 fn pattern_example_executes() {
     let source = load_example("pattern.aby");
     test_base(&source).expect("pattern example failed to execute");

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
                         { label: 'Control Flow: Pattern Matching', slug: 'reference/pattern-matching' },
                         { label: 'Control Flow: Loops', slug: 'reference/loops' },
                         { label: 'Functions', slug: 'reference/functions' },
+                        { label: 'Error Handling', slug: 'reference/error-handling' },
                         { label: 'Collections', slug: 'reference/collections' },
                         { label: 'Artifacts', slug: 'reference/artifacts' },
                     ],

--- a/docs/src/content/docs/reference/basic-syntax.mdx
+++ b/docs/src/content/docs/reference/basic-syntax.mdx
@@ -19,13 +19,16 @@ AbySS leans into symbolic, magic-inspired keywords without sacrificing readabili
 Pure, sandbox-safe helpers available everywhere — including the Playground:
 
 - `abs(x)` → magnitude of an `arcana` or `aether`, preserving the type.
-- `sqrt(x)` → square root of a non-negative `aether` (negative input errors for now; a `fate` return arrives with v0.7.0 error handling).
+- `sqrt(x)` → a `fate`: `bless { value }` with the square root, or `curse { reason }` for a negative input — so `sqrt(x)?` is the everyday form (see [Error Handling](/reference/error-handling/)).
 - `floor(x)` / `ceil(x)` → nearest `arcana` at or below / above an `aether`.
 
 ```aby
 unveil(abs(-7).transmute(rune));
 unveil(abs(-2.5).transmute(rune));
-unveil(sqrt(9.0).transmute(rune));
+oracle (sqrt(9.0)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
 unveil(floor(2.9).transmute(rune));
 unveil(ceil(2.1).transmute(rune));
 ```

--- a/docs/src/content/docs/reference/collections.mdx
+++ b/docs/src/content/docs/reference/collections.mdx
@@ -29,9 +29,9 @@ Methods keep APIs uniform with artifact calls.
 - `scroll.sort()` → new ascending scroll (homogeneous `arcana`, `aether`, or `rune` elements); the receiver is untouched.
 - `scroll.unique()` → new scroll keeping the first occurrence of each scalar value.
 - `scroll.sum()` → total of a numeric scroll (`arcana` or `aether`).
-- `scroll.min()` / `scroll.max()` → smallest / largest element.
+- `scroll.min()` / `scroll.max()` → an `augury`: `manifest { value }` with the smallest / largest element, or `naught {}` for an empty scroll (see [Error Handling](/reference/error-handling/)).
 
-`sum`, `min`, and `max` raise an error on an empty scroll for now; they move to `augury` returns in the v0.7.x fallible-API revision (see the roadmap).
+`sum` raises an error on an empty scroll; mixed-type scrolls are an error for all aggregation methods.
 
 ```aby
 forge rolls: scroll = [3, 1, 2, 3, 1];
@@ -39,8 +39,10 @@ forge rolls: scroll = [3, 1, 2, 3, 1];
 unveil(rolls.sort());
 unveil(rolls.unique());
 unveil(rolls.sum().transmute(rune));
-unveil(rolls.min().transmute(rune));
-unveil(rolls.max().transmute(rune));
+oracle (rolls.min()) {
+    manifest { value } => unveil(value);
+    naught {} => unveil("empty scroll");
+};
 ```
 
 ```
@@ -48,7 +50,6 @@ unveil(rolls.max().transmute(rune));
 [3, 1, 2]
 10
 1
-3
 ```
 - `lexicon.tally()` → number of rune entries.
 - `lexicon.define("key", value)` → insert/update.

--- a/docs/src/content/docs/reference/error-handling.mdx
+++ b/docs/src/content/docs/reference/error-handling.mdx
@@ -1,0 +1,99 @@
+---
+title: Error Handling
+description: fate, augury, and the ? propagation operator.
+---
+
+AbySS promotes failures from "the interpreter prints a diagnostic and aborts" to values your rituals can handle. Two union types cover the everyday cases:
+
+| Type | Variants | Meaning |
+|---|---|---|
+| `fate` | `bless { value }` / `curse { reason }` | an operation that succeeds or fails (the themed `Result`) |
+| `augury` | `manifest { value }` / `naught {}` | a reading that reveals something, or nothing (the themed `Option`) |
+
+The variants are ordinary artifacts: you construct them with artifact literals and destructure them with the artifact patterns you already know. Their names — and `fate` / `augury` themselves — are reserved; no user artifact may claim them. Payload fields are `materia` until generics arrive.
+
+## Returning a fate
+
+```aby
+engrave parse_rank(raw: arcana) -> fate {
+    oracle {
+        (raw < 0) => reveal curse { reason: "rank must be non-negative" };
+        _ => reveal bless { value: raw * 10 };
+    };
+};
+
+oracle (parse_rank(3)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
+```
+
+```
+30
+```
+
+A function declared `-> fate` may only return `bless` or `curse`; `-> augury` only `manifest` or `naught`. Anything else is a call-time type error.
+
+## The `?` operator
+
+Postfix `?` unwraps a success variant, or returns the failure variant from the enclosing `engrave` — so straight-line code stays straight:
+
+```aby
+engrave parse_rank(raw: arcana) -> fate {
+    oracle {
+        (raw < 0) => reveal curse { reason: "rank must be non-negative" };
+        _ => reveal bless { value: raw * 10 };
+    };
+};
+
+engrave total_rank(a: arcana, b: arcana) -> fate {
+    forge first: arcana = parse_rank(a)?;
+    forge second: arcana = parse_rank(b)?;
+    reveal bless { value: first + second };
+};
+
+oracle (total_rank(3, 0 - 4)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
+```
+
+```
+rank must be non-negative
+```
+
+Rules of the road:
+
+- `?` works on `fate` and `augury` values; anything else raises `? requires a fate or augury value, found …`.
+- There is **no implicit conversion** between the unions: propagating a `naught` out of a `fate`-returning function fails the return-type check. Convert explicitly at the boundary.
+- A propagation nobody catches surfaces as a diagnostic underlining the `?` expression — `Uncaught curse: rank must be non-negative` — and `abyss invoke` exits non-zero.
+
+## Fallible stdlib APIs
+
+APIs whose failure depends on the *data* return these unions; APIs whose failure is a programming error (wrong types, wrong arity) keep raising diagnostics.
+
+- `scroll.min()` / `scroll.max()` → `augury` (`naught {}` on an empty scroll).
+- `sqrt(x)` → `fate` (`curse` for a negative input), so `sqrt(x)?` is the everyday form.
+
+```aby
+forge rolls: scroll = [3, 1, 4];
+oracle (rolls.min()) {
+    manifest { value } => unveil(value);
+    naught {} => unveil("empty scroll");
+};
+
+engrave hypot(a: aether, b: aether) -> fate {
+    reveal bless { value: sqrt(a * a + b * b)? };
+};
+oracle (hypot(3.0, 4.0)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
+```
+
+```
+1
+5
+```
+
+See [`examples/fate.aby`](https://github.com/liebe-magi/abyss-lang/blob/main/examples/fate.aby) for the full tour.

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -59,6 +59,7 @@ Promote runtime failures from "interpreter prints a diagnostic and aborts" to a 
 - Stdlib **`augury`** type (the themed `Option`): **`manifest { value }`** / **`naught {}`** — an augury may reveal something, or nothing.
 - New `?` propagation operator that early-returns the `curse` / `naught` variant from the enclosing function: `forge x: arcana = parse(input)?;`.
 - `engrave` return-type support for `fate` and `augury`, with call-time enforcement.
+- Fallible stdlib revision folded in from v0.7.x (a return-type change is breaking, so it belongs in the `0.x.0`): `scroll.min()` / `max()` return `augury`, `sqrt` returns `fate`.
 - `try` / `recover` block syntax stays deferred — `?` covers the bulk of the use cases.
 
 ### v0.7.x — Scripting Ergonomics
@@ -69,7 +70,6 @@ The quality-of-life layer that makes AbySS practical for real command-line scrip
 - **`aura`** — a built-in `lexicon` of environment variables (read-only to start).
 - **`incant`** — string interpolation as a prefixed rune literal (`incant "count: {n}"`), additive so existing literals are untouched.
 - **`perish(code)`** — explicit abnormal termination.
-- Fallible-API revision: `min` / `max` / conversion helpers move to `augury` / `fate` returns.
 - REPL improvements: multi-line editing and history search.
 
 ### v0.8.x — LSP MVP

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -15,7 +15,13 @@ export function activate(context: vscode.ExtensionContext) {
                 'morph',
                 'engrave',
                 'summon',
-                'ward'
+                'ward',
+                'fate',
+                'augury',
+                'bless',
+                'curse',
+                'manifest',
+                'naught'
             ];
             const completionItems = keywords.map(keyword => {
                 return new vscode.CompletionItem(keyword, vscode.CompletionItemKind.Keyword);

--- a/editors/code/syntaxes/abyss.tmLanguage.json
+++ b/editors/code/syntaxes/abyss.tmLanguage.json
@@ -60,7 +60,7 @@
 			"patterns": [
 				{
 					"name": "storage.type.abyss",
-					"match": "\\b(arcana|aether|rune|omen|abyss|scroll|lexicon|materia|glyph)\\b"
+					"match": "\\b(arcana|aether|rune|omen|abyss|scroll|lexicon|materia|glyph|fate|augury)\\b"
 				}
 			]
 		},

--- a/examples/fate.aby
+++ b/examples/fate.aby
@@ -1,0 +1,47 @@
+// fate & augury: first-class error handling with the ? operator.
+
+engrave parse_rank(raw: arcana) -> fate {
+    oracle {
+        (raw < 0) => reveal curse { reason: "rank must be non-negative" };
+        _ => reveal bless { value: raw * 10 };
+    };
+};
+
+engrave total_rank(a: arcana, b: arcana) -> fate {
+    // ? unwraps a bless, or returns the curse from total_rank itself.
+    forge first: arcana = parse_rank(a)?;
+    forge second: arcana = parse_rank(b)?;
+    reveal bless { value: first + second };
+};
+
+oracle (total_rank(3, 4)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
+
+oracle (total_rank(3, 0 - 4)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};
+
+// augury: presence or absence, straight from the stdlib.
+forge rolls: scroll = [3, 1, 4];
+oracle (rolls.min()) {
+    manifest { value } => unveil(value);
+    naught {} => unveil("empty scroll");
+};
+
+forge nothing: scroll = [];
+oracle (nothing.min()) {
+    manifest { value } => unveil(value);
+    naught {} => unveil("empty scroll");
+};
+
+// sqrt returns a fate, so ? composes with math.
+engrave hypot(a: aether, b: aether) -> fate {
+    reveal bless { value: sqrt(a * a + b * b)? };
+};
+oracle (hypot(3.0, 4.0)) {
+    bless { value } => unveil(value);
+    curse { reason } => unveil(reason);
+};


### PR DESCRIPTION
## Summary

PR 3/3 of the v0.7.0 error-handling cycle (design: #548, decision 3: the revision belongs in the `0.x.0`, not a point release).

| API | Before | After |
|---|---|---|
| `scroll.min()` / `max()` | bare element; error on empty | `manifest { value }` / `naught {}` (`augury`) |
| `sqrt(x)` | bare `aether`; error on negative | `bless { value }` / `curse { reason }` (`fate`) — `sqrt(x)?` is the everyday form |
| `sum()` | unchanged | still errors on empty, pending generics |

Convention (recorded on the new docs page): **data-dependent failure returns a union; programming errors (wrong types, arity) keep raising diagnostics.**

### Also included

- **New reference page `reference/error-handling.mdx`** + sidebar entry — fate/augury, `?` rules, fallible-API list; every snippet executed end-to-end before publishing.
- **`examples/fate.aby`** — the full tour (propagation, augury matching, `sqrt(…)?` composition), locked by `test_examples.rs`.
- Extension: `fate` / `augury` join the type highlight group; the six new names join keyword completion.
- Roadmap: fallible-revision bullet moved from v0.7.x into v0.7.0; collections/math doc sections updated.

## Verification

- Integration tests updated: `min`/`max` manifest/naught (incl. empty scroll), `sqrt` curse/bless, new `sqrt(…)?` composition test (`hypot(3,4) → 5`)
- `cargo test --workspace` — all 25 test binaries pass; clippy clean; docs build (17 pages); grammar JSON valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)