### PR TITLE
feat(runtime): add invocation script arguments and perish(code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ## [Unreleased]
 
+### Added
+
+- **`invocation` script arguments and `perish(code)`** ([#557](https://github.com/liebe-magi/abyss-lang/issues/557)) — the first Scripting Ergonomics pieces. `invocation` is a built-in immutable scroll of runes holding everything after `--` in `abyss invoke script.aby -- …` (empty in the REPL and Playground); `perish(code)` terminates the script with an exit code (`perish()` = 0) — `invoke` exits with the code silently, the REPL prints a notice and continues.
+
 ## [0.7.0] - 2026-07-07
 
 The First-class Error Handling release. Failures become values: `fate` (`bless { value }` / `curse { reason }`) and `augury` (`manifest { value }` / `naught {}`) arrive as built-in union types constructed and destructured with the artifact machinery you already know, and the new postfix `?` unwraps a success or propagates the failure out of the enclosing `engrave`. The fallible stdlib APIs follow the convention from day one, and `abyss invoke` finally exits non-zero on script failure. Breaking changes are limited to the fallible-API return types and six newly reserved names.

--- a/crates/abyss-cli/src/commands.rs
+++ b/crates/abyss-cli/src/commands.rs
@@ -7,7 +7,7 @@ use abyss_core::{
     parser::{ParserDiagnostic, collect_comments, emit_diagnostics, parse},
 };
 use abyss_interpreter::{
-    eval::{display_error_with_source, evaluate},
+    eval::{EvalError, display_error_with_source, evaluate},
     stdlib,
 };
 
@@ -26,24 +26,32 @@ pub fn report_diagnostics(source_id: &str, source: &str, diagnostics: &[ParserDi
 }
 
 /// Executes a given AbySS script by parsing and evaluating it in a new
-/// environment. Returns `false` when parsing or evaluation failed (the
-/// diagnostic has already been rendered) so the caller can exit non-zero
-/// — an uncaught `curse` from `?` should fail the invocation the same
-/// way any other runtime error does.
-pub fn execute_script(script: &str) -> bool {
+/// environment, with `args` installed as the `invocation` scroll.
+/// Returns the process exit code: 0 on success, 1 when parsing or
+/// evaluation failed (the diagnostic has already been rendered), or the
+/// code a `perish(code)` requested (terminating silently — perishing is
+/// deliberate, not an error).
+pub fn execute_script(script: &str, args: &[String]) -> i32 {
     let mut env = stdlib::create_global_environment();
+    stdlib::set_invocation(&mut env, args);
     let outcome = parse(script);
     if report_diagnostics("<script>", script, &outcome.diagnostics) {
-        return false;
+        return 1;
     }
 
     for ast in outcome.ast {
-        if let Err(error) = evaluate(&ast, &mut env) {
-            display_error_with_source(script, &error);
-            return false;
+        match evaluate(&ast, &mut env) {
+            Ok(_) => {}
+            Err(EvalError::Perished(code, _)) => {
+                return i32::try_from(code).unwrap_or(1);
+            }
+            Err(error) => {
+                display_error_with_source(script, &error);
+                return 1;
+            }
         }
     }
-    true
+    0
 }
 
 /// Formats the provided AbySS script by parsing and reconstructing it with proper indentation.

--- a/crates/abyss-cli/src/main.rs
+++ b/crates/abyss-cli/src/main.rs
@@ -22,6 +22,10 @@ enum Commands {
     Invoke {
         /// The path to the script file
         script: String,
+        /// Arguments handed to the script as the `invocation` scroll
+        /// (everything after `--`)
+        #[arg(last = true)]
+        args: Vec<String>,
     },
     /// Start the interactive interpreter
     Cast {
@@ -40,10 +44,11 @@ fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Invoke { script } => {
+        Commands::Invoke { script, args } => {
             if let Ok(contents) = fs::read_to_string(script) {
-                if !execute_script(&contents) {
-                    std::process::exit(1);
+                let code = execute_script(&contents, args);
+                if code != 0 {
+                    std::process::exit(code);
                 }
             } else {
                 eprintln!("Error: Could not read the script file.");

--- a/crates/abyss-cli/src/repl.rs
+++ b/crates/abyss-cli/src/repl.rs
@@ -140,6 +140,13 @@ pub fn start_interpreter(debug: bool) {
                                     _ => {}
                                 }
                             }
+                            Err(abyss_interpreter::eval::EvalError::Perished(code, _)) => {
+                                println!(
+                                    "{}",
+                                    format!("Perished with code {} — the session lives on", code)
+                                        .yellow()
+                                );
+                            }
                             Err(e) => {
                                 println!("{}", format!("Error: {}", e).red());
                             }

--- a/crates/abyss-interpreter/src/eval/result.rs
+++ b/crates/abyss-interpreter/src/eval/result.rs
@@ -70,6 +70,10 @@ pub enum EvalError {
     /// Travelling on the error channel means every expression context
     /// propagates it without bespoke plumbing.
     Propagation(ArtifactHandle, Option<Span>),
+    /// `perish(code)` — deliberate script termination riding the error
+    /// channel. `invoke` exits with the code (no diagnostic), the REPL
+    /// prints and continues, the Playground reports it.
+    Perished(i64, Option<Span>),
 }
 
 /// Lowercase keyword name for a type, as used in "Expected … value"
@@ -106,6 +110,7 @@ impl EvalError {
             | EvalError::ScrollIndexOutOfBounds(_, info)
             | EvalError::MissingLexiconKey(_, info)
             | EvalError::Propagation(_, info)
+            | EvalError::Perished(_, info)
             | EvalError::NegativeExponent(info) => info.as_ref(),
         }
     }
@@ -128,6 +133,7 @@ impl EvalError {
                 "naught" => "Uncaught naught",
                 _ => "Uncaught propagation",
             },
+            EvalError::Perished(_, _) => "Perished",
         }
     }
 }
@@ -171,6 +177,7 @@ impl fmt::Display for EvalError {
             EvalError::MissingLexiconKey(key, _) => {
                 write!(f, "Invalid operation: Lexicon key '{}' does not exist", key)
             }
+            EvalError::Perished(code, _) => write!(f, "Perished with code {}", code),
             EvalError::Propagation(handle, _) => {
                 let borrowed = handle.borrow();
                 match borrowed.type_name.as_str() {

--- a/crates/abyss-interpreter/src/stdlib/functions/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/mod.rs
@@ -1,5 +1,6 @@
 pub mod io;
 pub mod math;
+pub mod runtime;
 
 use std::collections::HashMap;
 
@@ -25,7 +26,8 @@ pub fn get_all_global_functions() -> HashMap<String, Callable> {
     );
 
     for (name, func) in [
-        ("abs", math::native_abs as crate::env::BuiltinFunc),
+        ("perish", runtime::native_perish as crate::env::BuiltinFunc),
+        ("abs", math::native_abs),
         ("sqrt", math::native_sqrt),
         ("floor", math::native_floor),
         ("ceil", math::native_ceil),

--- a/crates/abyss-interpreter/src/stdlib/functions/runtime.rs
+++ b/crates/abyss-interpreter/src/stdlib/functions/runtime.rs
@@ -1,0 +1,58 @@
+//! Script-runtime rituals: deliberate termination.
+
+use crate::env::{CallArg, RuntimeEnv, Value};
+use crate::eval::{EvalError, EvalResult};
+use abyss_core::ast::Span;
+
+/// `perish(code)` — terminate the script with an exit code; `perish()`
+/// means code 0. Rides the error channel so every enclosing scope
+/// unwinds; the host decides what termination means (process exit for
+/// `invoke`, a printed notice for the REPL, an error report for the
+/// Playground).
+pub fn native_perish(
+    _env: &mut RuntimeEnv,
+    args: Vec<CallArg>,
+    line_info: Option<Span>,
+) -> Result<EvalResult, EvalError> {
+    let code = match args.len() {
+        0 => 0,
+        1 => match args.into_iter().next().expect("argument exists").value {
+            EvalResult::Data(Value::Arcana(code)) => code,
+            other => {
+                return Err(EvalError::InvalidOperation(
+                    format!("perish() expects an arcana exit code, got {:?}", other),
+                    line_info,
+                ));
+            }
+        },
+        _ => {
+            return Err(EvalError::InvalidOperation(
+                "perish() expects at most one arcana argument".to_string(),
+                line_info,
+            ));
+        }
+    };
+    Err(EvalError::Perished(code, line_info))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn perish_defaults_to_zero_and_accepts_code() {
+        let mut env = RuntimeEnv::new();
+        assert!(matches!(
+            native_perish(&mut env, vec![], None),
+            Err(EvalError::Perished(0, _))
+        ));
+        let arg = CallArg {
+            value: EvalResult::data(Value::Arcana(3)),
+            var_name: None,
+        };
+        assert!(matches!(
+            native_perish(&mut env, vec![arg], None),
+            Err(EvalError::Perished(3, _))
+        ));
+    }
+}

--- a/crates/abyss-interpreter/src/stdlib/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/mod.rs
@@ -88,6 +88,42 @@ pub(crate) fn make_variant(name: &str, field: Option<(&str, Value)>) -> Value {
     })))
 }
 
+/// Seed the script-runtime globals: `invocation` (the script arguments,
+/// empty by default — the CLI overwrites it for `invoke`) as an immutable
+/// scroll of runes.
+fn seed_runtime_globals(env: &mut RuntimeEnv) {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    env.set_var(
+        "invocation".to_string(),
+        Value::Scroll(Rc::new(RefCell::new(Vec::new()))),
+        Type::Scroll,
+        false,
+        None,
+    );
+}
+
+/// Install the given script arguments as the `invocation` scroll. The CLI
+/// calls this for `invoke script.aby -- …`; hosts that never call it keep
+/// the empty default.
+pub fn set_invocation(env: &mut RuntimeEnv, args: &[String]) {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let runes: Vec<Value> = args
+        .iter()
+        .map(|arg| Value::Rune(Rc::new(arg.clone())))
+        .collect();
+    env.set_var(
+        "invocation".to_string(),
+        Value::Scroll(Rc::new(RefCell::new(runes))),
+        Type::Scroll,
+        false,
+        None,
+    );
+}
+
 pub fn create_global_environment() -> RuntimeEnv {
     let mut env = RuntimeEnv::new();
     let functions = functions::get_all_global_functions();
@@ -96,6 +132,7 @@ pub fn create_global_environment() -> RuntimeEnv {
     env.set_builtin_methods(methods);
     seed_builtin_glyphs(&mut env);
     seed_error_handling_artifacts(&mut env);
+    seed_runtime_globals(&mut env);
     env
 }
 

--- a/crates/abyss-interpreter/tests/test_propagate.rs
+++ b/crates/abyss-interpreter/tests/test_propagate.rs
@@ -139,3 +139,34 @@ fn question_on_non_fate_value_errors() {
         },
     }
 }
+
+#[test]
+fn invocation_defaults_to_empty_scroll() {
+    let results = test_base("invocation.tally();").expect("invocation should exist");
+    assert!(matches!(
+        results.last().unwrap(),
+        EvalResult::Data(Value::Arcana(0))
+    ));
+}
+
+#[test]
+fn perish_unwinds_with_code() {
+    let input = r#"
+engrave run() -> abyss {
+    orbit (i = 0..10) {
+        oracle {
+            (i == 2) => perish(7);
+            _ => unveil(i);
+        };
+    };
+};
+run();
+"#;
+    match test_base(input) {
+        Ok(_) => panic!("expected perish"),
+        Err(err) => match err.downcast_ref::<EvalError>() {
+            Some(EvalError::Perished(7, _)) => {}
+            other => panic!("expected Perished(7), got {:?}", other),
+        },
+    }
+}

--- a/docs/src/content/docs/reference/input-output.mdx
+++ b/docs/src/content/docs/reference/input-output.mdx
@@ -23,3 +23,34 @@ unveil("Hello, ", name, "! You are ", age, " years old.");
 `summon` always returns a `rune`. Chain `.transmute(glyph)` to coerce into numeric runes as needed.
 
 These rituals keep the language's magical tone while retaining predictable console I/O behavior.
+
+## Script Runtime Rituals
+
+### `invocation` — script arguments
+
+`invocation` is a built-in immutable `scroll` of runes holding the arguments passed after `--`:
+
+```
+abyss invoke script.aby -- ember frost
+```
+
+```aby
+unveil(invocation.tally().transmute(rune));
+oracle {
+    (invocation.tally() == 0) => unveil("no arguments");
+    _ => unveil(invocation[0]);
+};
+```
+
+With `-- ember` this prints:
+
+```
+1
+ember
+```
+
+In the REPL and the Playground, `invocation` is an empty scroll.
+
+### `perish(code)` — deliberate termination
+
+`perish(code)` ends the script with an exit code; `perish()` means code 0. Perishing is deliberate, not an error: `abyss invoke` exits with the code silently, while the REPL prints `Perished with code N — the session lives on` and keeps going.


### PR DESCRIPTION
## Summary

Resolves #557 — the first Scripting Ergonomics pieces (v0.7.x cycle). Fully additive.

- **`invocation`** — built-in immutable `scroll` of runes: `abyss invoke script.aby -- alpha beta` → `["alpha", "beta"]` (clap `last = true` trailing args). Seeded empty in `create_global_environment`, overwritten via the new `stdlib::set_invocation`, so the REPL and Playground see an empty scroll with zero changes.
- **`perish(code)`** — deliberate termination riding the error channel (`EvalError::Perished`), unwinding out of nested `orbit`/`oracle`/functions like `?` propagation does. `perish()` = 0. `invoke` exits with the code **silently** (perishing is deliberate, not an error); the REPL prints `Perished with code N — the session lives on` and keeps the session; the Playground reports it through the existing error field.
- `execute_script` now returns the exit code (`0` / `1` / perish code).
- Docs: **Script Runtime Rituals** section in `reference/input-output.mdx` (snippet executed end-to-end).

## Verification

- Unit test for `perish` arity/default; integration tests: `invocation` empty default, `perish(7)` unwinding out of `orbit`+`oracle` inside a function
- CLI smoke: `invocation` prints args; `perish(2)` exits 2; success exits 0
- `cargo test --workspace` — all 25 test binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)