### PR TITLE
chore(release): bump workspace and extension to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-07
+
+The First-class Error Handling release. Failures become values: `fate` (`bless { value }` / `curse { reason }`) and `augury` (`manifest { value }` / `naught {}`) arrive as built-in union types constructed and destructured with the artifact machinery you already know, and the new postfix `?` unwraps a success or propagates the failure out of the enclosing `engrave`. The fallible stdlib APIs follow the convention from day one, and `abyss invoke` finally exits non-zero on script failure. Breaking changes are limited to the fallible-API return types and six newly reserved names.
+
 ### Changed (breaking — stdlib)
 
 - **Fallible stdlib APIs return `fate` / `augury`** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 3/3) — `scroll.min()` / `scroll.max()` now return `manifest { value }` or `naught {}` instead of a bare element / an empty-scroll error, and `sqrt(x)` returns `bless { value }` or `curse { reason }` instead of erroring on negative input — so `sqrt(x)?` is the everyday form. The convention: data-dependent failure returns a union; programming errors (wrong types, arity) keep raising diagnostics. `sum()` still errors on empty scrolls pending generics.
@@ -14,6 +18,8 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 - **`?` propagation operator** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 2/3) — postfix `expr?` unwraps a `bless` / `manifest` payload, or propagates the `curse` / `naught` out of the enclosing `engrave` as its return value (checked against the declared return type; cross-union propagation is rejected, no implicit conversion). A propagation that reaches the top level renders as an `Uncaught curse: …` / `Uncaught naught` diagnostic underlining the `?` expression, and `abyss invoke` now exits non-zero on any script failure. Scope depth is restored exactly at the catch point even when the propagation unwound out of nested `orbit` / `oracle` scopes.
 - **`fate` and `augury` types with built-in variant artifacts** ([#548](https://github.com/liebe-magi/abyss-lang/issues/548), v0.7.0 PR 1/3) — the themed `Result` / `Option`: `fate` admits the pre-seeded `bless { value }` / `curse { reason }` artifacts and `augury` admits `manifest { value }` / `naught {}`. Construction uses ordinary artifact literals, destructuring uses ordinary artifact patterns, and `forge` annotations, `engrave` parameters, and `engrave` return types all accept the union types with call-time enforcement. The six names are reserved in every scope. Payload fields are `materia` until generics land.
+
+For the full diff, see the [GitHub compare v0.6.1...v0.7.0](https://github.com/liebe-magi/abyss-lang/compare/v0.6.1...v0.7.0).
 
 ## [0.6.1] - 2026-07-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "abyss-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-interpreter"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "abyss-core",
  "ariadne",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-lang"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "abyss-wasm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "abyss-core",
  "abyss-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 authors = ["liebe-magi <ripe.gold1058@fastmail.com>"]
 license = "MIT"
@@ -16,8 +16,8 @@ repository = "https://github.com/liebe-magi/abyss-lang"
 homepage = "https://abyss-lang.dev"
 
 [workspace.dependencies]
-abyss-core = { path = "crates/abyss-core", version = "0.6.1" }
-abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.6.1" }
+abyss-core = { path = "crates/abyss-core", version = "0.7.0" }
+abyss-interpreter = { path = "crates/abyss-interpreter", version = "0.7.0" }
 ariadne = "0.6"
 chumsky = "0.13"
 ordered-float = "5"

--- a/docs/src/content/docs/roadmap.mdx
+++ b/docs/src/content/docs/roadmap.mdx
@@ -51,7 +51,7 @@ Round out the everyday helpers as compatibility-preserving point releases. `rune
 - `scroll` methods: `sort`, `unique`, `sum`, `min`, `max`. Empty-scroll `min` / `max` raise an error for now; they move to `augury` returns in the v0.7.x API revision.
 - Math rituals that are sandbox-safe everywhere: `abs`, `sqrt`, `floor`, `ceil`. Time rituals wait for the I/O design.
 
-### v0.7.0 — First-class Error Handling
+### v0.7.0 — First-class Error Handling *(shipped)*
 
 Promote runtime failures from "interpreter prints a diagnostic and aborts" to a value scripts can handle. The artifact pattern type-dispatch shipped in v0.5.0 already supports the mechanics; this cycle standardises the types and adds the propagation operator. The `Expr` / `Stmt` split makes `?` a straightforward postfix expression.
 

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [v0.7.0] - 2026-07-07
+
+### Added
+
+- `fate` and `augury` join the storage-type highlight group, and the six error-handling names (`fate`, `augury`, `bless`, `curse`, `manifest`, `naught`) join keyword completion, matching the v0.7.0 language release.
+
+### Changed
+
+- Bumped the extension version to 0.7.0 to stay in lockstep with the `abyss-lang` crate. The `?` operator needs no grammar change (punctuation).
+
 ## [v0.6.1] - 2026-07-06
 
 ### Fixed

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "abyss-codex-familiar",
   "displayName": "AbySS Codex Familiar",
   "description": "Custom syntax highlighting for the AbySS programming language.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "publisher": "liebe-magi",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Release prep for **v0.7.0** — the First-class Error Handling release.

- Root `Cargo.toml` + workspace dep pins + `editors/code/package.json` → `0.7.0` (`check_version_sync.py` passing); `Cargo.lock` regenerated.
- `CHANGELOG.md`: `[Unreleased]` → `[0.7.0] - 2026-07-07` with narrative and compare link.
- Extension changelog v0.7.0 entry; roadmap v0.7.0 section marked shipped.

## Verification

- `cargo test --workspace` — all 25 binaries pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)