### PR TITLE
feat(runtime): add the aura environment lexicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The accompanying VS Code extension has its own changelog at [`editors/code/CHANG
 
 ### Added
 
+- **`aura` environment lexicon** ([#558](https://github.com/liebe-magi/abyss-lang/issues/558)) — a built-in immutable lexicon snapshotting the process environment variables at startup; empty on the Playground, where the sandbox has no environment.
 - **`invocation` script arguments and `perish(code)`** ([#557](https://github.com/liebe-magi/abyss-lang/issues/557)) — the first Scripting Ergonomics pieces. `invocation` is a built-in immutable scroll of runes holding everything after `--` in `abyss invoke script.aby -- …` (empty in the REPL and Playground); `perish(code)` terminates the script with an exit code (`perish()` = 0) — `invoke` exits with the code silently, the REPL prints a notice and continues.
 
 ## [0.7.0] - 2026-07-07

--- a/crates/abyss-interpreter/src/stdlib/mod.rs
+++ b/crates/abyss-interpreter/src/stdlib/mod.rs
@@ -90,15 +90,31 @@ pub(crate) fn make_variant(name: &str, field: Option<(&str, Value)>) -> Value {
 
 /// Seed the script-runtime globals: `invocation` (the script arguments,
 /// empty by default — the CLI overwrites it for `invoke`) as an immutable
-/// scroll of runes.
+/// scroll of runes, and `aura` (the environment variables at startup) as
+/// an immutable lexicon of runes.
 fn seed_runtime_globals(env: &mut RuntimeEnv) {
     use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::rc::Rc;
 
     env.set_var(
         "invocation".to_string(),
         Value::Scroll(Rc::new(RefCell::new(Vec::new()))),
         Type::Scroll,
+        false,
+        None,
+    );
+
+    // `aura` — the ambience the script runs in: a snapshot of the process
+    // environment variables as an immutable lexicon. On wasm32 std yields
+    // no variables, so the Playground naturally sees an empty aura.
+    let vars: HashMap<String, Value> = std::env::vars()
+        .map(|(key, value)| (key, Value::Rune(Rc::new(value))))
+        .collect();
+    env.set_var(
+        "aura".to_string(),
+        Value::Lexicon(Rc::new(RefCell::new(vars))),
+        Type::Lexicon,
         false,
         None,
     );

--- a/crates/abyss-interpreter/tests/test_propagate.rs
+++ b/crates/abyss-interpreter/tests/test_propagate.rs
@@ -170,3 +170,15 @@ run();
         },
     }
 }
+
+#[test]
+fn aura_exposes_environment_variables() {
+    // SAFETY: test-local variable name; integration test binaries run
+    // their #[test] fns in threads, but nothing else reads this name.
+    unsafe { std::env::set_var("ABYSS_TEST_AURA", "sigil-9") };
+    let results = test_base(r#"aura["ABYSS_TEST_AURA"];"#).expect("aura lookup should evaluate");
+    match results.last().unwrap() {
+        EvalResult::Data(Value::Rune(s)) => assert_eq!(s.as_ref(), "sigil-9"),
+        other => panic!("expected rune from aura, got {:?}", other),
+    }
+}

--- a/docs/src/content/docs/reference/input-output.mdx
+++ b/docs/src/content/docs/reference/input-output.mdx
@@ -51,6 +51,19 @@ ember
 
 In the REPL and the Playground, `invocation` is an empty scroll.
 
+### `aura` — environment variables
+
+`aura` is a built-in immutable `lexicon` snapshotting the process environment at startup — the ambience the script runs in. Lexicon patterns make reading it pleasant:
+
+```aby
+oracle (aura) {
+    { "HOME": home } => unveil(home);
+    _ => unveil("no HOME in the aura");
+};
+```
+
+On the Playground the aura is empty (the browser sandbox has no environment).
+
 ### `perish(code)` — deliberate termination
 
 `perish(code)` ends the script with an exit code; `perish()` means code 0. Perishing is deliberate, not an error: `abyss invoke` exits with the code silently, while the REPL prints `Perished with code N — the session lives on` and keeps going.


### PR DESCRIPTION
## Summary

Resolves #558 — second Scripting Ergonomics piece (v0.7.x cycle). Additive.

**`aura`** — a built-in immutable `lexicon` snapshotting the process environment variables at startup: the ambience the script runs in. Lexicon patterns make reading it pleasant:

```aby
oracle (aura) {
    { "HOME": home } => unveil(home);
    _ => unveil("no HOME in the aura");
};
```

On `wasm32` std yields no variables, so the Playground naturally sees an empty aura — no `cfg` needed.

## Verification

- Integration test via a test-local environment variable; docs section (snippet executed end-to-end)
- `cargo test --workspace` — all 25 test binaries pass; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)